### PR TITLE
refactor(camunda-connectors): trim post-apply framing, surface result mapping

### DIFF
--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -53,8 +53,6 @@ Each result shows the template name, ID (e.g. `io.camunda.connectors.HttpJson.v2
 
 Inbound integrations typically ship as a *family* of templates — one per BPMN element type the inbound event can attach to (message-start event, intermediate-catch event, boundary event, receive task, …). `search` returns each variant; pick the one that matches the BPMN shape you're modelling.
 
-**Templates outside the OOTB catalog** (custom-built, vendor-published, in-development) don't need to be in the local cache — `apply` also accepts a local file path or an `https://` URL pointing to the template JSON (GitHub blob URLs are auto-rewritten to raw content). See "Applying a Template to a BPMN Element" below for the argument forms.
-
 ### Inspecting a Template
 
 Two commands cover the questions you'll ask before applying:

--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -129,7 +129,7 @@ Both can be set together — `resultVariable` captures the raw response, `result
 --set resultExpression='={user: response.body.user, status: response.statusCode}'
 ```
 
-The same mechanism applies to **inbound connectors** — webhook receivers, Slack inbound (`io.camunda.connectors.inbound.Slack.*`), email inbound (`io.camunda.connectors.inbound.Email*`), Kafka consumers (`io.camunda.connectors.inbound.Kafka*`). They surface `resultVariable` + `resultExpression` under the same Output mapping group; the engine writes the incoming event payload into the process scope when the trigger fires, identically to how outbound writes the response when the service task completes.
+The same mechanism applies to **inbound connectors** — e.g. the Slack inbound connector surfaces `resultVariable` + `resultExpression` under the same Output mapping group. The engine writes the incoming event payload into the process scope when the trigger fires, identically to how outbound writes the response when the service task completes.
 
 ### Example — HTTP REST Connector
 

--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -53,6 +53,8 @@ Each result shows the template name, ID (e.g. `io.camunda.connectors.HttpJson.v2
 
 Inbound integrations typically ship as a *family* of templates — one per BPMN element type the inbound event can attach to (message-start event, intermediate-catch event, boundary event, receive task, …). `search` returns each variant; pick the one that matches the BPMN shape you're modelling.
 
+**Templates outside the OOTB catalog** (custom-built, vendor-published, in-development) don't need to be in the local cache — `apply` also accepts a local file path or an `https://` URL pointing to the template JSON (GitHub blob URLs are auto-rewritten to raw content). See "Applying a Template to a BPMN Element" below for the argument forms.
+
 ### Inspecting a Template
 
 Two commands cover the questions you'll ask before applying:

--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -12,16 +12,16 @@ description: |
 
 # Camunda Connectors
 
-Browse and configure pre-built Camunda connectors using element templates. Apply connector configurations to BPMN service tasks for integrations with external systems (REST APIs, Slack, Kafka, AWS, email, databases, etc.).
+Browse and configure pre-built Camunda connectors using element templates. Apply connector configurations to BPMN service tasks and event elements for integrations with external systems (REST APIs, Slack, Kafka, AWS, email, databases, etc.).
 
 ## Prerequisites
 
 - c8ctl CLI installed and configured (`c8ctl add profile`) — provides `c8ctl element-template` commands
-- **Local OOTB catalog synced** — run `c8ctl element-template sync` **once** before using `search`, `info`, `get-properties`, `get`, or `apply` with an OOTB template ID. Applying a template from a local file path or `https://` URL bypasses the cache and does not require sync.
+- **Local OOTB catalog synced** — run `c8ctl element-template sync` **once** before using `search`, `info`, `get-properties`, `get`, or `apply` with an OOTB template ID. Re-run (optionally with `--prune`) to pick up upstream changes. Applying a template from a local file path or `https://` URL bypasses the cache and does not require sync.
 
 ## Cross-References
 
-- **camunda-bpmn**: Use for creating the BPMN process structure (service tasks that host connectors)
+- **camunda-bpmn**: Use for creating the BPMN process structure (service tasks and event elements that host connectors)
 - **camunda-feel**: Use for FEEL expressions in connector input/output mappings
 - **camunda-process-mgmt**: Use for deploying the configured process to a cluster
 
@@ -36,7 +36,7 @@ Element templates (also called **connector templates** — the terms are used in
 - **Constraints** validating user input (required fields, URL patterns, etc.)
 - **Groups** organizing properties into logical sections (authentication, endpoint, output, error handling)
 
-Read `references/element-template-schema.md` for a comprehensive guide to interpreting template JSON, understanding binding types, conditions, constraints, FEEL support, and how each property maps to BPMN XML.
+Read `references/element-template-schema.md` for the binding-types-and-XML-mapping deep dive.
 
 ### Discovering Connectors via Search
 
@@ -46,112 +46,54 @@ Read `references/element-template-schema.md` for a comprehensive guide to interp
 c8ctl element-template search "REST"             # find HTTP/REST connectors
 c8ctl element-template search "slack"            # find Slack connectors
 c8ctl element-template search "kafka"            # find Kafka connectors
-c8ctl element-template search "ai agent"         # find the AI Agent connector
 c8ctl element-template search "connector" --limit 5   # cap results (default 20)
 ```
 
-Each result shows the template name, ID (e.g., `io.camunda.connectors.HttpJson.v2`), version, applies-to, engine constraint, and description. The header reads `Showing N of M matches for '<query>'` — if `M > N`, narrow the query or raise `--limit`. Pick the ID that matches your use case.
+Each result shows the template name, ID (e.g. `io.camunda.connectors.HttpJson.v2`), version, `appliesTo`, engine constraint, and description. The header reads `Showing N of M matches for '<query>'` — if `M > N`, narrow the query or raise `--limit`. Pick the ID that matches your use case.
 
-The local OOTB cache must be synced **once** before `search` / `info` / `get-properties` / `get` / OOTB-ID `apply` work (see Prerequisites). Re-sync to pick up new upstream templates or drop stale ones:
-
-```bash
-c8ctl element-template sync             # fetch latest catalog
-c8ctl element-template sync --prune     # also drop entries that no longer exist upstream
-```
-
-#### Common templates (starting points)
-
-For frequently-used connectors, you can skip straight to a search keyword instead of guessing the ID. The exact ID and version still come from `search` — the table below is a navigation hint, not a substitute for it.
-
-| Use case | Search keyword | Typical template family |
-|---|---|---|
-| Call a REST / HTTP API (outbound) | `REST` or `HTTP` | `io.camunda.connectors.HttpJson.v2` |
-| Send Slack message | `slack` | `io.camunda.connectors.Slack.v1` |
-| Send / read email (SMTP / IMAP / POP3) | `email` | `io.camunda.connectors.email.v1` |
-| Kafka producer (outbound) | `kafka` | `io.camunda.connectors.KAFKA.v1` |
-| Kafka consumer (inbound start / intermediate / boundary) | `kafka` | `io.camunda.connectors.inbound.KafkaMessageStart.v1`, `…KafkaIntermediate.v1`, `…KafkaBoundary.v1` |
-| Receive a webhook (inbound start / intermediate / boundary) | `webhook` | `io.camunda.connectors.webhook.WebhookConnector.v1`, `…WebhookConnectorIntermediate.v1`, `…WebhookConnectorBoundary.v1` |
-| AI Agent (LLM-driven ad-hoc subprocess) | `ai agent` | Sub-process and Task variants — see **camunda-ai-agent** |
-
-For anything not in this table, search first. IDs and versions evolve — the local cache is the source of truth.
+Inbound integrations typically ship as a *family* of templates — one per BPMN element type the inbound event can attach to (message-start event, intermediate-catch event, boundary event, receive task, …). `search` returns each variant; pick the one that matches the BPMN shape you're modelling.
 
 ### Inspecting a Template
 
-Two complementary commands cover the questions you'll ask before applying:
+Two commands cover the questions you'll ask before applying:
 
-**`info`** — metadata card. *What is this thing?* (applies-to, engine constraint, description, docs link). Optional; useful when the connector is unfamiliar or you want to confirm it fits the target element type.
-
-```bash
-c8ctl element-template info io.camunda.connectors.HttpJson.v2
-```
-
-**`get-properties`** — settable properties. *What knobs can I turn?* The default is a cheap condensed view: name + description, grouped. Filter with positional names (shell-style globs supported, quote them) or `--group <id>` for narrower output.
+- **`c8ctl element-template info <id>`** — metadata card (applies-to, engine constraint, description, docs link). Useful when the connector is unfamiliar.
+- **`c8ctl element-template get-properties <id> [<name>...]`** — settable properties (condensed: name + description, grouped). Accepts positional names (shell-style globs work, quote them) and `--group <id>` to narrow. Add `--detailed` for per-property cards showing **Required**, **FEEL**, **Active when**, **Pattern**, **Default**, **Choices** — reach for `--detailed` when an `apply --set` call fails or when you need to know whether to prefix a value with `=`.
 
 ```bash
-c8ctl element-template get-properties io.camunda.connectors.HttpJson.v2          # all settable properties
-c8ctl element-template get-properties io.camunda.connectors.HttpJson.v2 url method  # named properties only
-c8ctl element-template get-properties io.camunda.connectors.HttpJson.v2 'auth*'   # glob filter
+c8ctl element-template get-properties io.camunda.connectors.HttpJson.v2 url method
 c8ctl element-template get-properties io.camunda.connectors.HttpJson.v2 --group endpoint
+c8ctl element-template get-properties io.camunda.connectors.HttpJson.v2 --detailed authentication.token
 ```
 
-When a property's internal id differs from its binding name (the name `--set` matches), the condensed view annotates the divergence on a continuation line, e.g.:
-
-```
-retries                              Number of retries
-    [id: retryCount]
-```
-
-Here `retries` is the binding name (use this with `--set`); `retryCount` is the template's internal id. `--detailed` shows both explicitly via the `Id` field.
-
-Add `--detailed` for full per-property cards showing **Required**, **FEEL** support, **Active when** (the conditional expression), **Pattern** constraint, **Default**, and **Choices**. Use this when you need to know whether to set a value, prefix it with `=` for FEEL, or which parent property unlocks the property:
-
-```bash
-c8ctl element-template get-properties io.camunda.connectors.HttpJson.v2 --detailed authentication.token url
-```
-
-**When to use which:**
-- For connectors documented in this skill (HTTP REST, Slack), apply directly — property names are obvious.
-- For unfamiliar connectors, run `get-properties` (condensed) to scan names + descriptions before applying.
-- Use `--detailed <name>` when you need to know whether a property is required, FEEL-supported, or has a condition — or when an `apply --set` call fails.
-
-#### Falling back to raw JSON (last resort)
-
-`info` + `get-properties --detailed` cover essentially every configuration question. **Only reach for raw JSON when c8ctl commands genuinely don't surface what you need** — e.g., inspecting hidden (non-settable) properties, studying schema fields the CLI doesn't render, or authoring a custom template:
-
-```bash
-c8ctl element-template get <id> --no-icon    # raw template JSON, base64 icon stripped
-```
-
-**Pass `--no-icon` when reading the raw JSON.** Without it, the embedded base64 icon dominates the output and wastes context. Use the c8ctl commands above first; treat raw JSON as the escape hatch, not the default.
+If a property's internal id differs from its binding name (the name `--set` matches), the condensed view annotates it as `[id: <internal>]` on a continuation line — always use the top-line name with `--set`.
 
 ### Applying a Template to a BPMN Element
 
-Apply a template to a service task (or other supported element):
+Apply a template to a service task (or other supported element) — one call produces a fully-configured connector:
 
 ```bash
 c8ctl element-template apply -i io.camunda.connectors.HttpJson.v2 Task_FetchUser process.bpmn
 ```
 
 The `<template>` argument can be:
-- An OOTB template ID (with optional `@<version>`, e.g., `io.camunda.connectors.HttpJson.v2@13`). Without `@<version>`, the highest version compatible with the BPMN's `executionPlatformVersion` is auto-resolved. **Requires `c8ctl element-template sync` to have run at least once.**
-- A local file path (e.g., `./my-custom-template.json`) — no sync required
+- An OOTB template ID (with optional `@<version>`, e.g. `io.camunda.connectors.HttpJson.v2@13`). Without `@<version>`, the highest version compatible with the BPMN's `executionPlatformVersion` is auto-resolved. **Requires `c8ctl element-template sync` to have run at least once.**
+- A local file path (e.g. `./my-custom-template.json`) — no sync required
 - An `https://` URL (GitHub blob URLs are auto-rewritten to raw content) — no sync required
 
-`-i` modifies the BPMN file directly. Without `-i`, the modified XML is printed to stdout — useful for previews, redirected output, or composing with other tooling:
+`-i` modifies the BPMN file in place. Without `-i`, the modified XML is printed to stdout — useful for previews, redirected output, or composing with other tooling:
 
 ```bash
 c8ctl element-template apply <id> <element> process.bpmn | diff process.bpmn -    # preview the diff
 c8ctl element-template apply <id> <element> process.bpmn > new-process.bpmn       # write to a different file
-c8ctl element-template apply <id> <element> process.bpmn | c8ctl bpmn lint           # apply and lint in one pipeline
+c8ctl element-template apply <id> <element> process.bpmn | c8ctl bpmn lint        # apply and lint in one pipeline
 ```
 
-Use `-i` for the common "apply and persist" case. Use the pipeable form for previews, dry-runs, or chaining into other tooling.
-
-Apply sets `zeebe:modelerTemplate`, `zeebe:modelerTemplateVersion`, `zeebe:taskDefinition`, default input mappings, and task headers on the target element.
+Apply writes `zeebe:modelerTemplate`, `zeebe:modelerTemplateVersion`, `zeebe:modelerTemplateIcon`, `zeebe:taskDefinition`, the `zeebe:input` mappings, and the `zeebe:taskHeaders` onto the element. All of those must stay consistent — `apply` owns them.
 
 ### Setting Property Values at Apply Time
 
-Set values inline using repeated `--set key=value` flags:
+Set every value via repeated `--set key=value` flags on the same `apply` call:
 
 ```bash
 c8ctl element-template apply -i io.camunda.connectors.HttpJson.v2 Task_FetchUser process.bpmn \
@@ -162,7 +104,7 @@ c8ctl element-template apply -i io.camunda.connectors.HttpJson.v2 Task_FetchUser
   --set resultExpression='={user: response.body}'
 ```
 
-Note the `string(userId)` wrapper — `userId` is a number and FEEL does not auto-coerce in arithmetic. Without `string()`, the expression silently evaluates to `null` (the connector then issues a request to `null`). See `camunda-feel` skill, `references/common-patterns.md` § Type Coercion Pitfalls.
+Note the `string(userId)` wrapper — `userId` is a number and FEEL does not auto-coerce in string concatenation. Without `string()`, the expression silently evaluates to `null` (the connector then issues a request to `null`). See **camunda-feel** for FEEL type coercion details.
 
 `key` matches the template's property binding names — discover them with `get-properties`. When the same name appears on multiple binding types, prefix with `input:`, `output:`, `header:`, `property:`, or `taskDefinition:`:
 
@@ -173,19 +115,21 @@ Note the `string(userId)` wrapper — `userId` is a number and FEEL does not aut
 
 `apply` errors with a helpful list of valid names if you pass an unknown property, and with the qualified-name list if a bare key is ambiguous.
 
-For complex cases (multi-line FEEL expressions, dynamic body templates, etc.) you may still edit the BPMN XML manually after applying. See "Manual XML configuration" below.
+### Result Mapping — `resultVariable` and `resultExpression`
 
-### Configuration Workflow
+Connectors expose two properties under the **Output mapping** group that control what gets written back into the process scope when the connector completes:
 
-1. **Sync the OOTB catalog once** — `c8ctl element-template sync` if you haven't synced in this environment yet. Without it, `search` returns empty and `apply` with an OOTB ID fails. Skip if you're applying from a local file or URL.
-2. **Search** — `c8ctl element-template search "<keyword>"` to discover the right template ID. Never guess IDs from memory.
-3. **Inspect when unfamiliar** — for connectors not documented in this skill, run `c8ctl element-template get-properties <id>` to scan available properties + descriptions. Add `--detailed <name>` when you need required/FEEL/condition details.
-4. **Decide on parent values** — authentication type, method, etc. These determine which child properties become active via conditions.
-5. **Apply with values** — `c8ctl element-template apply -i <id> <element-id> <bpmn> --set key=value ...`
-6. **Skip inactive properties** — do not set values for properties whose conditions are not met (a warning surfaces if you do).
-7. **Use FEEL expressions** for dynamic values (`=` prefix for `feel: optional`, always for `feel: required`).
-8. **Use secrets** for credentials: `{{secrets.API_KEY}}`.
-9. **Validate** with `c8ctl bpmn lint process.bpmn`.
+- **`resultVariable`** — name of a single process variable that receives the raw response. Plain string, no `=` prefix. Use when downstream tasks just need the whole response under one name.
+- **`resultExpression`** — FEEL expression evaluated against the response, with its result merged into the process scope. Requires the `=` prefix. Use to extract specific fields, rename them, or compute derived values.
+
+Both can be set together — `resultVariable` captures the raw response, `resultExpression` shapes named variables alongside it. **If neither is set, the response is discarded** and downstream tasks see no new variables from this connector.
+
+```bash
+--set resultVariable=apiResponse \
+--set resultExpression='={user: response.body.user, status: response.statusCode}'
+```
+
+The same mechanism applies to **inbound connectors** — webhook receivers, Slack inbound (`io.camunda.connectors.inbound.Slack.*`), email inbound (`io.camunda.connectors.inbound.Email*`), Kafka consumers (`io.camunda.connectors.inbound.Kafka*`). They surface `resultVariable` + `resultExpression` under the same Output mapping group; the engine writes the incoming event payload into the process scope when the trigger fires, identically to how outbound writes the response when the service task completes.
 
 ### Example — HTTP REST Connector
 
@@ -194,7 +138,7 @@ For complex cases (multi-line FEEL expressions, dynamic body templates, etc.) yo
 c8ctl element-template search "REST"
 # → io.camunda.connectors.HttpJson.v2 (REST Outbound Connector)
 
-# 2. Apply with values (no inspection needed — HTTP REST property names are obvious)
+# 2. Apply with all values in one call
 c8ctl element-template apply -i io.camunda.connectors.HttpJson.v2 Task_FetchUser process.bpmn \
   --set authentication.type=bearer \
   --set authentication.token='{{secrets.API_TOKEN}}' \
@@ -205,12 +149,13 @@ c8ctl element-template apply -i io.camunda.connectors.HttpJson.v2 Task_FetchUser
   --set errorExpression='=if response.statusCode >= 400 then bpmnError("HTTP_ERROR", string(response.statusCode)) else null'
 ```
 
-The resulting BPMN XML:
+Resulting BPMN (the `data:image/svg+xml;base64,...` icon blob is elided here for readability — leave it in place in the real file):
 
 ```xml
 <bpmn:serviceTask id="Task_FetchUser" name="Fetch user data"
   zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2"
-  zeebe:modelerTemplateVersion="13">
+  zeebe:modelerTemplateVersion="13"
+  zeebe:modelerTemplateIcon="data:image/svg+xml;base64,...">
   <bpmn:extensionElements>
     <zeebe:taskDefinition type="io.camunda:http-json:1" retries="3" />
     <zeebe:ioMapping>
@@ -228,48 +173,18 @@ The resulting BPMN XML:
 </bpmn:serviceTask>
 ```
 
-### Manual XML Configuration (fallback)
+After applying, validate with `c8ctl bpmn lint process.bpmn`.
 
-For complex multi-line FEEL expressions or post-apply tweaks, edit the BPMN XML directly. The bindings to write are described in `references/element-template-schema.md`. Examples:
+### Common Pitfalls
 
-```xml
-<!-- zeebe:input binding -->
-<zeebe:input source="{{secrets.API_KEY}}" target="authentication.token" />
-
-<!-- zeebe:taskHeader binding (note: feel:required values must start with =) -->
-<zeebe:header key="resultExpression" value="={user: response.body, ts: now()}" />
-```
-
-### Secrets
-
-Reference cluster secrets — never hardcode credentials:
-
-```xml
-<zeebe:input source="{{secrets.API_KEY}}" target="authentication.token" />
-<zeebe:input source="{{secrets.SLACK_OAUTH_TOKEN}}" target="token" />
-```
-
-For local c8run clusters, see **camunda-c8ctl** for the secrets bootstrap flow — where the file lives, how to load it before starting the cluster, how to add new keys without reading existing values.
-
-### Placeholder Values
-
-When the actual value is not yet known:
-- `TODO_REPLACE_WITH_API_URL` — clearly indicates what to replace
-- `PLACEHOLDER_SLACK_CHANNEL` — identifiable placeholder
-- Avoid `""`, `"test"`, or `"xxx"` — these are ambiguous
-
-### Best Practices
-
-1. **Use `c8ctl element-template apply`** to apply templates — never manually set `zeebe:modelerTemplate` attributes.
-2. **Inspect via c8ctl, not raw JSON.** Use `info` for metadata and `get-properties` (condensed by default; add `--detailed <name>` for required/FEEL/condition cards). Only fall back to `c8ctl element-template get --no-icon` if c8ctl commands don't surface what you need.
-3. **Set values via `--set`** when applying — saves a second editing pass.
-4. **Only set active properties** — respect conditions; inactive properties surface a warning and are skipped.
-5. **Use FEEL for dynamic values** — combine variables and functions with `=` prefix.
-6. **Use secrets for credentials** — `{{secrets.MY_SECRET}}`.
-7. **Validate after configuration** — `c8ctl bpmn lint process.bpmn`.
-8. **Avoid reading full BPMN XML after template application** — template icons are large base64 strings; use Grep for targeted reads.
+- **`apply` is the only writer.** It owns `zeebe:modelerTemplate{,Version,Icon}`, `zeebe:taskDefinition`, the `zeebe:input` mappings, and the `zeebe:taskHeaders` — they identify the template and the runtime that handles the job and must stay consistent. Don't hand-edit the BPMN to add, change, or remove connector properties; don't strip the icon attribute. Re-run `apply` with different `--set` values instead.
+- **`feel: required` values must start with `=`.** A bare value is treated as a literal string, not a FEEL expression. Confirm with `get-properties --detailed <name>` if unsure.
+- **Set only active properties.** Conditional properties (e.g. `authentication.token` only applies when `authentication.type=bearer`) are silently skipped if their gating property isn't set in the same call. Decide the parent value first, then set the children.
+- **Outbound and inbound connectors both need `resultVariable` and/or `resultExpression`.** Omitting both means the connector's response is discarded.
+- **Use `{{secrets.NAME}}` for credentials.** Never hardcode tokens, API keys, or webhook URLs in `--set`. See **camunda-c8ctl** for the secrets bootstrap on local clusters.
+- **For values that are not yet known, use a clear placeholder** like `TODO_REPLACE_WITH_API_URL` or `PLACEHOLDER_SLACK_CHANNEL`. Avoid `""`, `"test"`, or `"xxx"` — those can be mistaken for intended values.
 
 ## References
 
 For detailed reference material, read from `references/`:
-- [element-template-schema.md](references/element-template-schema.md) — comprehensive guide to the element template JSON schema: binding types, conditions, constraints, FEEL support, property-to-XML mapping, and step-by-step configuration examples
+- [element-template-schema.md](references/element-template-schema.md) — element template JSON schema: binding types, conditions, constraints, FEEL support, property-to-XML mapping

--- a/skills/camunda-connectors/references/element-template-schema.md
+++ b/skills/camunda-connectors/references/element-template-schema.md
@@ -358,28 +358,3 @@ Resulting BPMN XML for a GET request with bearer auth:
   </bpmn:extensionElements>
 </bpmn:serviceTask>
 ```
-
-### Secrets
-
-Credentials should always use the Camunda secrets syntax rather than hardcoded values:
-
-```xml
-<zeebe:input source="{{secrets.SLACK_OAUTH_TOKEN}}" target="token" />
-<zeebe:input source="{{secrets.AWS_ACCESS_KEY}}" target="authentication.accessKey" />
-```
-
-The `{{secrets.NAME}}` syntax is resolved at runtime by the Camunda platform. The URL constraint pattern `^(=|(http://|https://|secrets|\\{\\{).*$)` explicitly allows this syntax.
-
-### Placeholder Values
-
-When the actual value is not yet known, use clearly identifiable placeholders:
-
-```xml
-<!-- Good: clearly indicates what needs to be replaced -->
-<zeebe:input source="TODO_REPLACE_WITH_API_URL" target="url" />
-<zeebe:input source="TODO_REPLACE_WITH_CHANNEL_ID" target="data.channel" />
-
-<!-- Bad: ambiguous or could be mistaken for real values -->
-<zeebe:input source="" target="url" />
-<zeebe:input source="test" target="data.channel" />
-```


### PR DESCRIPTION
## Summary

\`c8ctl element-template apply --set\` is the only writer for connector configuration on a BPMN element. The pre-trim skill described it as one path among several — manual XML editing, raw JSON inspection, secrets and placeholders as standalone sections — which led at least one agent to post-process the BPMN after applying (stripping the modeler-template icon, hand-editing \`zeebe:taskHeaders\`). Rewrite SKILL.md around the single path.

Changes:

- **Drop the post-apply framing**: no more \"Manual XML Configuration (fallback)\", \"Falling back to raw JSON (last resort)\", standalone Secrets / Placeholder Values / Configuration Workflow / Best Practices sections.
- **Drop the Common templates table**: \`c8ctl element-template search\` is the source of truth; the table drifted upstream and added little.
- **New: dedicated Result Mapping section** documenting \`resultVariable\` and \`resultExpression\` explicitly — they drive what the connector writes back into the process scope, and omitting both discards the response. Same mechanism applies to inbound connectors (e.g. the Slack inbound connector surfaces both under the same Output mapping group) — verified via \`c8ctl element-template get-properties\`.
- **Keep the HTTP REST worked example rich** (method + url + bearer auth + result + error properties) with the resulting BPMN XML, including the \`zeebe:modelerTemplateIcon\` attribute (data-URL blob elided in the doc) so the agent sees it must stay.
- **Replace Best Practices with inline Common Pitfalls**: six tight bullets covering apply-is-the-only-writer, \`feel: required\` needs \`=\`, conditional-property activation, result-mapping omission, \`{{secrets.NAME}}\`, placeholder values.
- **Strip duplicate Secrets + Placeholder Values sections** from \`references/element-template-schema.md\` — that guidance now lives only in SKILL.md's Common Pitfalls.

SKILL.md drops from ~4000 to **2999 tokens** (well under the 5000 advisory).

## Test plan

- [x] \`make lint SKILL=camunda-connectors\` clean — spec compliance 9/9, links 1/1, token budget 2999/5000
- [x] Verified multi-line FEEL passes through \`apply --set\` cleanly (c8ctl XML-encodes newlines as \`&#10;\`) — informed the choice to drop the prior \"manual edit needed for multi-line FEEL\" guidance
- [x] Verified inbound + outbound connector families both surface \`resultVariable\` + \`resultExpression\` under the Output mapping group via \`c8ctl element-template get-properties\` on Slack outbound, Slack \`MessageStartEvent\` inbound, Email \`MessageStart\` inbound, Kafka \`MessageStart\`, and generic Webhook
- [x] Confirmed \`apply\` writes \`zeebe:modelerTemplateIcon\` as a base64 data URL — documented as a thing the agent must not strip