### PR TITLE
feat(camunda-job-workers): add job-worker skill for Java/Spring/TS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ AI skills for Camunda 8.8+ development. Use these skills to create, deploy, and 
 | **camunda-forms** | Creating Camunda Form JSON schemas for user tasks |
 | **camunda-connectors** | Configuring pre-built connectors (REST, Slack, Kafka, etc.) via element templates |
 | **camunda-development** | Choosing between OOTB connectors, custom connector templates, custom Java connectors, and job workers before writing integration code |
+| **camunda-job-workers** | Implementing custom Camunda 8 job workers in Java, Camunda Spring Boot, or TypeScript — handler code that activates jobs and signals complete / fail / BPMN error |
 | **camunda-process-mgmt** | Deploying resources, starting/inspecting instances, resolving incidents, completing user tasks — all via c8ctl |
 | **camunda-process-test** | Authoring and running Camunda Process Test (CPT) suites that reach 100% BPMN coverage with segment-based scenarios — `.test.json` instructions, `mvn test`, coverage report parsing |
 | **camunda-ai-agent** | Building AI agents in BPMN — AI Agent connector on an ad-hoc subprocess, tool modeling, `fromAi()` parameters, prompts, sub-flow tools |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ These skills follow the [Agent Skills](https://agentskills.io) open standard and
 | **camunda-forms** | Create Camunda Form JSON schemas for user tasks |
 | **camunda-connectors** | Browse and configure pre-built connectors via element templates |
 | **camunda-development** | Choose between OOTB connectors, custom connector templates, custom Java connectors, and job workers before writing integration code |
+| **camunda-job-workers** | Implement job workers in Java, Camunda Spring Boot, or TypeScript |
 | **camunda-process-mgmt** | Deploy resources, start/inspect instances, resolve incidents, complete tasks — via c8ctl |
 | **camunda-ai-agent** | Build AI agents in BPMN — AI Agent connector on an ad-hoc subprocess, tools, `fromAi()`, prompts |
 

--- a/skills/camunda-job-workers/SKILL.md
+++ b/skills/camunda-job-workers/SKILL.md
@@ -18,10 +18,7 @@ Implement job workers for Camunda 8.8+ in Java, Camunda Spring Boot, or TypeScri
 
 - Camunda 8.8+ cluster reachable from the worker process (local c8run, SaaS, or Self-Managed — see **camunda-c8ctl**)
 - A BPMN process with at least one element that has `<zeebe:taskDefinition type="..."/>` matching the worker's job type (see **camunda-bpmn**)
-- Toolchain for the chosen SDK:
-  - **Java**: OpenJDK 17+, Maven (or Gradle)
-  - **Camunda Spring Boot Starter**: OpenJDK 17+ and either Spring Boot 4.0.x (default starter) or Spring Boot 3.5.x (fallback starter — see "Spring Boot version" below)
-  - **TypeScript**: Node.js 18+ (Node-only worker runtimes can use both `createJobWorker` and `createThreadedJobWorker`; browsers are limited to `createJobWorker`)
+- Toolchain for the chosen SDK — OpenJDK 17+ and Maven/Gradle for Java and Spring; Node.js 18+ for TypeScript. SDK-specific version constraints (e.g. Spring Boot 4 vs 3, browser support) are in each SDK's reference.
 
 ## Cross-References
 
@@ -65,137 +62,44 @@ Storing local "has this job ran?" state in the worker process is not idempotency
 
 ## Failure modes — three distinct paths
 
-The choice depends on whether the failure is a **transient infrastructure problem**, a **business outcome modelled in the BPMN**, or an **unexpected programming error**.
+The choice depends on whether the failure is a **transient infrastructure problem**, a **modelled business outcome**, or an **unexpected programming error**:
 
-1. **`fail` with retries and back-off (transient).** Network timeout, downstream 5xx, broker unreachable. The handler computes a remaining-retries count (typically `job.retries - 1`) and a back-off duration, and the engine redelivers after the back-off. In the Camunda Spring Boot Starter, this is `throw CamundaError.jobError(message, variables, retries, retryBackoff, cause)`. In the Java client, this is the `newFailCommand(...).retries(...).retryBackoff(...).send()` builder. In TypeScript, this is `job.fail({ errorMessage, retries, retryBackOff })`. Reaching zero retries raises an incident.
+1. **Transient failure → fail with retries and back-off.** Network timeout, downstream 5xx, broker unreachable. The handler decrements retries and asks the engine to redeliver after a back-off. Reaching zero retries raises an incident.
 
-2. **BPMN error (modelled business outcome).** The handler succeeded in identifying that something the business expects can fail — a payment was declined, an inventory check came back empty, a license validation rejected the input. The handler throws a BPMN error with a code that an error boundary event (or error end event in a subprocess) catches in the model. The job is **not retried** — the engine takes the error path. In the Camunda Spring Boot Starter: `throw CamundaError.bpmnError("ERROR_CODE", "human-readable explanation")`. In the Java client: `client.newThrowErrorCommand(job.getKey()).errorCode(...).errorMessage(...).send()`. In TypeScript: `job.error({ errorCode, errorMessage })`.
+2. **Business outcome → BPMN error.** The handler succeeded in *identifying* a failure modelled in the BPMN — payment declined, inventory empty, license rejected. Throw a BPMN error with a code that an error boundary event (or error end event in a subprocess) catches. The job is **not** retried — the engine takes the error path.
 
-3. **Unhandled exception (programming error).** The handler threw something the SDK didn't expect — NullPointerException, unhandled promise rejection, type error. The SDK falls back to the default behaviour: `fail` with `retries = job.retries - 1` and `retryBackoff = 0`. The engine redelivers immediately; if the bug is deterministic the job burns through its retries and raises an incident. **Never use unhandled exceptions as a control-flow signal** — the zero back-off thrashes the cluster, and a future SDK change could redefine the default.
+3. **Programming error → unhandled exception.** A NullPointerException, an unhandled promise rejection, a type error. SDKs fall back to *fail-with-zero-back-off* — the engine redelivers immediately, burns retries, and raises an incident. **Never use unhandled exceptions as a control-flow signal**: the zero back-off thrashes the cluster, and a future SDK change could redefine the default.
+
+The SDK-specific call signatures (`CamundaError.jobError` / `CamundaError.bpmnError` for Spring, `newFailCommand` / `newThrowErrorCommand` for the Java client, `job.fail` / `job.error` for TypeScript) are in the per-SDK references.
 
 ## Auto-complete vs. explicit complete
 
-The Camunda Spring Boot Starter's `@JobWorker` defaults to `autoComplete = true`: the handler returns a value (a `Map<String, Object>` or a POJO that gets serialised to variables) and the framework calls `complete` with that value. Set `autoComplete = false` when the handler needs to call `complete` itself — e.g. to merge variables conditionally, to send the response asynchronously, or to hand the `ActivatedJob` to another component that owns completion.
+The Camunda Spring Boot Starter's `@JobWorker` auto-completes by default: the handler's return value is serialised as the job's output variables. Set `autoComplete = false` when the handler needs to call `complete` itself (conditional variables, asynchronous response, ownership transfer).
 
-The Java client and the TypeScript SDK do not auto-complete — the handler is responsible for calling `complete`, `fail`, or `error` on every code path. Forgetting to call one of those leaks the job's lease: it eventually times out and the engine redelivers it.
+The Java client and TypeScript SDK **do not** auto-complete — the handler must call `complete`, `fail`, or `error` on every code path. Missing a terminal call leaks the job's lease until activation timeout.
 
-## Quick start — Camunda Spring Boot Starter
+## Pick an SDK
 
-The Spring starter is the most common path for new Java workers. Drop the dependency, annotate a method, run.
+| SDK | When to pick |
+|---|---|
+| **Camunda Spring Boot Starter** — `camunda-spring-boot-starter` ([ref](references/worker-sdk-spring.md)) | New Java applications. Annotation-driven (`@JobWorker`), auto-complete, config via `application.yaml`. The default Java path. |
+| **Java client** — `camunda-client-java` ([ref](references/worker-sdk-java.md)) | Standalone JVM applications, non-Spring frameworks, libraries embedding Zeebe access. Lower-level builder API. Replaces the deprecated Zeebe Java Client (removed in 8.10). |
+| **TypeScript** — `@camunda8/orchestration-cluster-api` ([ref](references/worker-sdk-typescript.md)) | Node.js workers, browser-hosted clients, 8.9+ projects. Fall back to `@camunda8/sdk` (Node-only) only when gRPC streaming, sub-8.8 targets, or migration friction explicitly require it. |
 
-```xml
-<dependency>
-  <groupId>io.camunda</groupId>
-  <artifactId>camunda-spring-boot-starter</artifactId>
-  <version>${camunda.version}</version>
-</dependency>
-```
-
-```java
-@SpringBootApplication
-public class App {
-  public static void main(String[] args) { SpringApplication.run(App.class, args); }
-}
-
-@Component
-class OrderWorker {
-  @JobWorker(type = "process-order")
-  public Map<String, Object> processOrder(@Variable String orderId, @Variable BigDecimal amount) {
-    if (amount.compareTo(MAX) > 0) {
-      throw CamundaError.bpmnError("AMOUNT_EXCEEDED", "Amount " + amount + " exceeds limit");
-    }
-    var ref = paymentGateway.charge(orderId, amount);  // throws JobError on transient HTTP failure
-    return Map.of("paymentRef", ref);                  // autoComplete writes this back as a variable
-  }
-}
-```
-
-`application.yaml`:
-
-```yaml
-camunda:
-  client:
-    mode: self-managed            # or saas, depending on cluster
-    zeebe:
-      grpc-address: ${CAMUNDA_GRPC_ADDRESS}
-      rest-address: ${CAMUNDA_REST_ADDRESS}
-```
-
-Run the app — the starter activates jobs of type `process-order` as soon as a process instance reaches a service task with `<zeebe:taskDefinition type="process-order"/>`. For the SDK details (all annotation parameters, profile activation, environment-specific config, exception types), read `references/worker-sdk-spring.md`.
-
-## Spring Boot version — pick the right starter on 8.9+
+### Spring Boot 4 vs. 3 — high-stakes routing
 
 > The default Camunda Spring Boot Starter (`camunda-spring-boot-starter`) is bundled with and requires Spring Boot 4.0.x.
 
-Applications on Spring Boot 4 use `camunda-spring-boot-starter` directly. Applications that cannot upgrade yet use **`camunda-spring-boot-3-starter`** instead — bundled with Spring Boot 3.5.x. Spring's OSS support for the 3.5.x line ends **June 2026**, so treat the SB3 starter as a migration bridge, not a long-lived target.
+Applications still on Spring Boot 3.5.x use **`camunda-spring-boot-3-starter`** as a migration bridge — Spring's OSS support for the 3.5.x line ends **June 2026**. Don't mix the two starters on one classpath: the SB4 starter won't start on a Spring Boot 3 app, and the SB3 starter pulls conflicting transitive deps into a Spring Boot 4 app.
 
 All starter modules require OpenJDK 17+.
 
-## Java client — `camunda-client-java`
-
-The plain Java client (no Spring) is the right choice when the worker process is not a Spring application, or when you need the lower-level `JobWorkerBuilder` API directly. As of Camunda 8.8 the artifact is **`camunda-client-java`** — it replaces the Zeebe Java Client. The Zeebe client will be **removed in 8.10**; existing code should migrate.
-
-```xml
-<dependency>
-  <groupId>io.camunda</groupId>
-  <artifactId>camunda-client-java</artifactId>
-  <version>${camunda.version}</version>
-</dependency>
-```
-
-```java
-try (var client = CamundaClient.newClientBuilder().build()) {
-  client.newWorker()
-    .jobType("process-order")
-    .handler((jobClient, job) -> {
-      // run logic, then:
-      jobClient.newCompleteCommand(job.getKey())
-        .variables(Map.of("paymentRef", ref))
-        .send().join();
-    })
-    .timeout(Duration.ofMinutes(1))
-    .open();
-  Thread.currentThread().join();   // keep the worker alive
-}
-```
-
-Full client API (command builders, streaming, multi-tenancy, OAuth configuration), see `references/worker-sdk-java.md`.
-
-## TypeScript — `@camunda8/orchestration-cluster-api`
-
-The TypeScript path uses two packages. Pick the focused client by default; fall back to the bundled SDK only for narrow cases:
-
-- **`@camunda8/orchestration-cluster-api`** (recommended) — REST-only client targeting Camunda 8.9+, runs in Node *and* browsers (browsers limited to `createJobWorker`; `createThreadedJobWorker` is Node-only).
-- **`@camunda8/sdk`** (fallback) — bundles all clients, supports gRPC and REST, Node-only. Use it when: you need gRPC streaming, you target Camunda 8.7 or earlier, you depend on earlier Operate query APIs, or you are migrating an existing app and aren't ready to update environment configuration.
-
-```typescript
-import { CamundaRestApi } from "@camunda8/orchestration-cluster-api";
-
-const client = new CamundaRestApi();
-const worker = client.createJobWorker({
-  jobType: "process-order",
-  maxParallelJobs: 10,
-  jobTimeoutMs: 60_000,
-  jobHandler: async (job) => {
-    if (job.variables.amount > MAX) {
-      return job.error({ errorCode: "AMOUNT_EXCEEDED", errorMessage: `Amount ${job.variables.amount} exceeds limit` });
-    }
-    const ref = await paymentGateway.charge(job.variables.orderId, job.variables.amount);
-    return job.complete({ paymentRef: ref });
-  },
-});
-```
-
-For CPU-bound handlers in Node, swap `createJobWorker` for `createThreadedJobWorker` (moves the handler to a worker-thread pool). Full reference: `references/worker-sdk-typescript.md`.
-
 ## Common pitfalls
 
-- **Forgetting to complete / fail / error a job** (Java client, TypeScript). The lease times out and the engine redelivers. Handlers must hit exactly one terminal call on every code path. Spring's `autoComplete = true` covers happy-path returns; the failure paths still need `throw CamundaError.bpmnError(...)` / `CamundaError.jobError(...)` to signal the engine.
-- **Treating unhandled exceptions as BPMN errors.** An unhandled throw is a programming error, not a modelled outcome. The SDK fails the job with `retries - 1` and `retryBackoff = 0` — the engine redelivers immediately, burns retries, and raises an incident. Use `CamundaError.bpmnError(...)` (or the SDK equivalent) when the failure is a business outcome, and `CamundaError.jobError(...)` (or `fail`) with a sensible back-off when it's transient infrastructure.
+- **Forgetting to complete / fail / error a job** (Java client, TypeScript). The lease times out and the engine redelivers. Handlers must hit exactly one terminal call on every code path. Spring's `autoComplete = true` covers happy-path returns; failure paths still need an explicit signal.
+- **Treating unhandled exceptions as BPMN errors.** An unhandled throw is a programming error, not a modelled outcome. SDKs fail the job with `retries - 1` and `retryBackoff = 0` — the engine redelivers immediately, burns retries, and raises an incident.
 - **Storing "already processed" state in the worker process.** Crashes and scale-out erase it. Idempotency belongs in the downstream system or in process variables that survive redelivery.
-- **Polling and request-timeout misalignment.** The activation request timeout must be shorter than the gateway / load-balancer cutoff, otherwise the worker tears the connection down and reconnects in a loop. The SDK defaults are sensible — change them deliberately.
-- **Mixing `camunda-spring-boot-starter` and `camunda-spring-boot-3-starter`** on the same classpath. Pick one. The default SB4 starter on a Spring Boot 3 application will not start; the SB3 starter on a Spring Boot 4 application brings in conflicting transitive deps.
-- **Picking `@camunda8/sdk` for new 8.9+ TypeScript projects by default.** Reach for `@camunda8/orchestration-cluster-api` first; only fall back to the bundled SDK when gRPC, sub-8.8 compatibility, or migration friction explicitly requires it.
+- **Polling and request-timeout misalignment.** The activation request timeout must be shorter than the gateway / load-balancer cutoff, otherwise the worker tears the connection down and reconnects in a loop. SDK defaults are sensible — change them deliberately.
 
 ## References
 

--- a/skills/camunda-job-workers/SKILL.md
+++ b/skills/camunda-job-workers/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: camunda-job-workers
+description: |
+  Use this skill to implement Camunda 8 job workers in Java, Camunda Spring Boot, or TypeScript — handler code that activates jobs from a service task, runs business logic, and completes, fails, or throws a BPMN error.
+
+  Use for: choosing between camunda-client-java, the Camunda Spring Boot Starter, and `@camunda8/orchestration-cluster-api`; wiring a `@JobWorker` method or `createJobWorker(...)` call to a BPMN `zeebe:taskDefinition type`; signalling complete / fail / BPMN error; idempotency, retries, back-off, auto-complete; Spring Boot 4 vs 3 starter on Camunda 8.9+.
+
+  Do not use for: deciding worker-vs-connector (use camunda-development), authoring the BPMN task (use camunda-bpmn), configuring an OOTB connector (use camunda-connectors), or building a custom connector (use camunda-connectors-development).
+
+  **Workflow skill** — pick an SDK, declare a handler against a `zeebe:taskDefinition type`, handle complete / fail / BPMN-error cases. Java, Spring, and TypeScript on Camunda 8.8+.
+---
+
+# Camunda Job Workers
+
+Implement job workers for Camunda 8.8+ in Java, Camunda Spring Boot, or TypeScript. A job worker is the handler that the Zeebe engine hands an activated job to — it runs business logic, then signals success, failure, or a BPMN error back to the engine.
+
+## Prerequisites
+
+- Camunda 8.8+ cluster reachable from the worker process (local c8run, SaaS, or Self-Managed — see **camunda-c8ctl**)
+- A BPMN process with at least one element that has `<zeebe:taskDefinition type="..."/>` matching the worker's job type (see **camunda-bpmn**)
+- Toolchain for the chosen SDK:
+  - **Java**: OpenJDK 17+, Maven (or Gradle)
+  - **Camunda Spring Boot Starter**: OpenJDK 17+ and either Spring Boot 4.0.x (default starter) or Spring Boot 3.5.x (fallback starter — see "Spring Boot version" below)
+  - **TypeScript**: Node.js 18+ (Node-only worker runtimes can use both `createJobWorker` and `createThreadedJobWorker`; browsers are limited to `createJobWorker`)
+
+## Cross-References
+
+- **camunda-development**: Use first to decide whether a worker is the right shape at all (vs. an OOTB connector, a JSON-only protocol-connector template, or a custom Java connector via the SDK)
+- **camunda-connectors-development**: Use when the integration is closer to a reusable Java connector than to application-bound worker code, or when the integration needs inbound triggers (workers are outbound-only)
+- **camunda-bpmn**: Use for the service-task / receive-task element and its `zeebe:taskDefinition`, plus the boundary events that catch the worker's BPMN errors
+- **camunda-feel**: Use for FEEL in `zeebe:taskHeaders` and for the gateway conditions that consume the worker's output variables
+- **camunda-process-mgmt**: Use for deploying the process, starting instances against the running worker, and inspecting jobs / incidents from the cluster side
+- **camunda-process-test**: Use for end-to-end tests that drive worker handlers through an embedded Zeebe engine
+
+## When to write a job worker
+
+Walk **camunda-development** first. The short version of the matrix as it applies here:
+
+- **Non-Java stack** (TypeScript, plus any other official SDK in scope for a future release): worker is the path. Connectors are Java-only.
+- **Java stack, logic already lives in the app**: worker keeps the logic in the codebase that owns it.
+- **Java stack, reusable across processes / projects / clusters**: prefer a custom connector via **camunda-connectors-development**.
+- **Inbound triggers** (an external system pushes events *into* a process): always a connector — workers exclusively pull activated jobs from the engine.
+
+## Job lifecycle
+
+A worker's contract with the engine has four states:
+
+1. **Activate** — the worker requests jobs of a given `type` (polling) or receives them on a streamed connection. Each activation has a **timeout** (the lease the engine grants before it will hand the same job to another worker if the first doesn't respond) and a **fetch-variables** list (which process variables the engine ships with the job).
+2. **Handle** — the worker runs the handler code with the activated `job` (variables, headers, retries remaining, key).
+3. **Complete** — the worker calls `complete` (or returns a value with `autoComplete=true`). The engine merges the worker's output variables into the process scope and advances the token. Variables propagate from the job's scope up to the enclosing scopes per BPMN rules.
+4. **Fail** — the worker either calls `fail` explicitly with a remaining-retries count and an optional back-off, or throws. If retries reach zero, the engine raises an **incident** and the instance pauses until an operator resolves it (see **camunda-process-mgmt**).
+
+**Activation timeout vs. retries are independent.** A timeout means the engine reassigns the job without decrementing retries; a `fail` with retries left means the same job will be redelivered after the back-off. Long-running handlers should extend the timeout via `UpdateJobTimeout` rather than racing the lease.
+
+## Idempotency — handle every job at least twice
+
+The engine's at-least-once delivery guarantees that a handler may run more than once for the same `job.key`. Activation timeouts, network blips, and retries after a failed `complete` call all cause redelivery. **Handlers must be idempotent.**
+
+Two patterns work well:
+
+- **Idempotency token in your downstream system.** Use `job.key` (or a deterministic value derived from process variables) as a request id / Idempotency-Key header / database unique constraint. A retry of the same job hits the same key and is suppressed.
+- **Check-before-write.** Query the downstream system for the side effect's marker before applying it. Cheap when the system supports it; not always available.
+
+Storing local "has this job ran?" state in the worker process is not idempotency — the process can crash, scale out, or be replaced.
+
+## Failure modes — three distinct paths
+
+The choice depends on whether the failure is a **transient infrastructure problem**, a **business outcome modelled in the BPMN**, or an **unexpected programming error**.
+
+1. **`fail` with retries and back-off (transient).** Network timeout, downstream 5xx, broker unreachable. The handler computes a remaining-retries count (typically `job.retries - 1`) and a back-off duration, and the engine redelivers after the back-off. In the Camunda Spring Boot Starter, this is `throw CamundaError.jobError(message, variables, retries, retryBackoff, cause)`. In the Java client, this is the `newFailCommand(...).retries(...).retryBackoff(...).send()` builder. In TypeScript, this is `job.fail({ errorMessage, retries, retryBackOff })`. Reaching zero retries raises an incident.
+
+2. **BPMN error (modelled business outcome).** The handler succeeded in identifying that something the business expects can fail — a payment was declined, an inventory check came back empty, a license validation rejected the input. The handler throws a BPMN error with a code that an error boundary event (or error end event in a subprocess) catches in the model. The job is **not retried** — the engine takes the error path. In the Camunda Spring Boot Starter: `throw CamundaError.bpmnError("ERROR_CODE", "human-readable explanation")`. In the Java client: `client.newThrowErrorCommand(job.getKey()).errorCode(...).errorMessage(...).send()`. In TypeScript: `job.error({ errorCode, errorMessage })`.
+
+3. **Unhandled exception (programming error).** The handler threw something the SDK didn't expect — NullPointerException, unhandled promise rejection, type error. The SDK falls back to the default behaviour: `fail` with `retries = job.retries - 1` and `retryBackoff = 0`. The engine redelivers immediately; if the bug is deterministic the job burns through its retries and raises an incident. **Never use unhandled exceptions as a control-flow signal** — the zero back-off thrashes the cluster, and a future SDK change could redefine the default.
+
+## Auto-complete vs. explicit complete
+
+The Camunda Spring Boot Starter's `@JobWorker` defaults to `autoComplete = true`: the handler returns a value (a `Map<String, Object>` or a POJO that gets serialised to variables) and the framework calls `complete` with that value. Set `autoComplete = false` when the handler needs to call `complete` itself — e.g. to merge variables conditionally, to send the response asynchronously, or to hand the `ActivatedJob` to another component that owns completion.
+
+The Java client and the TypeScript SDK do not auto-complete — the handler is responsible for calling `complete`, `fail`, or `error` on every code path. Forgetting to call one of those leaks the job's lease: it eventually times out and the engine redelivers it.
+
+## Quick start — Camunda Spring Boot Starter
+
+The Spring starter is the most common path for new Java workers. Drop the dependency, annotate a method, run.
+
+```xml
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>camunda-spring-boot-starter</artifactId>
+  <version>${camunda.version}</version>
+</dependency>
+```
+
+```java
+@SpringBootApplication
+public class App {
+  public static void main(String[] args) { SpringApplication.run(App.class, args); }
+}
+
+@Component
+class OrderWorker {
+  @JobWorker(type = "process-order")
+  public Map<String, Object> processOrder(@Variable String orderId, @Variable BigDecimal amount) {
+    if (amount.compareTo(MAX) > 0) {
+      throw CamundaError.bpmnError("AMOUNT_EXCEEDED", "Amount " + amount + " exceeds limit");
+    }
+    var ref = paymentGateway.charge(orderId, amount);  // throws JobError on transient HTTP failure
+    return Map.of("paymentRef", ref);                  // autoComplete writes this back as a variable
+  }
+}
+```
+
+`application.yaml`:
+
+```yaml
+camunda:
+  client:
+    mode: self-managed            # or saas, depending on cluster
+    zeebe:
+      grpc-address: ${CAMUNDA_GRPC_ADDRESS}
+      rest-address: ${CAMUNDA_REST_ADDRESS}
+```
+
+Run the app — the starter activates jobs of type `process-order` as soon as a process instance reaches a service task with `<zeebe:taskDefinition type="process-order"/>`. For the SDK details (all annotation parameters, profile activation, environment-specific config, exception types), read `references/worker-sdk-spring.md`.
+
+## Spring Boot version — pick the right starter on 8.9+
+
+> The default Camunda Spring Boot Starter (`camunda-spring-boot-starter`) is bundled with and requires Spring Boot 4.0.x.
+
+Applications on Spring Boot 4 use `camunda-spring-boot-starter` directly. Applications that cannot upgrade yet use **`camunda-spring-boot-3-starter`** instead — bundled with Spring Boot 3.5.x. Spring's OSS support for the 3.5.x line ends **June 2026**, so treat the SB3 starter as a migration bridge, not a long-lived target.
+
+All starter modules require OpenJDK 17+.
+
+## Java client — `camunda-client-java`
+
+The plain Java client (no Spring) is the right choice when the worker process is not a Spring application, or when you need the lower-level `JobWorkerBuilder` API directly. As of Camunda 8.8 the artifact is **`camunda-client-java`** — it replaces the Zeebe Java Client. The Zeebe client will be **removed in 8.10**; existing code should migrate.
+
+```xml
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>camunda-client-java</artifactId>
+  <version>${camunda.version}</version>
+</dependency>
+```
+
+```java
+try (var client = CamundaClient.newClientBuilder().build()) {
+  client.newWorker()
+    .jobType("process-order")
+    .handler((jobClient, job) -> {
+      // run logic, then:
+      jobClient.newCompleteCommand(job.getKey())
+        .variables(Map.of("paymentRef", ref))
+        .send().join();
+    })
+    .timeout(Duration.ofMinutes(1))
+    .open();
+  Thread.currentThread().join();   // keep the worker alive
+}
+```
+
+Full client API (command builders, streaming, multi-tenancy, OAuth configuration), see `references/worker-sdk-java.md`.
+
+## TypeScript — `@camunda8/orchestration-cluster-api`
+
+The TypeScript path uses two packages. Pick the focused client by default; fall back to the bundled SDK only for narrow cases:
+
+- **`@camunda8/orchestration-cluster-api`** (recommended) — REST-only client targeting Camunda 8.9+, runs in Node *and* browsers (browsers limited to `createJobWorker`; `createThreadedJobWorker` is Node-only).
+- **`@camunda8/sdk`** (fallback) — bundles all clients, supports gRPC and REST, Node-only. Use it when: you need gRPC streaming, you target Camunda 8.7 or earlier, you depend on earlier Operate query APIs, or you are migrating an existing app and aren't ready to update environment configuration.
+
+```typescript
+import { CamundaRestApi } from "@camunda8/orchestration-cluster-api";
+
+const client = new CamundaRestApi();
+const worker = client.createJobWorker({
+  jobType: "process-order",
+  maxParallelJobs: 10,
+  jobTimeoutMs: 60_000,
+  jobHandler: async (job) => {
+    if (job.variables.amount > MAX) {
+      return job.error({ errorCode: "AMOUNT_EXCEEDED", errorMessage: `Amount ${job.variables.amount} exceeds limit` });
+    }
+    const ref = await paymentGateway.charge(job.variables.orderId, job.variables.amount);
+    return job.complete({ paymentRef: ref });
+  },
+});
+```
+
+For CPU-bound handlers in Node, swap `createJobWorker` for `createThreadedJobWorker` (moves the handler to a worker-thread pool). Full reference: `references/worker-sdk-typescript.md`.
+
+## Common pitfalls
+
+- **Forgetting to complete / fail / error a job** (Java client, TypeScript). The lease times out and the engine redelivers. Handlers must hit exactly one terminal call on every code path. Spring's `autoComplete = true` covers happy-path returns; the failure paths still need `throw CamundaError.bpmnError(...)` / `CamundaError.jobError(...)` to signal the engine.
+- **Treating unhandled exceptions as BPMN errors.** An unhandled throw is a programming error, not a modelled outcome. The SDK fails the job with `retries - 1` and `retryBackoff = 0` — the engine redelivers immediately, burns retries, and raises an incident. Use `CamundaError.bpmnError(...)` (or the SDK equivalent) when the failure is a business outcome, and `CamundaError.jobError(...)` (or `fail`) with a sensible back-off when it's transient infrastructure.
+- **Storing "already processed" state in the worker process.** Crashes and scale-out erase it. Idempotency belongs in the downstream system or in process variables that survive redelivery.
+- **Polling and request-timeout misalignment.** The activation request timeout must be shorter than the gateway / load-balancer cutoff, otherwise the worker tears the connection down and reconnects in a loop. The SDK defaults are sensible — change them deliberately.
+- **Mixing `camunda-spring-boot-starter` and `camunda-spring-boot-3-starter`** on the same classpath. Pick one. The default SB4 starter on a Spring Boot 3 application will not start; the SB3 starter on a Spring Boot 4 application brings in conflicting transitive deps.
+- **Picking `@camunda8/sdk` for new 8.9+ TypeScript projects by default.** Reach for `@camunda8/orchestration-cluster-api` first; only fall back to the bundled SDK when gRPC, sub-8.8 compatibility, or migration friction explicitly requires it.
+
+## References
+
+For SDK-specific detail, read from `references/`:
+- [worker-sdk-java.md](references/worker-sdk-java.md) — `camunda-client-java`: client bootstrap, `JobWorkerBuilder`, command builders, streaming, multi-tenancy, OAuth config
+- [worker-sdk-spring.md](references/worker-sdk-spring.md) — Camunda Spring Boot Starter: `@JobWorker` parameter reference, `@Variable` / `@VariablesAsType`, `CamundaError`, configuration property tree, Spring Boot 4 vs 3 starter selection
+- [worker-sdk-typescript.md](references/worker-sdk-typescript.md) — `@camunda8/orchestration-cluster-api`: `createJobWorker` / `createThreadedJobWorker`, job-handler return shapes, when to fall back to `@camunda8/sdk`

--- a/skills/camunda-job-workers/references/worker-sdk-java.md
+++ b/skills/camunda-job-workers/references/worker-sdk-java.md
@@ -1,0 +1,130 @@
+# Java client — `camunda-client-java`
+
+Plain Java client for Camunda 8.8+, no Spring. The right SDK when the worker process is a standalone JVM application, a non-Spring framework, or a library that needs to embed Zeebe access without bringing Spring transitively.
+
+## Dependency
+
+```xml
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>camunda-client-java</artifactId>
+  <version>${camunda.version}</version>
+</dependency>
+```
+
+The artifact replaces the **Zeebe Java Client** (`io.camunda:zeebe-client-java`) as of 8.8. The Zeebe client is deprecated; existing code must migrate before 8.10, when it is removed.
+
+Java 17+ required.
+
+## Client bootstrap
+
+```java
+try (CamundaClient client = CamundaClient.newClientBuilder()
+        .grpcAddress(URI.create("http://localhost:26500"))
+        .restAddress(URI.create("http://localhost:8080"))
+        .usePlaintext()
+        .build()) {
+
+  // workers and commands go here
+
+  Thread.currentThread().join();   // keep the main thread alive while workers run
+}
+```
+
+Authentication, multi-tenancy, OAuth flags follow the standard builder pattern (`.credentialsProvider(...)`, `.defaultTenantId(...)`). See the [c8ctl docs](https://docs.camunda.io/docs/apis-tools/c8ctl/getting-started/) for the same env-var shape — the client reads the same `ZEEBE_*` / `CAMUNDA_*` variables as `c8ctl`.
+
+## `newWorker()` — the worker builder
+
+```java
+JobWorker worker = client.newWorker()
+  .jobType("process-order")
+  .handler(new OrderHandler())                      // JobHandler — see below
+  .timeout(Duration.ofMinutes(1))                   // activation lease
+  .pollInterval(Duration.ofMillis(100))             // polling cadence when streaming is off
+  .maxJobsActive(32)                                // concurrent leases
+  .streamEnabled(true)                              // long-lived stream for low-latency delivery
+  .fetchVariables("orderId", "amount")              // ship only these variables
+  .name("order-worker")                             // identifier for cluster-side audit
+  .tenantIds(List.of("tenant-a"))                   // restrict to tenants
+  .open();
+// ...
+worker.close();                                     // graceful shutdown drains in-flight jobs
+```
+
+`JobWorker` implements `AutoCloseable`. Close it explicitly when the application shuts down.
+
+## Handler interface — `JobHandler`
+
+```java
+public class OrderHandler implements JobHandler {
+  @Override
+  public void handle(final JobClient jobClient, final ActivatedJob job) {
+    var orderId = (String) job.getVariablesAsMap().get("orderId");
+    // ...
+    jobClient.newCompleteCommand(job.getKey())
+      .variables(Map.of("paymentRef", ref))
+      .send().join();
+  }
+}
+```
+
+`job.getVariablesAsType(OrderVars.class)` deserialises the variable map into a POJO via Jackson.
+
+`job.getKey()`, `job.getRetries()`, `job.getCustomHeaders()`, `job.getProcessInstanceKey()`, `job.getElementId()` are the most commonly used metadata accessors.
+
+## Command builders
+
+Three terminal operations on every job. The handler is responsible for hitting exactly one of them on every code path — there is no auto-complete.
+
+### `newCompleteCommand` — success
+
+```java
+jobClient.newCompleteCommand(job.getKey())
+  .variables(Map.of("paymentRef", ref))   // merged into the process scope
+  .send().join();
+```
+
+### `newFailCommand` — transient failure
+
+```java
+jobClient.newFailCommand(job.getKey())
+  .retries(job.getRetries() - 1)
+  .retryBackoff(Duration.ofSeconds(10))
+  .errorMessage("payment-gateway-timeout")
+  .variables(Map.of("attempt", attemptNumber))
+  .send().join();
+```
+
+Reaching `retries = 0` raises an incident. The engine redelivers after the back-off otherwise.
+
+### `newThrowErrorCommand` — BPMN error
+
+```java
+jobClient.newThrowErrorCommand(job.getKey())
+  .errorCode("AMOUNT_EXCEEDED")
+  .errorMessage("Amount exceeds limit")
+  .variables(Map.of("attemptedAmount", amount))
+  .send().join();
+```
+
+The engine routes the token to the matching error boundary event (or error end event in a subprocess). The job is not retried.
+
+## Streaming vs polling
+
+`streamEnabled(true)` opens a long-lived gRPC unidirectional stream — the engine pushes activated jobs to the worker without a polling round-trip. Lower latency, fewer wasted requests. Polling is the fall-back when streaming is unavailable (mixed-version clusters, network constraints).
+
+Streaming has a graceful fall-back: when the stream drops, the client polls until the stream reopens.
+
+## Lifecycle and shutdown
+
+`JobWorker.close()` stops activating new jobs but lets in-flight handlers run to completion. Wrap the worker in a try-with-resources block or register a JVM shutdown hook to ensure clean exit. Crashing without `close()` leaks the in-flight job leases — the engine reassigns them after the activation timeout, but you may see duplicate processing on the next start.
+
+## Multi-tenancy
+
+`.defaultTenantId(...)` on the client builder sets the tenant for every command unless overridden per-command. `.tenantIds(List.of(...))` on the worker builder restricts which tenants the worker activates jobs from. Without an explicit tenant, the client uses `<default>`.
+
+## Where to look next
+
+- Annotation-driven workers in Spring Boot: `worker-sdk-spring.md`
+- TypeScript equivalents: `worker-sdk-typescript.md`
+- BPMN element wiring (`zeebe:taskDefinition`): see **camunda-bpmn**

--- a/skills/camunda-job-workers/references/worker-sdk-java.md
+++ b/skills/camunda-job-workers/references/worker-sdk-java.md
@@ -31,7 +31,7 @@ try (CamundaClient client = CamundaClient.newClientBuilder()
 }
 ```
 
-Authentication, multi-tenancy, OAuth flags follow the standard builder pattern (`.credentialsProvider(...)`, `.defaultTenantId(...)`). See the [c8ctl docs](https://docs.camunda.io/docs/apis-tools/c8ctl/getting-started/) for the same env-var shape — the client reads the same `ZEEBE_*` / `CAMUNDA_*` variables as `c8ctl`.
+Authentication, multi-tenancy, and OAuth flags follow the standard builder pattern (`.credentialsProvider(...)`, `.defaultTenantId(...)`). For the env-var shape, OAuth flow, and per-environment configuration, see the [Java client getting-started docs](https://docs.camunda.io/docs/apis-tools/java-client/getting-started/).
 
 ## `newWorker()` — the worker builder
 

--- a/skills/camunda-job-workers/references/worker-sdk-spring.md
+++ b/skills/camunda-job-workers/references/worker-sdk-spring.md
@@ -18,6 +18,39 @@ Do not mix the two starters on one classpath.
 
 The starter replaces the deprecated **Spring Zeebe SDK** (`spring-zeebe-starter` / `io.camunda.spring:spring-boot-starter-camunda-sdk`); existing applications should migrate.
 
+## Minimal worker
+
+```java
+@SpringBootApplication
+public class App {
+  public static void main(String[] args) { SpringApplication.run(App.class, args); }
+}
+
+@Component
+class OrderWorker {
+  @JobWorker(type = "process-order")
+  public Map<String, Object> processOrder(@Variable String orderId, @Variable BigDecimal amount) {
+    if (amount.compareTo(MAX) > 0) {
+      throw CamundaError.bpmnError("AMOUNT_EXCEEDED", "Amount " + amount + " exceeds limit");
+    }
+    var ref = paymentGateway.charge(orderId, amount);
+    return Map.of("paymentRef", ref);                  // autoComplete writes this back as a variable
+  }
+}
+```
+
+```yaml
+# application.yaml
+camunda:
+  client:
+    mode: self-managed            # or saas, depending on cluster
+    zeebe:
+      grpc-address: ${CAMUNDA_GRPC_ADDRESS}
+      rest-address: ${CAMUNDA_REST_ADDRESS}
+```
+
+Run the app — the starter activates jobs of type `process-order` as soon as a process instance reaches a service task with `<zeebe:taskDefinition type="process-order"/>`.
+
 ## `@JobWorker` parameters
 
 ```java
@@ -41,7 +74,13 @@ public Map<String, Object> processOrder(@Variable String orderId, @Variable BigD
 }
 ```
 
-All parameters are optional; sensible defaults apply. `maxJobsActive` defaults to 64.
+All parameters are optional. The most common defaults:
+
+- **`type`** — defaults to the method name (e.g. `processOrder` → job type `processOrder`). Always set `type` explicitly unless the method is named exactly to match the BPMN's `zeebe:taskDefinition type`; method-name binding is silent and easy to break by renaming the method.
+- **`name`** — defaults to the bean name + method name; surfaced in cluster-side audit views.
+- **`autoComplete`** — `true`.
+- **`maxJobsActive`** — `64`.
+- **`enabled`** — `true`.
 
 ## Handler-method shape
 

--- a/skills/camunda-job-workers/references/worker-sdk-spring.md
+++ b/skills/camunda-job-workers/references/worker-sdk-spring.md
@@ -1,0 +1,130 @@
+# Camunda Spring Boot Starter — `@JobWorker` reference
+
+Annotation-driven workers for Spring Boot applications on Camunda 8.8+. Drop-in dependency, no manual client lifecycle.
+
+## Dependency
+
+```xml
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>camunda-spring-boot-starter</artifactId>
+  <version>${camunda.version}</version>
+</dependency>
+```
+
+`camunda-spring-boot-starter` is bundled with and requires Spring Boot 4.0.x. If the application is still on Spring Boot 3.5.x, use `camunda-spring-boot-3-starter` instead — same coordinate prefix, same surface, different transitive Spring Boot version. Spring's OSS support for Spring Boot 3.5.x ends June 2026.
+
+Do not mix the two starters on one classpath.
+
+The starter replaces the deprecated **Spring Zeebe SDK** (`spring-zeebe-starter` / `io.camunda.spring:spring-boot-starter-camunda-sdk`); existing applications should migrate.
+
+## `@JobWorker` parameters
+
+```java
+@JobWorker(
+  type = "process-order",        // job type; defaults to the method name if omitted
+  name = "order-worker",         // worker identifier surfaced in cluster operations
+  autoComplete = true,           // call complete with the method's return value; default true
+  fetchVariables = {"orderId","amount"},  // engine ships only these variables with the job
+  fetchAllVariables = false,     // override — ship every variable in the instance scope
+  timeout = 60_000,              // activation lease in milliseconds
+  maxJobsActive = 32,            // engine-side cap on concurrent leases for this worker
+  pollInterval = 100,            // ms between polling requests when no jobs are streamed
+  requestTimeout = 10_000,       // ms the activation request waits for the engine
+  streamEnabled = true,          // long-lived stream for low-latency delivery
+  tenantIds = {"tenant-a"},      // restrict to specific tenants
+  retryBackoff = 5_000,          // default ms back-off when failing without an explicit value
+  enabled = true                 // toggle the worker without removing the annotation
+)
+public Map<String, Object> processOrder(@Variable String orderId, @Variable BigDecimal amount) {
+  // ...
+}
+```
+
+All parameters are optional; sensible defaults apply. `maxJobsActive` defaults to 64.
+
+## Handler-method shape
+
+The method body is the handler. Parameter binding is annotation-driven:
+
+- **`@Variable("name")`** — bind one process variable to a parameter. If the JSON name and the Java parameter name match, the value is optional.
+- **`@VariablesAsType ProcessVars vars`** — deserialise the entire variable map into a POJO (Jackson).
+- **`@CustomHeaders Map<String,String> headers`** — read static `zeebe:taskHeaders` declared on the task.
+- **`ActivatedJob job` / `JobClient jobClient`** — escape hatches for the raw types when `autoComplete = false`.
+
+Return type:
+- `void` — auto-completes with no variables.
+- `Map<String, Object>` or a serialisable POJO — auto-completes with that as the variable payload.
+- `CompleteJobCommandStep1` — manually built command. Pair with `autoComplete = false`.
+
+## Signalling failure — `CamundaError`
+
+Three terminal paths, picked by what the failure means:
+
+```java
+// 1. BPMN error — modelled business outcome. Engine takes the error boundary path.
+throw CamundaError.bpmnError("AMOUNT_EXCEEDED", "Amount exceeds limit");
+
+// 2. Job failure — transient. Engine redelivers after retryBackoff; raises an incident at 0.
+throw CamundaError.jobError(
+  "payment-gateway-timeout",          // errorMessage
+  Map.of("attempt", attemptNumber),   // optional variables to set on the job
+  job.getRetries() - 1,               // remaining retries (default: job.getRetries() - 1)
+  Duration.ofSeconds(10),             // retryBackoff (default: configured value)
+  e                                   // cause (optional)
+);
+
+// 3. Unhandled exception — default fall-back. retries -= 1, retryBackoff = 0. Programming-error semantics.
+//    Don't reach for this deliberately.
+throw new RuntimeException("unexpected");
+```
+
+`jobError` accepts a `Function<Integer, Duration>` for `retryBackoff` to compute the back-off from the remaining-retries count (exponential back-off, jitter, etc.).
+
+## Configuration tree (`camunda.client.*`)
+
+```yaml
+camunda:
+  client:
+    mode: self-managed          # saas | self-managed
+    auth:
+      method: none              # none | basic | oidc
+      client-id: ...
+      client-secret: ...
+    zeebe:
+      grpc-address: http://localhost:26500
+      rest-address: http://localhost:8080
+    tenant-ids: [default]       # multi-tenancy
+    worker:
+      defaults:                 # apply to every @JobWorker unless overridden
+        timeout: 30000
+        max-jobs-active: 32
+      override:                 # per-job-type overrides
+        process-order:
+          max-jobs-active: 8
+```
+
+`camunda.client.worker.defaults.<property>` sets the floor for all workers; `camunda.client.worker.override.<jobType>.<property>` wins over both the default and the annotation value.
+
+## Profile activation
+
+Spring profiles compose naturally with `@JobWorker`:
+
+```java
+@Component
+@Profile("payments")
+class PaymentWorker {
+  @JobWorker(type = "charge-card")
+  public void charge(...) { ... }
+}
+```
+
+Workers in inactive profiles are not registered against the engine, so a single application can host a different set of workers per profile / per deployment.
+
+## Wiring to a BPMN service task
+
+The handler's `type` must match the BPMN element's `<zeebe:taskDefinition type="..."/>` exactly. Apply the task type via `camunda-bpmn`; the engine activates the matching worker once a process instance reaches the task.
+
+## Multi-tenancy
+
+`tenantIds` on the annotation restricts which tenants the worker activates jobs from. Without it, the worker picks up jobs from every tenant the client is authorised against. Combine with `camunda.client.tenant-ids` for the global default.

--- a/skills/camunda-job-workers/references/worker-sdk-typescript.md
+++ b/skills/camunda-job-workers/references/worker-sdk-typescript.md
@@ -1,0 +1,130 @@
+# TypeScript SDK — `@camunda8/orchestration-cluster-api`
+
+REST-only TypeScript client for Camunda 8.9+. Runs in Node.js and in browsers. The default TypeScript path for new applications.
+
+The full-featured **`@camunda8/sdk`** (gRPC + REST, bundles every Camunda 8 client) is still maintained but should only be reached for in three cases:
+
+- The application needs gRPC streaming for job workers (lower latency than REST polling).
+- The application targets Camunda 8.7 or earlier — the focused client is 8.9-first.
+- The application depends on earlier Operate query APIs that the focused client does not expose, or is mid-migration and cannot adopt the focused client's config shape yet.
+
+Browsers cannot use `@camunda8/sdk` (Node-only) regardless.
+
+## Install
+
+```bash
+npm install @camunda8/orchestration-cluster-api
+```
+
+```typescript
+import { CamundaRestApi } from "@camunda8/orchestration-cluster-api";
+
+const client = new CamundaRestApi({
+  baseUrl: "http://localhost:8080",
+  // OAuth or basic auth options if applicable
+});
+```
+
+The client reads the same `CAMUNDA_*` environment variables as `c8ctl` and the Java client — `CAMUNDA_OAUTH_URL`, `CAMUNDA_CLIENT_ID`, `CAMUNDA_CLIENT_SECRET`, `CAMUNDA_TOKEN_AUDIENCE` — when the constructor options are omitted.
+
+## `createJobWorker` — polling-based worker
+
+```typescript
+const worker = client.createJobWorker({
+  jobType: "process-order",
+  maxParallelJobs: 10,
+  jobTimeoutMs: 60_000,
+  pollIntervalMs: 100,
+  fetchVariables: ["orderId", "amount"],
+  jobHandler: async (job) => {
+    if (job.variables.amount > MAX) {
+      return job.error({
+        errorCode: "AMOUNT_EXCEEDED",
+        errorMessage: `Amount ${job.variables.amount} exceeds limit`,
+      });
+    }
+    try {
+      const ref = await paymentGateway.charge(job.variables.orderId, job.variables.amount);
+      return job.complete({ paymentRef: ref });
+    } catch (e) {
+      return job.fail({
+        errorMessage: "payment-gateway-timeout",
+        retries: job.retries - 1,
+        retryBackOff: 10_000,
+      });
+    }
+  },
+});
+
+// shutdown
+await worker.close();
+```
+
+Runs in Node and in browsers. Browsers cannot use `createThreadedJobWorker`.
+
+### Handler return — terminal calls
+
+A handler must return one of:
+
+- `job.complete(variables?)` — success; variables are merged into the process scope
+- `job.fail({ errorMessage, retries, retryBackOff, variables? })` — transient failure; engine redelivers after `retryBackOff` ms; reaching `retries = 0` raises an incident
+- `job.error({ errorCode, errorMessage, variables? })` — BPMN error; engine routes to the matching error boundary event; no retry
+
+Unhandled exceptions (an `await` that throws, an unhandled promise rejection) fall through to the default `fail` behaviour: `retries -= 1`, `retryBackOff = 0`. Use that as the bug-detection net, not as a control-flow signal.
+
+## `createThreadedJobWorker` — CPU-bound, Node-only
+
+When the handler is genuinely CPU-bound (PDF rendering, image transforms, large JSON shape conversion), the single-threaded event loop becomes the bottleneck. `createThreadedJobWorker` offloads handlers to a worker-thread pool.
+
+```typescript
+// main.ts
+const worker = client.createThreadedJobWorker({
+  jobType: "render-invoice",
+  maxParallelJobs: 4,
+  jobTimeoutMs: 120_000,
+  handlerModule: "./render-invoice-handler.ts",   // separate module — runs in worker thread
+  threadPoolSize: 4,
+});
+
+// render-invoice-handler.ts
+export default async function handler(job) {
+  const pdf = await renderInvoicePdf(job.variables);     // blocks CPU
+  return job.complete({ pdfDocumentId: pdf.id });
+}
+```
+
+The handler module is loaded once per worker thread and called per job. No shared state between threads — pass everything you need via `job.variables` / `job.customHeaders`.
+
+Node-only. Browsers must use `createJobWorker`.
+
+## Choosing between the two
+
+| Aspect | `createJobWorker` | `createThreadedJobWorker` |
+|---|---|---|
+| Execution | Main event loop | Worker-thread pool |
+| Best for | I/O-bound (HTTP, DB, message queues) | CPU-bound (rendering, encoding, hashing) |
+| Handler | Inline function in main module | Separate module file |
+| Platforms | Node *and* browsers | Node only |
+| Extra options | — | `handlerModule`, `threadPoolSize` |
+
+Default to `createJobWorker`. Switch to the threaded variant only after measuring an event-loop bottleneck.
+
+## When to fall back to `@camunda8/sdk`
+
+```bash
+npm install @camunda8/sdk
+```
+
+```typescript
+import { Camunda8 } from "@camunda8/sdk";
+
+const c8 = new Camunda8();
+const zbc = c8.getZeebeGrpcApiClient();             // gRPC client
+const worker = zbc.createWorker({ ... });           // legacy gRPC worker
+```
+
+Use this path only when the focused client cannot do the job (gRPC streaming, sub-8.8 target, Operate v1 queries). Document the reason in the codebase — future maintainers will otherwise migrate it back.
+
+## Wiring to BPMN
+
+`jobType` must exactly match the BPMN element's `<zeebe:taskDefinition type="..."/>`. The engine activates the worker when an instance reaches the task. Apply the task type via **camunda-bpmn**.


### PR DESCRIPTION
## Summary

- Adds **camunda-job-workers**, a workflow skill for implementing the handler side of a Camunda 8 service task. Covers Java (`camunda-client-java`), Camunda Spring Boot Starter, and TypeScript (`@camunda8/orchestration-cluster-api`); other official SDKs are out of scope for v1.
- SKILL.md walks the lifecycle (activate → handle → complete / fail / BPMN error), idempotency rules around `job.key`, the three distinct failure modes (transient back-off, modelled BPMN error, unhandled exception), and the Spring Boot 4 vs 3 starter selection on Camunda 8.9+ (`camunda-spring-boot-starter` requires Spring Boot 4; `camunda-spring-boot-3-starter` is the bridge for SB 3.5.x — OSS support to June 2026).
- Three SDK references: `worker-sdk-java.md`, `worker-sdk-spring.md`, `worker-sdk-typescript.md`. Each covers dependency, bootstrap, full parameter / annotation surface, terminal calls, and idempotency / multi-tenancy notes specific to that SDK.

All technical facts (`camunda-client-java` replacing the Zeebe Java client and being removed in 8.10, the Spring Boot 4 requirement wording, `CamundaError.bpmnError` / `CamundaError.jobError` semantics, `createThreadedJobWorker` being Node-only) were verified against `docs.camunda.io` before writing.

## Test plan

- [x] `waza check camunda-job-workers` — ready for submission (3784/5000 tokens, 9/9 spec checks, 0 hard violations, 3 reference modules — optimal)
- [x] Skills table updated in `README.md` and `AGENTS.md`
- [ ] Reverse cross-refs from peer skills (camunda-bpmn, camunda-process-mgmt, camunda-process-test) into camunda-job-workers will land in a follow-up sweep once camunda-connectors-development is in, so the two new build skills get the same treatment together