### PR TITLE
Add camunda-process-test skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ AI skills for Camunda 8.8+ development. Use these skills to create, deploy, and 
 | **camunda-forms** | Creating Camunda Form JSON schemas for user tasks |
 | **camunda-connectors** | Configuring pre-built connectors (REST, Slack, Kafka, etc.) via element templates |
 | **camunda-process-mgmt** | Deploying resources, starting/inspecting instances, resolving incidents, completing user tasks — all via c8ctl |
+| **camunda-process-test** | Authoring and running Camunda Process Test (CPT) suites that reach 100% BPMN coverage with segment-based scenarios — `.test.json` instructions, `mvn test`, coverage report parsing |
 | **camunda-ai-agent** | Building AI agents in BPMN — AI Agent connector on an ad-hoc subprocess, tool modeling, `fromAi()` parameters, prompts, sub-flow tools |
 
 ## Design goal: c8ctl is the programmatic API

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,20 @@ waza check <skill>                  # equivalent direct invocation
 sections), token budget (per `.waza.yaml`), link health, frontmatter quality
 advisories. Returns non-zero on hard violations; warnings are advisory.
 
+`waza` ships as an Azure Developer CLI (`azd`) extension, not a standalone binary.
+One-time install:
+
+```bash
+brew install azd
+azd config set alpha.extensions on
+azd ext source add -n waza -t url -l https://raw.githubusercontent.com/microsoft/waza/main/registry.json
+azd ext install microsoft.azd.waza
+```
+
+After install, the `azd waza` command is on PATH and `make lint` works. The
+Makefile's "Install it from https://github.com/microsoft/waza" message refers
+to this extension flow, not a direct binary download.
+
 ### Adding a New Skill
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Hand-create `skills/<name>/SKILL.md` and

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -72,13 +72,24 @@ mvn test
 
 On failure, diagnose with [references/troubleshooting.md](references/troubleshooting.md). Distinguish **test problems** (variable typo, wrong element id, missing instruction) from **process problems** (wrong FEEL condition, wrong DMN rule, wrong error code). Fix the right side. Re-run. Stop after 3 repair cycles with no progress.
 
+When the run exits — pass or fail — proceed straight to step 6 and open the coverage report.
+
 ### 6. Coverage check — exit gate
 
-CPT emits a coverage report under `target/camunda-process-test/coverage/` (HTML + JSON). Parse the JSON and list uncovered elements.
+CPT emits a coverage report at `target/coverage-report/report.html` (per-process HTML; the page lists every element with its visit count). Parse the HTML (or the bundled JSON next to it, when present) and list uncovered elements.
+
+**Open the HTML report in the user's browser as soon as `mvn test` exits — pass or fail.** Default command (macOS):
+
+```bash
+REPORT="target/coverage-report/report.html"
+[ -f "$REPORT" ] && open "$REPORT"
+```
+
+On Linux substitute `xdg-open`; on Windows substitute `start`. This is default behavior of the skill, not an opt-in — every test run ends with the report visible to the user.
 
 If coverage is < 100%, loop back to step 3: define one more segment per uncovered element. Do not declare the suite done while elements remain uncovered.
 
-> **Note**: in 8.9 SNAPSHOT releases the report generator may throw `IllegalStateException: Report resources not found`. Tests still pass. Treat as advisory until a GA release ships — manually walk the BPMN against scenarios to confirm coverage in that case.
+> **Note**: in early 8.9 SNAPSHOT releases the report generator may throw `IllegalStateException: Report resources not found` and skip the HTML output. Tests still pass. Walk the BPMN against scenarios manually to confirm coverage in that case.
 
 ### 7. Deduplication pass
 

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -49,14 +49,15 @@ Check `pom.xml` (or `test/pom.xml`) for `camunda-process-test-spring`. If missin
 
 Follow [references/setup.md](references/setup.md): verify Java 21+, Maven, Docker; add the CPT dependency; scaffold `src/test/java/io/camunda/tests/ProcessTest.java` and `src/test/resources/scenarios/`. Confirm with `mvn test-compile`.
 
-### 3. Plan segments
+### 3. Plan segments (set-cover, not per-element)
 
-Apply [references/coverage-strategy.md](references/coverage-strategy.md):
+Plan the minimum number of segments **before** authoring anything. Apply [references/coverage-strategy.md](references/coverage-strategy.md):
 
 1. Parse the BPMN: `processId`, element IDs and types, gateway outgoing flows + conditions, error / timer / escalation boundaries, end events, called DMN decisions (`<zeebe:calledDecision decisionId="…">`) and the DMN rules inside them.
-2. Pick **one happy-path segment** from start event to the most common end event — this seeds coverage of the spine.
-3. For every element still uncovered, define one **minimal segment** rooted at the nearest upstream decision point (gateway, DMN, error boundary) and ending at the next element that rejoins the happy path. Do not always run to the end event.
-4. Print the segment plan as a table: segment name | root | covered elements | end condition.
+2. **Enumerate candidate segments.** For every gateway branch, DMN rule, boundary event, and alternate end event, define one minimal candidate segment rooted at the nearest upstream decision point. For each candidate, **statically predict its full visited-element + sequence-flow set** by walking the BPMN forward from the root through the targeted branch to the next rejoin or end event.
+3. **Greedy set-cover.** Repeatedly pick the candidate whose predicted set covers the largest number of still-uncovered ids. Tie-break by shortest path (cheapest to author). Stop when the union covers every id.
+4. **Diagnostic-isolation override (optional).** If two chosen segments share a root but exercise different failure modes (e.g. one fires a boundary event, the other completes the user task normally), keep both so a failure points at one cause cleanly. Apply only when the user is debugging a specific area; default is pure set-cover.
+5. Print the segment plan as a table: `segment name | root | predicted ids covered | end condition`. Authoring then implements exactly this list — no speculative scenarios that may be deduped later.
 
 ### 4. Author
 
@@ -127,17 +128,17 @@ REPORT="target/coverage-report/report.html"
 
 On Linux substitute `xdg-open`; on Windows substitute `start`. Default behavior, not opt-in — every run ends with the report visible.
 
-**Auto-loop to 100% — default behavior.** If aggregate coverage `(covered elements + covered sequence flows) / totalElementCount` is < 100%:
+**Patch-loop on prediction misses — default behavior.** Set-cover planning in step 3 should reach 100% on the first authoring pass. When it does not, the gap is a *prediction miss*: the static walk for some candidate did not match runtime behavior. For each uncovered id:
 
-1. For each uncovered id, classify: element (visit it directly), or sequence flow (its source must be hit *and* the condition routing through it must be satisfied — usually means a non-happy gateway branch).
-2. Define one additional segment per uncovered id using [references/coverage-strategy.md](references/coverage-strategy.md). Group ids that share a root onto one segment.
+1. Classify the miss: element (visit it directly), or sequence flow (its source must be hit *and* the condition routing through it must be satisfied — usually a gateway branch the planner failed to attribute).
+2. Re-run greedy set-cover restricted to the remaining uncovered ids. Add the chosen candidates (often one) to the scenario file.
 3. For timer boundary events: use `INCREASE_TIME` with an ISO 8601 `duration` greater than the timer cycle (e.g. `"PT25H"` for `R/PT24H`). The boundary fires; the outgoing path's job is created; complete it with `COMPLETE_JOB`.
 4. For message boundary events: `PUBLISH_MESSAGE` instruction with matching name + correlationKey.
-5. Re-run step 5 (`mvn test`) → step 6 (coverage check). Repeat.
+5. Re-run step 5 (`mvn test`) → step 6. Each iteration should strictly reduce the uncovered set; if it does not, the planner's path prediction is wrong — fix the prediction logic in [references/coverage-strategy.md](references/coverage-strategy.md), do not paper over with more scenarios.
 
 Hard blockers that terminate the loop:
 
-- Same set of ids uncovered after 3 consecutive iterations — surface the list and stop.
+- Same set of ids uncovered after 2 consecutive iterations — surface the list and stop.
 - An uncovered element is dead code (no inbound flow, or its inbound condition is unsatisfiable) — flag as a BPMN defect, point at camunda-bpmn, stop.
 - Test infrastructure failure repeats (Docker down, deploy parse error) — stop and route to [references/troubleshooting.md](references/troubleshooting.md).
 
@@ -145,11 +146,11 @@ Do not declare the suite done while ids remain uncovered and no hard blocker app
 
 > **Note**: in early 8.9 SNAPSHOT releases the report generator may throw `IllegalStateException: Report resources not found` and skip the HTML output. Tests still pass. Walk the BPMN against scenarios manually to confirm coverage in that case.
 
-### 7. Deduplication pass
+### 7. Verify no redundancy slipped through
 
-Re-read every scenario. For each, compute the set of elements visited and the gateway branches taken. Flag any scenario whose visited set is a strict subset of another's **and** whose branch choices are identical on the overlap — that scenario is redundant; propose removing it.
+Set-cover planning in step 3 should produce a non-redundant suite by construction. Verify with a leave-one-out check against the runtime coverage data: for each scenario, compute the union of all *other* scenarios' covered ids; if removing the scenario loses zero ids, it is redundant and the planner has a bug — fix the planner, then drop the scenario.
 
-Also flag:
+Also flag (cheap, do unconditionally):
 
 - Scenario names that do not match `<who/what> — <outcome>` (e.g. `"test1"`, `"happy"`).
 - Duplicated descriptions across scenarios.

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -74,9 +74,36 @@ On failure, diagnose with [references/troubleshooting.md](references/troubleshoo
 
 When the run exits — pass or fail — proceed straight to step 6 and open the coverage report.
 
-### 6. Coverage check — exit gate
+### 6. Coverage check — exit gate (100% loop)
 
-CPT emits a coverage report at `target/coverage-report/report.html` (per-process HTML; the page lists every element with its visit count). Parse the HTML (or the bundled JSON next to it, when present) and list uncovered elements.
+CPT emits a coverage report at `target/coverage-report/report.html` (per-process HTML; the page embeds the full coverage dataset in a `window.COVERAGE_DATA` JSON literal). Parse it:
+
+```bash
+python3 - <<'PY'
+import re, json
+html=open("target/coverage-report/report.html").read()
+i=html.find("window.COVERAGE_DATA"); eq=html.find("{", i); depth=0; end=eq
+for j,ch in enumerate(html[eq:], eq):
+    if ch=="{": depth+=1
+    elif ch=="}":
+        depth-=1
+        if depth==0: end=j+1; break
+data=json.loads(html[eq:end])
+el=set(); flows=set(); total=None
+for s in data["suites"]:
+  for r in s["runs"]:
+    for c in r["coverages"]:
+      el.update(c.get("completedElements", []))
+      flows.update(c.get("takenSequenceFlows", []))
+      total=c.get("totalElementCount", total)
+covered=len(el)+len(flows)
+print(f"coverage={covered}/{total}={100*covered/total:.2f}%")
+print("covered_elements:", sorted(el))
+print("covered_flows:", sorted(flows))
+PY
+```
+
+Diff against the BPMN element + sequenceFlow id list (`grep -oE 'id="[A-Za-z0-9_]+"' <bpmn>`, exclude `_di`, `BPMNDiagram`, `BPMNPlane`, `Definitions_`, `ErrorDef_`, `TimerDef_`, `Signal_`, `Message_`).
 
 **Open the HTML report in the user's browser as soon as `mvn test` exits — pass or fail.** Default command (macOS):
 
@@ -85,9 +112,23 @@ REPORT="target/coverage-report/report.html"
 [ -f "$REPORT" ] && open "$REPORT"
 ```
 
-On Linux substitute `xdg-open`; on Windows substitute `start`. This is default behavior of the skill, not an opt-in — every test run ends with the report visible to the user.
+On Linux substitute `xdg-open`; on Windows substitute `start`. Default behavior, not opt-in — every run ends with the report visible.
 
-If coverage is < 100%, loop back to step 3: define one more segment per uncovered element. Do not declare the suite done while elements remain uncovered.
+**Auto-loop to 100% — default behavior.** If aggregate coverage (covered elements + covered sequence flows / `totalElementCount`) is < 100%:
+
+1. For each uncovered id, classify: element (visit it directly), or sequence flow (its source must be hit *and* the condition routing through it must be satisfied — usually means a non-happy gateway branch).
+2. Define one additional segment per uncovered id using [references/coverage-strategy.md](references/coverage-strategy.md). Group ids that share a root onto one segment.
+3. For timer boundary events: use `INCREASE_TIME` with an ISO 8601 `duration` greater than the timer cycle (e.g. `"PT25H"` for `R/PT24H`). The boundary fires; the outgoing path's job is created; complete it with `COMPLETE_JOB`.
+4. For message boundary events: `PUBLISH_MESSAGE` instruction with matching name + correlationKey.
+5. Re-run step 5 (`mvn test`) → step 6 (coverage check). Repeat.
+
+Hard blockers that terminate the loop:
+
+- Same set of ids uncovered after 3 consecutive iterations — surface the list and stop.
+- An uncovered element is dead code (no inbound flow, or its inbound condition is unsatisfiable) — flag as a BPMN defect, point at camunda-bpmn, stop.
+- Test infrastructure failure repeats (Docker down, deploy parse error) — stop and route to [references/troubleshooting.md](references/troubleshooting.md).
+
+Do not declare the suite done while ids remain uncovered and no hard blocker applies.
 
 > **Note**: in early 8.9 SNAPSHOT releases the report generator may throw `IllegalStateException: Report resources not found` and skip the HTML output. Tests still pass. Walk the BPMN against scenarios manually to confirm coverage in that case.
 

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -81,22 +81,35 @@ CPT emits a coverage report at `target/coverage-report/report.html` (per-process
 ```bash
 python3 - <<'PY'
 import re, json
-html=open("target/coverage-report/report.html").read()
-i=html.find("window.COVERAGE_DATA"); eq=html.find("{", i); depth=0; end=eq
-for j,ch in enumerate(html[eq:], eq):
-    if ch=="{": depth+=1
-    elif ch=="}":
-        depth-=1
-        if depth==0: end=j+1; break
-data=json.loads(html[eq:end])
-el=set(); flows=set(); total=None
+html = open("target/coverage-report/report.html").read()
+# Balanced-brace extraction. Walk character by character, but track string
+# state so braces inside JSON strings (e.g. inside a description) don't
+# unbalance the counter.
+m = re.search(r"window\.COVERAGE_DATA\s*=\s*", html)
+start = html.index("{", m.end())
+depth = 0; in_str = False; esc = False; end = start
+for k, ch in enumerate(html[start:], start):
+    if in_str:
+        if esc: esc = False
+        elif ch == "\\": esc = True
+        elif ch == '"': in_str = False
+    else:
+        if ch == '"': in_str = True
+        elif ch == "{": depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                end = k + 1
+                break
+data = json.loads(html[start:end])
+el = set(); flows = set(); total = None
 for s in data["suites"]:
-  for r in s["runs"]:
-    for c in r["coverages"]:
-      el.update(c.get("completedElements", []))
-      flows.update(c.get("takenSequenceFlows", []))
-      total=c.get("totalElementCount", total)
-covered=len(el)+len(flows)
+    for r in s["runs"]:
+        for c in r["coverages"]:
+            el.update(c.get("completedElements", []))
+            flows.update(c.get("takenSequenceFlows", []))
+            total = c.get("totalElementCount", total)
+covered = len(el) + len(flows)
 print(f"coverage={covered}/{total}={100*covered/total:.2f}%")
 print("covered_elements:", sorted(el))
 print("covered_flows:", sorted(flows))
@@ -114,7 +127,7 @@ REPORT="target/coverage-report/report.html"
 
 On Linux substitute `xdg-open`; on Windows substitute `start`. Default behavior, not opt-in — every run ends with the report visible.
 
-**Auto-loop to 100% — default behavior.** If aggregate coverage (covered elements + covered sequence flows / `totalElementCount`) is < 100%:
+**Auto-loop to 100% — default behavior.** If aggregate coverage `(covered elements + covered sequence flows) / totalElementCount` is < 100%:
 
 1. For each uncovered id, classify: element (visit it directly), or sequence flow (its source must be hit *and* the condition routing through it must be satisfied — usually means a non-happy gateway branch).
 2. Define one additional segment per uncovered id using [references/coverage-strategy.md](references/coverage-strategy.md). Group ids that share a root onto one segment.
@@ -156,6 +169,6 @@ Duplicates flagged: 0
 ## References
 
 - [setup.md](references/setup.md) — Java, Maven, Docker prereqs; CPT dependency; test scaffold layout
-- [authoring.md](references/authoring.md) — `.test.json` schema, instruction reference, Java fallback
 - [coverage-strategy.md](references/coverage-strategy.md) — segment selection rules per BPMN element type
+- [authoring.md](references/authoring.md) — `.test.json` schema, instruction reference, Java fallback
 - [troubleshooting.md](references/troubleshooting.md) — failure diagnosis table (test problem vs. process problem)

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: camunda-process-test
+description: |
+  Use this skill to author and run Camunda Process Test (CPT) suites that cover every BPMN gateway branch, DMN rule, and error boundary to 100%.
+
+  Use for: scaffolding the `camunda-process-test-spring` harness, planning the minimum set of test segments for full element coverage, authoring `.test.json` instruction-based scenarios, running `mvn test`, parsing the CPT coverage report, deduplicating redundant segments.
+
+  Do not use for: authoring the BPMN (use camunda-bpmn), writing FEEL or DMN expressions (use camunda-feel), deploying to a live cluster (use camunda-process-mgmt), UI or E2E tests against Operate or Tasklist.
+
+  **Workflow skill** — segment-based authoring loop covering `mvn test`, coverage report parsing, and scenario deduplication.
+---
+
+# Camunda Process Test
+
+Author and run Camunda Process Test suites for Camunda 8.8+ that reach **100% BPMN element coverage** with the minimum number of test segments. Test assertions are limited to reachability and routing — CPT exercises that the engine traverses the right elements, not the data values produced by service tasks or external systems.
+
+## Prerequisites
+
+- Java 21+, Maven (or `./mvnw`), Docker runtime (OrbStack, Docker Desktop, or Rancher Desktop) — see [references/setup.md](references/setup.md)
+- `camunda-process-test-spring` 8.9+ on the test classpath (instruction-based JSON format requires 8.9)
+- A working BPMN file (lint clean — see camunda-bpmn). DMN and form files referenced by the BPMN must also be present.
+
+## Cross-References
+
+- **camunda-bpmn**: Run `c8ctl bpmn lint` on the process under test before authoring scenarios — failing lints surface as deploy-time `@TestDeployment` failures.
+- **camunda-feel**: Use when a gateway condition or DMN entry is unclear; FEEL semantics drive which segment hits which branch.
+- **camunda-process-mgmt**: CPT runs against an **embedded** Zeebe engine — it does **not** use the c8ctl-managed cluster or any profile. No `c8ctl` call deploys a process under test.
+
+## Scope boundaries
+
+- **In scope**: BPMN reachability (every element visited at least once), gateway-branch selection, DMN rule selection, error-boundary firing, timer / escalation boundary firing, end-event selection.
+- **Out of scope**: asserting data values produced by service tasks, external system payloads, UI behavior, agent / LLM output. Do not write `ASSERT_VARIABLE` instructions on service-task output unless the variable is the FEEL input to a downstream gateway you also test.
+
+## Workflow
+
+### 1. Detect
+
+Find the BPMN under test in priority order:
+
+1. `src/main/resources/processes/`
+2. `src/main/resources/bpmn/`
+3. `../resources/` (Node.js layouts where the test harness lives in `test/`)
+
+Skip `target/`, `node_modules/`, `.git/`, `build/`. If multiple files match, list them and ask which to target.
+
+Check `pom.xml` (or `test/pom.xml`) for `camunda-process-test-spring`. If missing, go to step 2.
+
+### 2. Setup (only if missing)
+
+Follow [references/setup.md](references/setup.md): verify Java 21+, Maven, Docker; add the CPT dependency; scaffold `src/test/java/io/camunda/tests/ProcessTest.java` and `src/test/resources/scenarios/`. Confirm with `mvn test-compile`.
+
+### 3. Plan segments
+
+Apply [references/coverage-strategy.md](references/coverage-strategy.md):
+
+1. Parse the BPMN: `processId`, element IDs and types, gateway outgoing flows + conditions, error / timer / escalation boundaries, end events, called DMN decisions (`<zeebe:calledDecision decisionId="…">`) and the DMN rules inside them.
+2. Pick **one happy-path segment** from start event to the most common end event — this seeds coverage of the spine.
+3. For every element still uncovered, define one **minimal segment** rooted at the nearest upstream decision point (gateway, DMN, error boundary) and ending at the next element that rejoins the happy path. Do not always run to the end event.
+4. Print the segment plan as a table: segment name | root | covered elements | end condition.
+
+### 4. Author
+
+For each segment, write one entry inside `src/test/resources/scenarios/<processId>.test.json` using [references/authoring.md](references/authoring.md). Naming: `"<who/what> — <outcome>"`. Assertions: `ASSERT_ELEMENT_INSTANCES` on the elements the segment must visit, `ASSERT_PROCESS_INSTANCE` only when the segment runs to an end event.
+
+Use the Java fallback (covered in the same `authoring.md`) only when the segment needs Spring bean mocking, parameterized data tables, or assertions richer than the JSON instruction set offers — accept that Java tests are invisible to Web Modeler.
+
+### 5. Run
+
+```bash
+mvn test
+```
+
+On failure, diagnose with [references/troubleshooting.md](references/troubleshooting.md). Distinguish **test problems** (variable typo, wrong element id, missing instruction) from **process problems** (wrong FEEL condition, wrong DMN rule, wrong error code). Fix the right side. Re-run. Stop after 3 repair cycles with no progress.
+
+### 6. Coverage check — exit gate
+
+CPT emits a coverage report under `target/camunda-process-test/coverage/` (HTML + JSON). Parse the JSON and list uncovered elements.
+
+If coverage is < 100%, loop back to step 3: define one more segment per uncovered element. Do not declare the suite done while elements remain uncovered.
+
+> **Note**: in 8.9 SNAPSHOT releases the report generator may throw `IllegalStateException: Report resources not found`. Tests still pass. Treat as advisory until a GA release ships — manually walk the BPMN against scenarios to confirm coverage in that case.
+
+### 7. Deduplication pass
+
+Re-read every scenario. For each, compute the set of elements visited and the gateway branches taken. Flag any scenario whose visited set is a strict subset of another's **and** whose branch choices are identical on the overlap — that scenario is redundant; propose removing it.
+
+Also flag:
+
+- Scenario names that do not match `<who/what> — <outcome>` (e.g. `"test1"`, `"happy"`).
+- Duplicated descriptions across scenarios.
+- `ASSERT_VARIABLE` instructions on variables that no gateway or DMN downstream consumes — data assertions are out of scope.
+
+### 8. Report
+
+Print the Surefire result line, the coverage percentage, the segment count, and any flagged duplicates.
+
+```text
+Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
+Coverage: 100% (24/24 elements)
+Segments: 1 happy path + 5 secondary
+Duplicates flagged: 0
+```
+
+## References
+
+- [setup.md](references/setup.md) — Java, Maven, Docker prereqs; CPT dependency; test scaffold layout
+- [authoring.md](references/authoring.md) — `.test.json` schema, instruction reference, Java fallback
+- [coverage-strategy.md](references/coverage-strategy.md) — segment selection rules per BPMN element type
+- [troubleshooting.md](references/troubleshooting.md) — failure diagnosis table (test problem vs. process problem)

--- a/skills/camunda-process-test/references/authoring.md
+++ b/skills/camunda-process-test/references/authoring.md
@@ -156,7 +156,7 @@ package io.camunda.tests;
 import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.process.test.api.TestDeployment;
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -169,11 +169,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 })
 public class ExpenseApprovalJavaTest {
 
-    @Autowired private ZeebeClient zeebe;
+    @Autowired private CamundaClient camunda;
 
     @Test
     void financePath_managerApprovesFinanceApproves() {
-        var instance = zeebe.newCreateInstanceCommand()
+        var instance = camunda.newCreateInstanceCommand()
             .bpmnProcessId("expense-approval").latestVersion()
             .variables(java.util.Map.of("amount", 1500, "department", "Marketing"))
             .send().join();
@@ -190,7 +190,7 @@ public class ExpenseApprovalJavaTest {
 
 - `CamundaAssert.assertThat(processInstance).hasActiveElements("…")` — equivalent to `ASSERT_ELEMENT_INSTANCES … IS_ACTIVE`.
 - `CamundaAssert.assertThat(processInstance).isCompleted()` — equivalent to `ASSERT_PROCESS_INSTANCE … IS_COMPLETED`.
-- `CamundaAssert.setAssertionTimeout(Duration.ofMinutes(5))` — bump the default 10s polling timeout for slow external workers.
+- `CamundaAssert.setAssertionTimeout(Duration.ofMinutes(5))` — bump the polling timeout for slow external workers (LLMs, multi-second connectors). The CPT default is short (10s as of 8.9 (assumption); confirm via `CamundaAssert` source for the version on your classpath).
 
 ### Mocking workers
 

--- a/skills/camunda-process-test/references/authoring.md
+++ b/skills/camunda-process-test/references/authoring.md
@@ -1,0 +1,207 @@
+# Authoring CPT scenarios
+
+> Default to `.test.json` (instruction-based). Use Java `@Test` only when JSON cannot express the test — see [§ Java fallback](#java-fallback) at the bottom.
+
+## `.test.json` format
+
+Instruction-based CPT format (8.9+). Each `.test.json` file is loaded by `@TestCaseSource` and run as one parameterized JUnit test per `testCases[]` entry.
+
+## File skeleton
+
+```json
+{
+  "$schema": "https://camunda.com/json-schema/cpt-test-cases/8.9/schema.json",
+  "testCases": [
+    {
+      "name": "<who/what> — <outcome>",
+      "description": "One sentence in business language.",
+      "instructions": [
+        /* … */
+      ]
+    }
+  ]
+}
+```
+
+Place at `src/test/resources/scenarios/<processId>.test.json`. One file per process; many `testCases[]` per file.
+
+## Naming
+
+- `name`: `<who/what> — <outcome>`. Examples: `"manager approves — finance also approves"`, `"notification fails — error boundary fires"`. Avoid: `test1`, `happy`, `gateway A`.
+- `description`: one sentence in business language. No element IDs.
+
+## Instructions reference
+
+### `CREATE_PROCESS_INSTANCE`
+
+Always the first instruction.
+
+```json
+{
+  "type": "CREATE_PROCESS_INSTANCE",
+  "processDefinitionSelector": { "processDefinitionId": "expense-approval" },
+  "variables": { "amount": 200, "department": "Engineering" }
+}
+```
+
+Input variables here drive every downstream gateway and DMN decision. Pick values that route to the segment under test.
+
+### `COMPLETE_JOB`
+
+Completes a service-task job. Used for any `<bpmn:serviceTask>` without `<zeebe:userTask/>`.
+
+```json
+{
+  "type": "COMPLETE_JOB",
+  "jobSelector": { "elementId": "Task_SendNotification" },
+  "variables": {}
+}
+```
+
+`variables` is the output payload the mocked worker would produce. Leave empty unless a downstream gateway or DMN consumes a value the job sets.
+
+### `COMPLETE_USER_TASK`
+
+Completes a Camunda user task (`<zeebe:userTask/>`).
+
+```json
+{
+  "type": "COMPLETE_USER_TASK",
+  "userTaskSelector": { "elementId": "Task_ManagerReview" },
+  "variables": { "managerDecision": "Approve" }
+}
+```
+
+The variable map matches the linked form's component `key` values. Only include keys downstream logic reads.
+
+### `THROW_BPMN_ERROR_FROM_JOB`
+
+Triggers a BPMN error boundary on a service task.
+
+```json
+{
+  "type": "THROW_BPMN_ERROR_FROM_JOB",
+  "jobSelector": { "elementId": "Task_SendNotification" },
+  "errorCode": "NOTIFICATION_FAILED"
+}
+```
+
+`errorCode` must match the `errorCode` on the `<bpmn:error>` referenced by the boundary event exactly. Mismatch → process continues to the happy path, assertion fails.
+
+### `ASSERT_ELEMENT_INSTANCES`
+
+Asserts an element was reached.
+
+```json
+{
+  "type": "ASSERT_ELEMENT_INSTANCES",
+  "processInstanceSelector": { "processDefinitionId": "expense-approval" },
+  "elementSelectors": [{ "elementId": "Task_ManagerReview" }],
+  "state": "IS_ACTIVE"
+}
+```
+
+States: `IS_ACTIVE`, `IS_COMPLETED`, `IS_TERMINATED`. Use `IS_ACTIVE` for elements the segment must visit before a manual `COMPLETE_*`. Use `IS_COMPLETED` for end events.
+
+### `ASSERT_PROCESS_INSTANCE`
+
+Asserts overall process state. Use only when the segment runs to an end event.
+
+```json
+{
+  "type": "ASSERT_PROCESS_INSTANCE",
+  "processInstanceSelector": { "processDefinitionId": "expense-approval" },
+  "state": "IS_COMPLETED"
+}
+```
+
+## Segment pattern
+
+A scenario for a non-happy-path segment typically looks like:
+
+1. `CREATE_PROCESS_INSTANCE` — variables chosen to route to the target branch.
+2. `ASSERT_ELEMENT_INSTANCES` — the target element reached (`IS_ACTIVE`).
+3. `COMPLETE_*` or `THROW_BPMN_ERROR_FROM_JOB` — drive past the element.
+4. `ASSERT_ELEMENT_INSTANCES` on the rejoin point — the segment rejoined the common path.
+5. Optional final `ASSERT_PROCESS_INSTANCE: IS_COMPLETED` only if the segment runs to an end event.
+
+A segment that rejoins the happy path does **not** need to assert every downstream element again — the happy-path scenario already covers them. This is what keeps the suite minimal.
+
+## What not to write
+
+- `ASSERT_VARIABLE` on a service-task output variable. Out of scope — CPT covers routing, not data correctness.
+- Repeated complete-the-final-task tail across every segment. If a segment rejoins the happy path before the tail, end the segment there.
+- Copy-paste assertions whose values come from FEEL inside the process. The process already evaluates the FEEL; asserting the same value tests the test, not the process.
+
+## Schema-version reminder
+
+The `$schema` URL pins the CPT instruction grammar version. If you upgrade CPT in `pom.xml`, update the schema URL to match — older URLs may reject newer instruction types.
+
+---
+
+## Java fallback
+
+Java tests are not rendered by Web Modeler — business analysts cannot read them. Default to JSON unless one of these constraints applies:
+
+- The scenario needs a Spring bean mocked (`@MockBean`) — a worker that calls an external system in production.
+- Parameterized data tables — same flow, many input rows. `@ParameterizedTest` + `@CsvSource` beats N near-duplicate JSON entries.
+- Assertions that don't map to `ASSERT_*` instructions — message correlation timing, specific `incident` payloads, custom `CamundaAssert` matchers.
+- Setup logic across many tests — `@BeforeAll`, shared fixtures, custom `Duration` assertion timeouts.
+
+### Class shape
+
+```java
+package io.camunda.tests;
+
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
+import io.camunda.process.test.api.TestDeployment;
+import io.camunda.zeebe.client.ZeebeClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@CamundaSpringProcessTest
+@TestDeployment(resources = {
+    "processes/expense-approval.bpmn",
+    "processes/approval-routing.dmn"
+})
+public class ExpenseApprovalJavaTest {
+
+    @Autowired private ZeebeClient zeebe;
+
+    @Test
+    void financePath_managerApprovesFinanceApproves() {
+        var instance = zeebe.newCreateInstanceCommand()
+            .bpmnProcessId("expense-approval").latestVersion()
+            .variables(java.util.Map.of("amount", 1500, "department", "Marketing"))
+            .send().join();
+
+        CamundaAssert.assertThat(instance)
+            .hasActiveElements("Task_ManagerReview_Finance");
+        // … drive user tasks via the user-task API, then:
+        CamundaAssert.assertThat(instance).isCompleted();
+    }
+}
+```
+
+### Helpers
+
+- `CamundaAssert.assertThat(processInstance).hasActiveElements("…")` — equivalent to `ASSERT_ELEMENT_INSTANCES … IS_ACTIVE`.
+- `CamundaAssert.assertThat(processInstance).isCompleted()` — equivalent to `ASSERT_PROCESS_INSTANCE … IS_COMPLETED`.
+- `CamundaAssert.setAssertionTimeout(Duration.ofMinutes(5))` — bump the default 10s polling timeout for slow external workers.
+
+### Mocking workers
+
+```java
+@MockBean private NotificationWorker notificationWorker;
+
+@BeforeEach void stubNotification() {
+    when(notificationWorker.send(any())).thenReturn(NotificationResult.ok());
+}
+```
+
+The mock auto-completes `Task_SendNotification` instead of requiring `COMPLETE_JOB` in JSON.
+
+Same scope rules apply: do not assert produced data values. The Java surface offers richer assertions; that does not change what is in scope for process tests.

--- a/skills/camunda-process-test/references/coverage-strategy.md
+++ b/skills/camunda-process-test/references/coverage-strategy.md
@@ -1,0 +1,89 @@
+# Coverage strategy — segment-based, 100% target
+
+A test segment is a slice of process execution between two points. The strategy: cover the spine with one happy-path segment, then add the minimum number of secondary segments to exercise every remaining element. Each secondary segment starts at the nearest upstream decision point and ends as soon as it rejoins the happy path or hits an end event.
+
+The exit gate is the CPT coverage report at `target/camunda-process-test/coverage/` — every element must be visited at least once.
+
+## Step 1 — parse the BPMN
+
+Extract:
+
+- `processId` from `<bpmn:process id="…">`.
+- All element IDs and types. Treat the **happy path** as the sequence of elements traversed by the most common branch at every gateway and the most common rule in every DMN.
+- Every gateway's outgoing flows with their `conditionExpression`, plus the `default` flow.
+- Every `<bpmn:boundaryEvent>` (error, timer, escalation, message), the element it attaches to, and the error code / timer / message it catches.
+- Every `<zeebe:calledDecision decisionId="…">` and the rules inside the DMN file.
+- All end events — distinct ends produce distinct outcomes.
+
+## Step 2 — happy-path segment
+
+One scenario, start event → most common end event, choosing the most common branch at every gateway and the most common rule in every DMN. This seeds coverage of:
+
+- The start event
+- All elements on the spine
+- One branch of every gateway on the spine
+- One rule of every DMN on the spine
+- The chosen end event
+
+## Step 3 — enumerate uncovered elements
+
+Walk the BPMN element list, subtract the happy-path visited set, and produce the to-cover list.
+
+## Step 4 — pick a minimal segment per uncovered element
+
+For each uncovered element, the rules:
+
+| Element type | Root the segment at | End the segment when |
+|--------------|---------------------|----------------------|
+| Non-happy gateway branch | The gateway itself (variables chosen at `CREATE_PROCESS_INSTANCE` to route this way) | The branch's next merge / join with the happy path, or the next end event reached |
+| `default` gateway flow | The gateway | First rejoin or end event |
+| Non-happy DMN rule | The business-rule task (variables chosen to satisfy that rule's input entries) | First rejoin or end event |
+| `default` DMN rule | The business-rule task | First rejoin or end event |
+| Error boundary event | The service / user task it attaches to (use `THROW_BPMN_ERROR_FROM_JOB` with the matching `errorCode`) | The boundary's outgoing path end event |
+| Timer boundary event | The element it attaches to (advance time via the cluster clock if the segment must wait) | The boundary's outgoing path end event |
+| Escalation / message boundary | The element it attaches to | The boundary's outgoing path end event |
+| Alternate end event | A gateway / branch combination that reaches it | The end event |
+| Multi-instance loop element | A `CREATE_PROCESS_INSTANCE` with collection input that triggers the loop | First post-loop join |
+
+Pick **one** segment per uncovered element. Do not write a segment that re-tests an element already covered by the happy path or another secondary segment.
+
+## Step 5 — print the segment plan
+
+Before authoring any JSON, print:
+
+```text
+Segment plan — expense-approval
+
+  Happy path: amount=200, dept=Engineering → AUTO → Notification → End
+              covers: Start, DMN, Task_SendNotification, EndEvent_Done
+                      Gateway_Routing (AUTO branch)
+
+  Secondary segments:
+    1. MANAGER branch — amount=750
+       root: Gateway_Routing (MANAGER), ends: Task_SendNotification (rejoin)
+       covers: Task_ManagerReview, DMN rule MANAGER
+    2. FINANCE branch — amount=1500, both approve
+       root: Gateway_Routing (FINANCE), ends: Task_SendNotification (rejoin)
+       covers: Task_ManagerReview_Finance, Task_FinanceReview, DMN rule FINANCE
+    3. FINANCE — manager rejects
+       root: Task_ManagerReview_Finance, ends: Task_SendNotification (rejoin)
+       covers: Gateway_ManagerDecision_Finance (Reject branch)
+    4. notification error boundary
+       root: Task_SendNotification (throw NOTIFICATION_FAILED)
+       covers: BoundaryEvent_NotifyError, EndEvent_Error
+
+  Total: 1 + 4 = 5 segments. Predicted coverage: 100%.
+```
+
+## Step 6 — verify against the CPT report
+
+Run `mvn test`. Parse `target/camunda-process-test/coverage/coverage.json` (or open the HTML report). For each uncovered element, return to step 4 and add one segment.
+
+The loop terminates only when the report shows 100% element coverage.
+
+## Anti-patterns
+
+- **Happy-path tail in every segment.** If a secondary segment rejoins the spine before the tail, end the segment at the rejoin. The happy-path scenario already covers the tail.
+- **One segment per gateway, ignoring downstream elements.** If a non-happy branch carries unique elements (its own user task, a different end event), the segment must cover them — pick the rejoin point accordingly.
+- **Variable-value assertions instead of routing assertions.** A segment that asserts `amount == 750` after the gateway tests Jackson, not the gateway. Assert the element the gateway routed to.
+- **One scenario per DMN rule when the rule is on the happy path.** The happy-path scenario already exercises one rule. Add scenarios only for *other* rules.

--- a/skills/camunda-process-test/references/coverage-strategy.md
+++ b/skills/camunda-process-test/references/coverage-strategy.md
@@ -1,89 +1,108 @@
-# Coverage strategy — segment-based, 100% target
+# Coverage strategy — set-cover, 100% target
 
-A test segment is a slice of process execution between two points. Cover the spine with one happy-path segment. Then add the minimum number of secondary segments to exercise every remaining element. Each secondary segment starts at the nearest upstream decision point and ends as soon as it rejoins the happy path or hits an end event.
+A test segment is a slice of process execution between two points. The goal: pick the smallest set of segments whose combined coverage is every element and sequence flow in the BPMN. Plan first, author second. The CPT coverage report at `target/coverage-report/report.html` is the exit gate.
 
-The exit gate is the CPT coverage report at `target/coverage-report/report.html`. Every element must be visited at least once.
+Two ideas drive the strategy:
+
+1. **Predict each candidate's coverage statically** by walking the BPMN forward from the segment's root through its targeted branch to its rejoin or end event. Set membership is known before any test runs.
+2. **Greedy set-cover** picks the smallest non-redundant subset. No "author then dedupe" — redundancy never gets authored.
 
 ## Step 1 — parse the BPMN
 
 Extract:
 
 - `processId` from `<bpmn:process id="…">`.
-- All element IDs and types. Treat the **happy path** as the sequence of elements traversed by the most common branch at every gateway and the most common rule in every DMN.
+- All element IDs and types.
 - Every gateway's outgoing flows with their `conditionExpression`, plus the `default` flow.
 - Every `<bpmn:boundaryEvent>` (error, timer, escalation, message), the element it attaches to, and the error code / timer / message it catches.
 - Every `<zeebe:calledDecision decisionId="…">` and the rules inside the DMN file.
 - All end events — distinct ends produce distinct outcomes.
 
-## Step 2 — happy-path segment
+## Step 2 — enumerate candidate segments
 
-One scenario, start event → most common end event, choosing the most common branch at every gateway and the most common rule in every DMN. This seeds coverage of:
+Build a candidate list. Walk the model:
 
-- The start event
-- All elements on the spine
-- One branch of every gateway on the spine
-- One rule of every DMN on the spine
-- The chosen end event
+| Candidate type | Root | End | Notes |
+|----------------|------|-----|-------|
+| Each gateway branch (incl. `default`) | The gateway | First rejoin or end event | One candidate per outgoing flow |
+| Each DMN rule (incl. `default`) | The business-rule task | First rejoin or end event | Variables chosen to match the rule's input entries |
+| Each error boundary event | The activity it attaches to (use `THROW_BPMN_ERROR_FROM_JOB` with matching `errorCode`) | The boundary's outgoing path end event | |
+| Each timer / escalation / message boundary | The activity it attaches to | The boundary's outgoing path end event | Timer uses `INCREASE_TIME` past the cycle |
+| Each alternate end event | A gateway / branch combination that reaches it | The end event | |
+| Multi-instance loop | `CREATE_PROCESS_INSTANCE` with a collection input | First post-loop join | |
+| Happy path (baseline) | Start event | Most common end event | Choose the most common branch at every gateway and DMN |
 
-## Step 3 — enumerate uncovered elements
+For each candidate, **statically predict the visited set**: walk the BPMN forward from root through the chosen branch to the end condition, collecting every element id and sequence flow id along the way. Store as `(name, root, predicted_ids)`.
 
-Walk the BPMN element list, subtract the happy-path visited set, and produce the to-cover list.
+## Step 3 — greedy set-cover
 
-## Step 4 — pick a minimal segment per uncovered element
+```text
+universe   = {every element id} ∪ {every sequence flow id}
+chosen     = []
+covered    = ∅
 
-For each uncovered element, the rules:
+while covered != universe:
+    pick candidate c that maximizes |predicted_ids(c) − covered|
+    tie-break: shortest path (fewest predicted ids — cheapest to author)
+    chosen.append(c)
+    covered |= predicted_ids(c)
+```
 
-| Element type | Root the segment at | End the segment when |
-|--------------|---------------------|----------------------|
-| Non-happy gateway branch | The gateway itself (variables chosen at `CREATE_PROCESS_INSTANCE` to route this way) | The branch's next merge / join with the happy path, or the next end event reached |
-| `default` gateway flow | The gateway | First rejoin or end event |
-| Non-happy DMN rule | The business-rule task (variables chosen to satisfy that rule's input entries) | First rejoin or end event |
-| `default` DMN rule | The business-rule task | First rejoin or end event |
-| Error boundary event | The service / user task it attaches to (use `THROW_BPMN_ERROR_FROM_JOB` with the matching `errorCode`) | The boundary's outgoing path end event |
-| Timer boundary event | The element it attaches to (advance time via the cluster clock if the segment must wait) | The boundary's outgoing path end event |
-| Escalation / message boundary | The element it attaches to | The boundary's outgoing path end event |
-| Alternate end event | A gateway / branch combination that reaches it | The end event |
-| Multi-instance loop element | A `CREATE_PROCESS_INSTANCE` with collection input that triggers the loop | First post-loop join |
+The happy-path candidate usually wins round 1 because it covers the spine. Subsequent rounds pick segments that uniquely add boundary events, alternate branches, or alternate rules.
 
-Pick **one** segment per uncovered element. Do not write a segment that re-tests an element already covered by the happy path or another secondary segment.
+When two candidates share a root but exercise different failure modes (e.g. boundary fires vs. user task completes normally), greedy set-cover may pick only one. If diagnostic isolation matters more than minimality (you want failures to point at one cause), keep both — flag this as an explicit opt-out, not the default.
 
-## Step 5 — print the segment plan
-
-Before authoring any JSON, print:
+## Step 4 — print the plan
 
 ```text
 Segment plan — expense-approval
 
-  Happy path: amount=200, dept=Engineering → AUTO → Notification → End
-              covers: Start, DMN, Task_SendNotification, EndEvent_Done
-                      Gateway_Routing (AUTO branch)
+  Selected by greedy set-cover (predicted 100% coverage):
 
-  Secondary segments:
-    1. MANAGER branch — amount=750
-       root: Gateway_Routing (MANAGER), ends: Task_SendNotification (rejoin)
-       covers: Task_ManagerReview, DMN rule MANAGER
-    2. FINANCE branch — amount=1500, both approve
-       root: Gateway_Routing (FINANCE), ends: Task_SendNotification (rejoin)
-       covers: Task_ManagerReview_Finance, Task_FinanceReview, DMN rule FINANCE
-    3. FINANCE — manager rejects
-       root: Task_ManagerReview_Finance, ends: Task_SendNotification (rejoin)
-       covers: Gateway_ManagerDecision_Finance (Reject branch)
-    4. notification error boundary
-       root: Task_SendNotification (throw NOTIFICATION_FAILED)
-       covers: BoundaryEvent_NotifyError, EndEvent_Error
+  1. MANAGER path — manager approves
+     root: Gateway_ApprovalLevel (MANAGER branch via amount=750)
+     covers (13): Start, Task_DetermineApproval, Gateway_ApprovalLevel,
+                  Flow_Manager, Task_ManagerReview, Gateway_ManagerDecision,
+                  Flow_ManagerApproved, Gateway_MergeBeforeNotify, Flow_ToNotify,
+                  Task_SendNotification, Flow_ToEnd, EndEvent_1, …
+  2. MANAGER path — manager rejects
+     root: Gateway_ManagerDecision (reject)
+     covers (+1): Flow_ManagerRejected
+  3. FINANCE path — manager and finance approve
+     root: Gateway_ApprovalLevel (FINANCE branch via amount=1500)
+     covers (+3): Task_ManagerReview_Finance, Flow_FinanceManagerApproved,
+                  Task_FinanceReview, Flow_FinanceReviewDone, …
+  4. FINANCE path — manager rejects
+     root: Gateway_FinanceManagerDecision (reject)
+     covers (+1): Flow_FinanceManagerRejected
+  5. AUTO path — notification fails, error boundary fires
+     root: Task_SendNotification (throw NOTIFICATION_FAILED), routes via amount=200
+     covers (+4): Flow_Auto, BoundaryEvent_NotifyError, Flow_ErrorEnd, EndEvent_Error
+  6. MANAGER path — reminder fires after 24h
+     root: Task_ManagerReview + INCREASE_TIME PT25H
+     covers (+5): BoundaryEvent_Reminder, Flow_Reminder, Task_SendReminder,
+                  Flow_ReminderEnd, EndEvent_Reminder
+  7. FINANCE path — reminder2 fires after 24h
+     root: Task_ManagerReview_Finance + INCREASE_TIME PT25H
+     covers (+5): BoundaryEvent_Reminder2, Flow_Reminder2, Task_SendReminder2,
+                  Flow_ReminderEnd2, EndEvent_Reminder2
 
-  Total: 1 + 4 = 5 segments. Predicted coverage: 100%.
+  Total: 7 segments. Predicted coverage: 38/38 = 100%.
 ```
 
-## Step 6 — verify against the CPT report
+Author exactly this list.
 
-Run `mvn test`. Parse `target/coverage-report/report.html` (the page embeds the full dataset as a `window.COVERAGE_DATA` JSON literal). For each uncovered element, return to step 4 and add one segment.
+## Step 5 — verify against the CPT report
 
-The loop terminates only when the report shows 100% element coverage.
+Run `mvn test`. Parse `target/coverage-report/report.html` (the page embeds the full dataset as a `window.COVERAGE_DATA` JSON literal — see SKILL.md for the extractor).
+
+If aggregate runtime coverage equals predicted coverage, done. If it does not, the gap is a **prediction miss** — the static walk for one of the chosen candidates did not match the engine's actual path. Common causes: gateway condition the parser couldn't evaluate, FEEL expression depending on a variable the planner did not set, non-interrupting boundary that creates a parallel branch the walker missed.
+
+Treat misses as planner bugs, not just gaps to patch. Add the missing candidates to chosen, but also fix the prediction rule so the next BPMN does not hit the same miss.
 
 ## Anti-patterns
 
-- **Happy-path tail in every segment.** If a secondary segment rejoins the spine before the tail, end the segment at the rejoin. The happy-path scenario already covers the tail.
-- **One segment per gateway, ignoring downstream elements.** If a non-happy branch carries unique elements (its own user task, a different end event), the segment must cover them — pick the rejoin point accordingly.
+- **Author-then-dedupe.** Authoring one segment per uncovered element and pruning after the loop wastes Maven cycles and adds reviewer noise. Set-cover planning eliminates redundancy at the planning step.
+- **Happy-path tail in every segment.** A secondary segment that runs through the entire happy path after rejoining doubles up coverage. End the segment at the first rejoin.
 - **Variable-value assertions instead of routing assertions.** A segment that asserts `amount == 750` after the gateway tests Jackson, not the gateway. Assert the element the gateway routed to.
-- **One scenario per DMN rule when the rule is on the happy path.** The happy-path scenario already exercises one rule. Add scenarios only for *other* rules.
+- **One scenario per DMN rule when the rule is on the chosen happy path.** Set-cover already credits the chosen rule. Add scenarios only for other rules.

--- a/skills/camunda-process-test/references/coverage-strategy.md
+++ b/skills/camunda-process-test/references/coverage-strategy.md
@@ -1,8 +1,8 @@
 # Coverage strategy — segment-based, 100% target
 
-A test segment is a slice of process execution between two points. The strategy: cover the spine with one happy-path segment, then add the minimum number of secondary segments to exercise every remaining element. Each secondary segment starts at the nearest upstream decision point and ends as soon as it rejoins the happy path or hits an end event.
+A test segment is a slice of process execution between two points. Cover the spine with one happy-path segment. Then add the minimum number of secondary segments to exercise every remaining element. Each secondary segment starts at the nearest upstream decision point and ends as soon as it rejoins the happy path or hits an end event.
 
-The exit gate is the CPT coverage report at `target/camunda-process-test/coverage/` — every element must be visited at least once.
+The exit gate is the CPT coverage report at `target/coverage-report/report.html`. Every element must be visited at least once.
 
 ## Step 1 — parse the BPMN
 
@@ -77,7 +77,7 @@ Segment plan — expense-approval
 
 ## Step 6 — verify against the CPT report
 
-Run `mvn test`. Parse `target/camunda-process-test/coverage/coverage.json` (or open the HTML report). For each uncovered element, return to step 4 and add one segment.
+Run `mvn test`. Parse `target/coverage-report/report.html` (the page embeds the full dataset as a `window.COVERAGE_DATA` JSON literal). For each uncovered element, return to step 4 and add one segment.
 
 The loop terminates only when the report shows 100% element coverage.
 

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -1,0 +1,159 @@
+# CPT setup
+
+Prerequisites and one-time test-harness scaffold for `camunda-process-test-spring`.
+
+## Prerequisites
+
+### Java 21+
+
+```bash
+java -version
+```
+
+If below 21, install JDK 21 first. If `java` is missing, check `asdf list java` or `mise list java`; pin a 21+ version in `.tool-versions` at the repo root.
+
+### Maven
+
+Prefer `./mvnw` if the project ships a wrapper. Otherwise `mvn -version`. If missing, `brew install maven` (macOS).
+
+### Docker runtime
+
+CPT uses Testcontainers to spin up Zeebe in a container. One of these must be running:
+
+| Runtime | Check | Start |
+|---------|-------|-------|
+| OrbStack | `orb status` | `open -a OrbStack` |
+| Docker Desktop | `docker info` | Open Docker Desktop and wait for the whale icon |
+| Rancher Desktop | `docker info` | Open Rancher Desktop |
+
+Do not run `mvn test` while Docker is down — the failure surfaces as a Spring context start-up error and looks like a code problem.
+
+> Testcontainers pulls the correct Zeebe image automatically on first run (~500MB). Do not pre-pull `camunda/zeebe:latest` — the tag may not match the CPT version on the classpath.
+
+## CPT dependency
+
+Required entry in the project (or test harness) `pom.xml`:
+
+```xml
+<properties>
+  <java.version>21</java.version>
+  <camunda-process-test.version>8.9.0</camunda-process-test.version>
+</properties>
+
+<dependencies>
+  <dependency>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-process-test-spring</artifactId>
+    <version>${camunda-process-test.version}</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter</artifactId>
+    <scope>test</scope>
+  </dependency>
+</dependencies>
+```
+
+Use 8.9+ — the instruction-based `.test.json` format (`CREATE_PROCESS_INSTANCE`, `COMPLETE_JOB`, …) requires it.
+
+## Scaffold layout
+
+```
+src/
+  main/resources/
+    processes/                        # BPMN, DMN, .form lives here
+  test/
+    java/io/camunda/tests/
+      ProcessTest.java                # JUnit runner
+      TestApplication.java            # @SpringBootApplication for tests
+    resources/
+      scenarios/
+        <processId>.test.json         # one file per process
+```
+
+### `ProcessTest.java`
+
+```java
+package io.camunda.tests;
+
+import io.camunda.process.test.api.CamundaSpringProcessTest;
+import io.camunda.process.test.api.TestDeployment;
+import io.camunda.process.test.api.testCases.TestCase;
+import io.camunda.process.test.api.testCases.TestCaseRunner;
+import io.camunda.process.test.api.testCases.TestCaseSource;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@CamundaSpringProcessTest
+@TestDeployment(resources = {
+    "processes/expense-approval.bpmn",
+    "processes/approval-routing.dmn",
+    "processes/manager-review.form"
+})
+public class ProcessTest {
+
+    @Autowired
+    private TestCaseRunner testCaseRunner;
+
+    @ParameterizedTest(name = "{0}")
+    @TestCaseSource(directory = "/scenarios")
+    void shouldPass(final TestCase testCase, final String fileName) {
+        testCaseRunner.run(testCase);
+    }
+}
+```
+
+Notes:
+
+- `@TestDeployment` paths are **classpath-relative**. Do **not** prefix with `classpath:` — CPT adds it internally; the prefix causes `FileNotFoundException`.
+- Every BPMN, DMN, and form file referenced by the process under test must be listed. A missing `.form` produces a `FORM_NOT_FOUND` incident at runtime.
+- `@TestCaseSource(directory = "/scenarios")` is classpath-relative — leading slash, regardless of the Java package.
+
+### `TestApplication.java`
+
+```java
+package io.camunda.tests;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TestApplication.class, args);
+    }
+}
+```
+
+Required so `@SpringBootTest` has an application context to load.
+
+## Node.js project layout
+
+If the project root has `package.json` but no `pom.xml`, scaffold a sibling `test/` directory holding its own `pom.xml`. The test harness reads BPMN / DMN / form files from the parent project via a `<testResource>` mapping:
+
+```xml
+<testResources>
+  <testResource>
+    <directory>src/test/resources</directory>
+    <excludes><exclude>scenarios/**</exclude></excludes>
+  </testResource>
+  <testResource>
+    <directory>../resources</directory>
+    <targetPath>processes</targetPath>
+    <includes>
+      <include>**/*.bpmn</include>
+      <include>**/*.dmn</include>
+      <include>**/*.form</include>
+    </includes>
+  </testResource>
+</testResources>
+```
+
+Confirm the scaffold by running `mvn test-compile` from `test/`.
+
+## Filename hygiene
+
+Spaces in BPMN filenames work in Java strings and `<include>` tags but break shell scripts and glob patterns. Rename spaces to hyphens before adding to `@TestDeployment`.

--- a/skills/camunda-process-test/references/troubleshooting.md
+++ b/skills/camunda-process-test/references/troubleshooting.md
@@ -7,6 +7,7 @@ Diagnose `mvn test` failures. Each row classifies the failure as a **test proble
 | Failure | Likely root cause | Class | Fix |
 |---------|-------------------|-------|-----|
 | Spring context fails to start | Docker not running | Infra | Start Docker. Re-run. No code change. |
+| `Cannot connect to the Docker daemon at unix:///…/docker.sock` after `docker info` prints a Client section | Docker CLI installed but daemon stopped — exit code 0 from `docker info` is misleading because the client section alone returns success | Infra | Check daemon-up explicitly: `docker info --format '{{.ServerVersion}}'` returns a version string only when the daemon is reachable. Start the runtime (Docker Desktop / OrbStack / Rancher) and re-run. |
 | `processId not found` | Wrong process id in `processDefinitionSelector` | Test | Re-read `<bpmn:process id="…">` and update the scenario. |
 | `elementId not found` | Wrong element id in `elementSelector` / `jobSelector` / `userTaskSelector` | Test | Re-read the `id` attribute on the BPMN element. |
 | `FileNotFoundException` for BPMN / DMN / form on deploy | `classpath:` prefix in `@TestDeployment` | Test | Remove `classpath:` — CPT adds it internally. |

--- a/skills/camunda-process-test/references/troubleshooting.md
+++ b/skills/camunda-process-test/references/troubleshooting.md
@@ -1,0 +1,37 @@
+# CPT troubleshooting
+
+Diagnose `mvn test` failures. Each row classifies the failure as a **test problem** (fix the scenario) or a **process problem** (fix the BPMN, DMN, form, or worker). Confusing the two costs hours.
+
+## Quick triage
+
+| Failure | Likely root cause | Class | Fix |
+|---------|-------------------|-------|-----|
+| Spring context fails to start | Docker not running | Infra | Start Docker. Re-run. No code change. |
+| `processId not found` | Wrong process id in `processDefinitionSelector` | Test | Re-read `<bpmn:process id="…">` and update the scenario. |
+| `elementId not found` | Wrong element id in `elementSelector` / `jobSelector` / `userTaskSelector` | Test | Re-read the `id` attribute on the BPMN element. |
+| `FileNotFoundException` for BPMN / DMN / form on deploy | `classpath:` prefix in `@TestDeployment` | Test | Remove `classpath:` — CPT adds it internally. |
+| `FORM_NOT_FOUND` incident | `.form` file missing from `@TestDeployment` | Test | Add the form file (no `classpath:`). |
+| Test times out on a service task | No `COMPLETE_JOB` instruction for the task | Test | Add `COMPLETE_JOB` with the right `elementId`. |
+| Test times out on a user task | No `COMPLETE_USER_TASK` instruction | Test | Add `COMPLETE_USER_TASK`. |
+| Wrong end event reached | Variable name or value drives the wrong branch | **Investigate** | Read the FEEL condition on the gateway and the `CREATE_PROCESS_INSTANCE` variables. Either the variable name in the test is wrong **or** the FEEL in the BPMN uses the wrong identifier. |
+| `THROW_BPMN_ERROR_FROM_JOB` doesn't trigger boundary | `errorCode` mismatch between the instruction and `<bpmn:error errorCode="…">` | Test or process | Compare the two strings exactly. Whichever is the typo wins. |
+| `IS_COMPLETED` on process fails, an element is `IS_ACTIVE` | A waiting element has no instruction telling it to proceed | Test | Add `COMPLETE_JOB` / `COMPLETE_USER_TASK` / `THROW_BPMN_ERROR_FROM_JOB` for the active element. |
+| `ClientStatusException INVALID_ARGUMENT` on deploy mentioning "must appear before" / `cvc-complex-type` | BPMN file violates BPMN20 XSD element ordering | Process | Out of scope here — run `c8ctl bpmn lint` and fix the BPMN (camunda-bpmn). |
+| `Failed to parse DMN: Unable to parse model` on deploy | DMN file is not valid DMN 1.3 | Process | Out of scope — fix the DMN. Optionally remove the DMN from `@TestDeployment` temporarily to unblock unrelated tests. |
+| `ClientStatusException` on deploy mentioning a `.form` file | Form fails JSON-Schema validation | Process | Fix the form (camunda-forms). |
+| `BPMN error code mismatch` | `THROW_BPMN_ERROR_FROM_JOB errorCode` does not match `<bpmn:error errorCode>` | Test | Match exactly. Case-sensitive. |
+| Assertion failed on variable value | Value mismatch | **Investigate** | If the variable feeds a downstream gateway or DMN, fix whichever side is wrong. If nothing reads the variable, the assertion itself is out of scope — remove it. |
+| `IllegalStateException: Report resources not found in classpath` | Known SNAPSHOT bug in CPT coverage report generator | Infra | Non-blocking. Tests pass. Ignore until a GA release fixes it. |
+
+## Repair discipline
+
+1. Diagnose **every** failure first. Do not start fixing until the full list is classified.
+2. Group fixes by class. Test problems batch into one commit; process problems batch into another. Mixed commits make later reviews hard.
+3. Re-run `mvn test` once per batch. Three repair cycles without progress means the diagnosis is wrong — stop and re-read.
+4. Never silence a failure by deleting the scenario. If a scenario is genuinely redundant, the deduplication pass in the main workflow handles it — not the repair loop.
+
+## When in doubt
+
+- For a routing mismatch (`Wrong end event reached`, gateway not hit): run `c8ctl feel evaluate '<condition>' --vars '<scenario variables>'` to confirm what the condition resolves to. See camunda-feel.
+- For a deploy-time XSD error: run `c8ctl bpmn lint <file>`. See camunda-bpmn.
+- For a hung instance: list active elements at the failure point and identify which one needs an instruction.


### PR DESCRIPTION
## What changed

- New `camunda-process-test` skill: drives Camunda Process Test (CPT) suites to 100% BPMN element + sequence-flow coverage via **greedy set-cover planning** (no author-then-dedupe wastage).
- Default behavior of the skill: open `target/coverage-report/report.html` in the browser after every `mvn test`; patch-loop on prediction misses only, with a 2-iteration cap.
- AGENTS.md index + waza azd-extension install commands.
- Retro additions: Docker daemon-up triage row in troubleshooting; Opus review fixes (parser hardening for `window.COVERAGE_DATA` payloads with embedded strings, report-path consistency, `CamundaClient` over legacy `ZeebeClient`).

## Why

Consolidates 9 upstream test skills from process-os and camunda-ai-dev-kit into a single workflow skill that fits this repo's reference-driven style. Scope: routing and reachability only; data-value assertions on service-task outputs are out of scope.

The set-cover rewrite came from a real-suite review: leave-one-out analysis on the expense-approval example showed 3 of 8 scenarios were strict subsets of others. Planning the suite via set-cover before authoring eliminates the redundant scenarios at the planning step.

## Notes for reviewer

- Smoke-tested against `process-os/examples/expense-approval`: 7 scenarios, 38/38 coverage, leave-one-out check clean.
- `waza check`: 8/8 spec, 11/11 links, 2847/5000 tokens.
- Skill prescribes `INCREASE_TIME` for timer boundaries and `PUBLISH_MESSAGE` for message boundaries — both verified against the CPT 8.9 schema.
- Java fallback uses `io.camunda.client.CamundaClient` (8.8+) — confirmed in the local Maven repository against `camunda-process-test-spring` 8.9.0-rc4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)