### PR TITLE
refactor(camunda-bpmn,camunda-process-mgmt): add deploy-safety validation path

### DIFF
--- a/skills/camunda-bpmn/SKILL.md
+++ b/skills/camunda-bpmn/SKILL.md
@@ -24,7 +24,9 @@ Create and edit executable BPMN 2.0 processes for Camunda 8.8+. Generates valid 
 - **camunda-feel**: Use for FEEL expressions in gateway conditions, input/output mappings, timer definitions
 - **camunda-forms**: Use for creating Camunda Form JSON schemas linked to user tasks
 - **camunda-connectors**: Use for configuring pre-built connectors (REST, Slack, Kafka, etc.) via element templates
-- **camunda-process-mgmt**: Use for deploying BPMN to a Camunda cluster and managing running instances via c8ctl
+- **camunda-process-test**: **Preferred validation path after lint** — CPT runs the process against an embedded Zeebe engine; fast feedback, no cluster needed
+- **camunda-process-mgmt**: Fallback validation — deploy and run on a real cluster (prefer local c8run; safety check before any shared cluster)
+- **camunda-c8ctl**: Always pass `--profile=<name>` on deploy commands and confirm with the user before touching anything that isn't local c8run. See the "Safety: target the right cluster" section.
 - **camunda-ai-agent**: Use when modeling an AI agent — ad-hoc subprocess hosting tools driven by the AI Agent connector
 
 ## Instructions
@@ -127,9 +129,9 @@ BPMN files can be large. Follow these rules:
 - Include BPMN DI section for visual layout (see `references/layout-rules.md`)
 - Include `<bpmn:incoming>` and `<bpmn:outgoing>` flow references on elements
 
-### Lint loop — mandatory exit gate
+### Lint loop — structural exit gate
 
-A BPMN edit is **not done** until `c8ctl bpmn lint` reports zero errors AND zero warnings. Treat this as the closing step of every BPMN task — generation, modification, refactor, or merge.
+A BPMN edit is **not structurally done** until `c8ctl bpmn lint` reports zero errors AND zero warnings. Treat this as the closing structural step of every BPMN task — generation, modification, refactor, or merge.
 
 1. Run the linter against the file you touched:
 
@@ -147,9 +149,49 @@ A BPMN edit is **not done** until `c8ctl bpmn lint` reports zero errors AND zero
    - **no-implicit-split** — exclusive gateway outgoing flows need conditions + a default
    - **superfluous-gateway** — drop pass-through gateways with one in, one out
 
-3. Loop until the linter is clean. Do not declare the task done while warnings remain — silently-failing BPMN deploys to the cluster and surfaces as runtime incidents.
+3. Loop until the linter is clean. Do not declare the task structurally done while warnings remain — silently-failing BPMN deploys to the cluster and surfaces as runtime incidents.
 
 If a warning is genuinely a false positive, suppress it explicitly in a project-level `.bpmnlintrc` and flag the suppression in your final message — never silently ignore.
+
+### Behavioural validation — by execution
+
+Lint catches structure. It does not catch FEEL errors at runtime, missing job workers, mismatched job types, missing variables, or unreachable end events. After lint is clean, validate behaviour by **running the process**. Two paths, in preference order:
+
+#### 1. Camunda Process Test (preferred)
+
+If the repo already has a CPT setup, that's the best feedback loop — fastest, no cluster, embedded Zeebe runs the process to completion against a `.test.json` scenario. CPT catches gateway routing bugs, FEEL evaluation errors, DMN integration issues, error boundary firing, and timer behaviour.
+
+See **camunda-process-test** for authoring scenarios, the segment-based coverage approach, and the 100% BPMN coverage exit gate.
+
+If no CPT setup exists and adding one is a heavier lift than the change warrants, fall back to path 2.
+
+#### 2. Deploy to a cluster and start an instance
+
+For ad-hoc validation or projects without CPT, deploy and run an instance with representative input.
+
+**Cluster safety — ask before deploying:**
+
+- **Always prefer local c8run.** If `c8ctl cluster status` shows a running local cluster, validate there. If not, start one with `c8ctl cluster start` (see **camunda-c8ctl**).
+- **If only a remote profile is configured**, run `c8ctl which profile` and **confirm with the user** before deploying — a profile named `prod`, `staging`, `live`, or a customer name should never receive a validation deploy without explicit confirmation.
+- **Always pass `--profile=<name>` explicitly** on the deploy command.
+
+Validation deploy + run:
+
+```bash
+# 1. Confirm or start a local cluster
+c8ctl cluster status || c8ctl cluster start
+
+# 2. Deploy (use the local profile)
+c8ctl deploy process.bpmn --profile=local
+
+# 3. Start an instance with representative input
+c8ctl run process.bpmn --variables '{"orderId":"ORD-123"}' --profile=local
+
+# Or, block until completion (useful for smoke tests)
+c8ctl await pi --id MyProcess --variables '{"orderId":"ORD-123"}' --profile=local
+```
+
+If the instance reaches an end event, the behaviour is sound for that input. If it raises an incident, inspect with `c8ctl search inc --state=ACTIVE` and follow the debug workflow in **camunda-process-mgmt**. Iterate: fix → lint → redeploy → restart.
 
 ## References
 

--- a/skills/camunda-bpmn/SKILL.md
+++ b/skills/camunda-bpmn/SKILL.md
@@ -24,9 +24,8 @@ Create and edit executable BPMN 2.0 processes for Camunda 8.8+. Generates valid 
 - **camunda-feel**: Use for FEEL expressions in gateway conditions, input/output mappings, timer definitions
 - **camunda-forms**: Use for creating Camunda Form JSON schemas linked to user tasks
 - **camunda-connectors**: Use for configuring pre-built connectors (REST, Slack, Kafka, etc.) via element templates
-- **camunda-process-test**: **Preferred validation path after lint** — CPT runs the process against an embedded Zeebe engine; fast feedback, no cluster needed
-- **camunda-process-mgmt**: Fallback validation — deploy and run on a real cluster (prefer local c8run; safety check before any shared cluster)
-- **camunda-c8ctl**: Always pass `--profile=<name>` on deploy commands and confirm with the user before touching anything that isn't local c8run. See the "Safety: target the right cluster" section.
+- **camunda-process-test**: Use for testing processes against an embedded Zeebe engine
+- **camunda-process-mgmt**: Use for deploying to a cluster and running instances
 - **camunda-ai-agent**: Use when modeling an AI agent — ad-hoc subprocess hosting tools driven by the AI Agent connector
 
 ## Instructions
@@ -153,45 +152,9 @@ A BPMN edit is **not structurally done** until `c8ctl bpmn lint` reports zero er
 
 If a warning is genuinely a false positive, suppress it explicitly in a project-level `.bpmnlintrc` and flag the suppression in your final message — never silently ignore.
 
-### Behavioural validation — by execution
+### Behavioural validation
 
-Lint catches structure. It does not catch FEEL errors at runtime, missing job workers, mismatched job types, missing variables, or unreachable end events. After lint is clean, validate behaviour by **running the process**. Two paths, in preference order:
-
-#### 1. Camunda Process Test (preferred)
-
-If the repo already has a CPT setup, that's the best feedback loop — fastest, no cluster, embedded Zeebe runs the process to completion against a `.test.json` scenario. CPT catches gateway routing bugs, FEEL evaluation errors, DMN integration issues, error boundary firing, and timer behaviour.
-
-See **camunda-process-test** for authoring scenarios, the segment-based coverage approach, and the 100% BPMN coverage exit gate.
-
-If no CPT setup exists and adding one is a heavier lift than the change warrants, fall back to path 2.
-
-#### 2. Deploy to a cluster and start an instance
-
-For ad-hoc validation or projects without CPT, deploy and run an instance with representative input.
-
-**Cluster safety — ask before deploying:**
-
-- **Always prefer local c8run.** If `c8ctl cluster status` shows a running local cluster, validate there. If not, start one with `c8ctl cluster start` (see **camunda-c8ctl**).
-- **If only a remote profile is configured**, run `c8ctl which profile` and **confirm with the user** before deploying — a profile named `prod`, `staging`, `live`, or a customer name should never receive a validation deploy without explicit confirmation.
-- **Always pass `--profile=<name>` explicitly** on the deploy command.
-
-Validation deploy + run:
-
-```bash
-# 1. Confirm or start a local cluster
-c8ctl cluster status || c8ctl cluster start
-
-# 2. Deploy (use the local profile)
-c8ctl deploy process.bpmn --profile=local
-
-# 3. Start an instance with representative input
-c8ctl run process.bpmn --variables '{"orderId":"ORD-123"}' --profile=local
-
-# Or, block until completion (useful for smoke tests)
-c8ctl await pi --id MyProcess --variables '{"orderId":"ORD-123"}' --profile=local
-```
-
-If the instance reaches an end event, the behaviour is sound for that input. If it raises an incident, inspect with `c8ctl search inc --state=ACTIVE` and follow the debug workflow in **camunda-process-mgmt**. Iterate: fix → lint → redeploy → restart.
+Lint catches structure, not runtime behaviour (FEEL errors, missing workers, unreachable end events). After lint is clean, validate by **running the process**: prefer **camunda-process-test** for embedded-engine feedback without a cluster, or fall back to **camunda-process-mgmt** to deploy and run an instance.
 
 ## References
 

--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -21,11 +21,11 @@ Runtime operations for Camunda 8.8+ clusters via c8ctl: deploy resources, start 
 
 ## Cross-References
 
-- **camunda-c8ctl**: Use for installing c8ctl, configuring profiles, starting a local c8run cluster. Read the "Safety: target the right cluster" section — this skill enforces those rules on every mutating command.
+- **camunda-c8ctl**: Use for c8ctl install, profile management, local cluster operations, and cluster-safety rules
 - **camunda-bpmn**: Use for fixing BPMN process issues found during debugging
 - **camunda-connectors**: Use for fixing connector configuration issues found during debugging
 - **camunda-feel**: Use for diagnosing FEEL evaluation errors (EXTRACT_VALUE_ERROR, CONDITION_ERROR) in incidents
-- **camunda-process-test**: Prefer CPT (embedded engine, no cluster) over deploy-to-cluster for behavioural validation when a CPT setup is available
+- **camunda-process-test**: Use for testing processes against an embedded Zeebe engine
 
 ## Instructions
 
@@ -39,7 +39,7 @@ The globally-active c8ctl profile might still point at a shared cluster (`prod`,
 - **Always pass `--profile=<name>` explicitly** on `deploy` and other mutating commands (`run`, `cancel`, `resolve`, `complete`, `publish`, `watch`).
 - For validation deploys (just running the change once to check it works), prefer `--profile=local` against a running c8run cluster — `c8ctl cluster start` if not running.
 
-The full safety rules live in **camunda-c8ctl** § "Safety: target the right cluster". This skill follows them throughout.
+See **camunda-c8ctl** for the authoritative cluster-safety rules.
 
 **Example** — deploy a single BPMN file to the local profile:
 

--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -21,19 +21,30 @@ Runtime operations for Camunda 8.8+ clusters via c8ctl: deploy resources, start 
 
 ## Cross-References
 
-- **camunda-c8ctl**: Use for installing c8ctl, configuring profiles, starting a local c8run cluster
+- **camunda-c8ctl**: Use for installing c8ctl, configuring profiles, starting a local c8run cluster. Read the "Safety: target the right cluster" section — this skill enforces those rules on every mutating command.
 - **camunda-bpmn**: Use for fixing BPMN process issues found during debugging
 - **camunda-connectors**: Use for fixing connector configuration issues found during debugging
 - **camunda-feel**: Use for diagnosing FEEL evaluation errors (EXTRACT_VALUE_ERROR, CONDITION_ERROR) in incidents
+- **camunda-process-test**: Prefer CPT (embedded engine, no cluster) over deploy-to-cluster for behavioural validation when a CPT setup is available
 
 ## Instructions
 
 ### Deploying Resources
 
-**Example** — deploy a single BPMN file:
+**Cluster safety — ask before deploying to anything that isn't local c8run.**
+
+The globally-active c8ctl profile might still point at a shared cluster (`prod`, `staging`, customer name, …) from a previous session. A bare `c8ctl deploy process.bpmn` then silently writes there.
+
+- Run `c8ctl which profile` first. If the name suggests a shared environment, confirm with the user before deploying.
+- **Always pass `--profile=<name>` explicitly** on `deploy` and other mutating commands (`run`, `cancel`, `resolve`, `complete`, `publish`, `watch`).
+- For validation deploys (just running the change once to check it works), prefer `--profile=local` against a running c8run cluster — `c8ctl cluster start` if not running.
+
+The full safety rules live in **camunda-c8ctl** § "Safety: target the right cluster". This skill follows them throughout.
+
+**Example** — deploy a single BPMN file to the local profile:
 
 ```bash
-c8ctl deploy process.bpmn
+c8ctl deploy process.bpmn --profile=local
 ```
 
 Deploy multiple resources at once (BPMN, DMN, forms):


### PR DESCRIPTION
## Summary

- Add a **behavioural validation** step to `camunda-bpmn` after the structural `c8ctl bpmn lint` gate. Two paths in preference order: (1) CPT for the embedded-engine feedback loop, (2) deploy to a cluster, preferring local c8run with an explicit safety check before anything shared.
- Open `camunda-process-mgmt` § Deploying Resources with the same cluster-safety guidance so every mutating command (`deploy`, `run`, `cancel`, `resolve`, …) is gated by `c8ctl which profile` + explicit `--profile=<name>`. The authoritative rules continue to live in **camunda-c8ctl** § "Safety: target the right cluster"; both skills cross-reference it.
- Rename the bpmn `Lint loop — mandatory exit gate` to `Lint loop — structural exit gate` so the structural and behavioural gates are distinguishable.

## Why

The previous lint-only exit gate left a real gap: a BPMN file can be structurally clean but still hit FEEL errors at runtime, deploy against a worker that doesn't exist, or reach an unreachable end event. We also had no inline guardrail against an agent silently deploying to a shared cluster because the c8ctl active profile happened to point there from a previous session.

This PR fills both gaps without adding new tooling — it just wires existing skills (`camunda-process-test`, `camunda-c8ctl`) into the right step of the workflow.

## Test plan

- [x] `make lint SKILL=camunda-bpmn` — clean (advisory warnings only)
- [x] `make lint SKILL=camunda-process-mgmt` — clean (advisory warnings only)
- [ ] Cross-references resolve: bpmn → camunda-process-test, camunda-process-mgmt, camunda-c8ctl § "Safety: target the right cluster"
- [ ] Cross-references resolve: process-mgmt → camunda-c8ctl § "Safety: target the right cluster", camunda-process-test