### PR TITLE
feat(camunda-connectors-development): add custom-connector skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ AI skills for Camunda 8.8+ development. Use these skills to create, deploy, and 
 | **camunda-connectors** | Configuring pre-built connectors (REST, Slack, Kafka, etc.) via element templates |
 | **camunda-development** | Choosing between OOTB connectors, custom connector templates, custom Java connectors, and job workers before writing integration code |
 | **camunda-job-workers** | Implementing custom Camunda 8 job workers in Java, Camunda Spring Boot, or TypeScript — handler code that activates jobs and signals complete / fail / BPMN error |
+| **camunda-connectors-development** | Building custom Camunda 8 connectors — JSON-only template on a protocol connector (Path A) or custom Java connector via the Connectors SDK (Path B, outbound + inbound) |
 | **camunda-process-mgmt** | Deploying resources, starting/inspecting instances, resolving incidents, completing user tasks — all via c8ctl |
 | **camunda-process-test** | Authoring and running Camunda Process Test (CPT) suites that reach 100% BPMN coverage with segment-based scenarios — `.test.json` instructions, `mvn test`, coverage report parsing |
 | **camunda-ai-agent** | Building AI agents in BPMN — AI Agent connector on an ad-hoc subprocess, tool modeling, `fromAi()` parameters, prompts, sub-flow tools |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ These skills follow the [Agent Skills](https://agentskills.io) open standard and
 | **camunda-connectors** | Browse and configure pre-built connectors via element templates |
 | **camunda-development** | Choose between OOTB connectors, custom connector templates, custom Java connectors, and job workers before writing integration code |
 | **camunda-job-workers** | Implement job workers in Java, Camunda Spring Boot, or TypeScript |
+| **camunda-connectors-development** | Build custom Camunda 8 connectors — JSON-only template on a protocol connector, or custom Java connector via the Connectors SDK (outbound + inbound) |
 | **camunda-process-mgmt** | Deploy resources, start/inspect instances, resolve incidents, complete tasks — via c8ctl |
 | **camunda-ai-agent** | Build AI agents in BPMN — AI Agent connector on an ad-hoc subprocess, tools, `fromAi()`, prompts |
 

--- a/skills/camunda-connectors-development/SKILL.md
+++ b/skills/camunda-connectors-development/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: camunda-connectors-development
+description: |
+  Use this skill to build a custom Camunda 8 connector — outbound or inbound — when the OOTB catalog doesn't cover the integration. Two paths: a JSON-only element template on a protocol connector (no Java), or a Java connector via the Connectors SDK with annotation-driven template generation.
+
+  Use for: choosing Path A (JSON-only protocol-connector template) vs Path B (custom Java); element template JSON; `OutboundConnectorProvider` + `@Operation` for outbound; `InboundConnectorExecutable` for webhook / subscription / polling inbound; SPI vs Spring-Bean registration; SaaS / SM / Hybrid hosting; element-template-generator Maven plugin.
+
+  Do not use for: applying an OOTB connector (use camunda-connectors), worker-vs-connector decisions (use camunda-development), or job-worker handlers (use camunda-job-workers).
+
+  **Build skill** — pick a path, write the template (and Java if Path B), register, host. Java 17+ on Path B.
+---
+
+# Camunda Connectors Development
+
+Build a custom Camunda 8 connector when the OOTB catalog doesn't cover the integration. Two distinct paths share the same element-template surface but differ in whether you write Java.
+
+## Prerequisites
+
+- Camunda 8.8+ cluster reachable for testing (local c8run, SaaS, or Self-Managed — see **camunda-c8ctl**)
+- Path A: Web Modeler access (Desktop or SaaS) to use *Save as Template* and edit the generated JSON
+- Path B: Java 17+, Maven 3.8+ (or Gradle equivalent), and a JVM hosting option for the resulting connector JAR
+
+## Cross-References
+
+- **camunda-development**: Use first to decide whether building a connector is the right shape at all (vs. an OOTB connector or a job worker)
+- **camunda-connectors**: Use for discovering and applying OOTB connectors — the catalog you're extending here
+- **camunda-job-workers**: Use when the integration logic belongs in application code rather than a reusable connector (Path C in the decision matrix; workers are outbound-only)
+- **camunda-bpmn**: Use for authoring the BPMN element the connector attaches to (service task for outbound, start/intermediate/boundary event or receive task for inbound)
+- **camunda-feel**: Use for the FEEL expressions that pre-fill template properties and bind input/output mappings
+- **camunda-process-test**: Use for end-to-end tests that drive a process through a custom connector
+
+## When to write a custom connector
+
+Walk **camunda-development** first. The short version of the matrix as it applies here:
+
+- **OOTB connector covers it** → use the OOTB template. Stop.
+- **Single API call over a common protocol** (REST, SOAP, GraphQL, Kafka, RabbitMQ, AWS SQS/SNS, …) and Java is acceptable → **Path A**: customise a JSON template on the existing protocol connector. No Java, no extra deployment.
+- **Multi-step orchestration, proprietary protocol, non-HTTP I/O, or significant business logic** and you have a Java stack → **Path B**: custom Java connector via the Connectors SDK.
+- **Non-Java SDK, or the logic belongs inside your existing application** → write a job worker. Workers cannot serve inbound triggers.
+
+## Outbound vs. inbound
+
+The two directions are not symmetric — an inbound connector is the only way an external event drives a process from outside the engine. Workers cannot replace inbound; the connector framework owns it.
+
+- **Outbound**: process token reaches a service task, the connector calls the external system, the result flows back as variables. Path A and Path B both support outbound.
+- **Inbound**: external system fires (HTTP request, message-queue delivery, scheduled poll). The connector correlates the event to a process — starting a new instance (start event) or continuing a waiting instance (intermediate catch, boundary event, message start, receive task). Path B only — Path A's protocol templates layer on outbound protocol connectors; the inbound webhook connector has its own OOTB template you customise directly.
+
+Three inbound flavours, each owned by a different SDK shape:
+
+- **Webhook** — the runtime exposes an HTTP endpoint per deployed process; external systems POST to it.
+- **Subscription** — the runtime opens a connection to a message broker and consumes messages (Kafka, RabbitMQ, AWS SQS, …).
+- **Polling** — the runtime periodically calls an external system on the process's behalf.
+
+See `references/connector-sdk-inbound.md` for the lifecycle (`activate` / `deactivate`) and the `correlateWithResult` contract that funnels events into the engine.
+
+## Pick a path
+
+| Path | When to pick |
+|---|---|
+| **Path A — JSON-only template on a protocol connector** ([ref](references/protocol-connector-templates.md)) | Outbound integration that is a single call over a supported protocol (REST/SOAP/GraphQL/Kafka/RabbitMQ/AWS messaging). Domain-friendly UI in Modeler without writing Java. Ships as a single JSON file in the repo. |
+| **Path B — Custom Java connector via the SDK** ([refs: [outbound](references/connector-sdk-outbound.md), [inbound](references/connector-sdk-inbound.md)]) | Anything Path A can't reach: multi-step orchestration, proprietary protocols, non-HTTP I/O, inbound triggers (webhook/subscription/polling), or logic that needs reuse across processes as a versioned artefact. Requires Java 17+ and a hosting decision. |
+
+A JSON template is also the natural way to give a job worker a polished Modeler UI when Path A's protocol overlap isn't there and Path B is too heavy — hand-author the template using `references/element-template-json.md` and bind it to the worker's `zeebe:taskDefinition type`. That's still a worker, not a connector.
+
+## Element templates — the shared surface
+
+Both paths produce an element template JSON file. The schema is the same; what differs is how the file gets written:
+
+- **Path A**: start from the protocol connector's published template (`*Save as Template*` in Web Modeler is the canonical entry point), then customise — hide infrastructure properties (URL, method, auth) with `"type": "Hidden"`, pre-fill them with FEEL, and expose only the domain-specific inputs.
+- **Path B**: annotate the connector class with `@ElementTemplate` and let the Maven plugin generate the JSON during build (`references/element-template-generator.md`), or hand-author it.
+
+`references/element-template-json.md` is the schema reference for both — property types, binding types, FEEL/constraints/condition/generatedValue features, and the template variants for each BPMN attachment.
+
+> **Field-ordering rule:** any property used in another property's FEEL `value` must appear earlier in the `properties` array. Out-of-order references silently evaluate to `null`. The same rule applies to Path A customisation and to hand-authored Path B templates.
+
+## Shared facilities (Path A and Path B)
+
+- **Secrets** — element templates and Java code resolve `{{secrets.NAME}}` placeholders at execution time. Never store secrets in the BPMN, the template defaults, or hard-coded strings. The standalone runtime reads from `SECRET_*` environment variables by default (8.9+).
+- **Intrinsic functions** — template defaults and FEEL inputs can call intrinsic functions like `getText`, `base64`, and `createLink` to transform values before the connector receives them.
+- **Camunda Documents** — connectors that produce or consume binary content (PDFs, images) handle Camunda Documents natively; workers must wire that plumbing themselves.
+- **Result variable / result expression / error expression** — both paths surface the standard *Output mapping* group (`resultVariable`, `resultExpression`) and the *Error handling* group (`errorExpression`) via element template headers. See `references/element-template-json.md` for the binding shapes.
+
+## Registration and hosting
+
+Path B has a hosting decision that Path A doesn't — the JAR has to run somewhere. Four options, covered in `references/registration-and-hosting.md`:
+
+- **SaaS managed runtime** — Camunda runs the standard connectors; custom JARs aren't supported on the managed runtime, so Path B on SaaS requires Hybrid mode (below).
+- **Self-Managed standalone** — the `camunda/connectors:X.Y.Z` Docker image with custom connector JARs mounted into its app directory.
+- **Self-Managed embedded** — Spring Boot application with the `spring-boot-starter-camunda-connectors` starter; your application hosts both connectors and your own business code.
+- **Hybrid** — the standalone runtime runs in your environment but connects to a SaaS cluster. Required when SaaS is the engine but the connector needs to run inside your perimeter (private network access, on-prem dependencies, custom JARs).
+
+**SPI vs. Spring Bean registration is independent of the hosting choice but constrains it.** SPI registration writes a `META-INF/services/...` file (default behaviour of the Maven plugin) and works in the standalone runtime. Spring Bean registration (`@Component` on the connector class) needs the embedded Spring Boot runtime and requires `<writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>` on the Maven plugin to suppress the SPI file — both mechanisms registering the same class causes duplicate discovery.
+
+## Hybrid templates
+
+When Path B will run via the standalone runtime against a SaaS cluster (Hybrid hosting), the Maven plugin's `<generateHybridTemplates>true</generateHybridTemplates>` flag emits a parallel `*-hybrid.json` template per connector. The hybrid template flips the connector's task type to a job-worker style binding the SaaS engine can pick up and route to the standalone runtime. Without it, deploying the standard template to SaaS produces a runtime that can never receive jobs.
+
+## Common pitfalls
+
+- **Inventing template IDs or property names from training memory** — verify with `c8ctl element-template search "<keyword>"` and `c8ctl element-template get-properties <id>` against the live OOTB catalog before naming any ID, group, or property in code or docs.
+- **Forgetting `<writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>` when using Spring Bean registration** — the SPI file and `@Component` register the same class twice; the runtime instantiates two instances and the second silently shadows the first.
+- **Field-ordering bugs** — a property whose FEEL `value` references a sibling declared *after* it evaluates to `null` at runtime. The Modeler doesn't flag this; the connector just gets an empty input.
+- **Skipping Hybrid templates when running standalone against SaaS** — the standard template's task type isn't routable to a standalone runtime from SaaS. Set `<generateHybridTemplates>true</generateHybridTemplates>` and deploy the `-hybrid` variant.
+- **Path A on a non-supported protocol** — Path A is only as broad as the protocol-connector catalog (REST, SOAP, GraphQL, Kafka, RabbitMQ, AWS messaging). A "custom binary protocol over TCP" template has nothing to layer on; go to Path B.
+- **Treating the inbound webhook as a job worker** — inbound connectors are activated at process-definition deploy and deactivated when the deployment is removed; there is no per-instance job to poll for. The lifecycle is `activate(InboundConnectorContext)` / `deactivate()`, not handler-per-job.
+
+## References
+
+For detail, read from `references/`:
+
+- [protocol-connector-templates.md](references/protocol-connector-templates.md) — Path A walkthrough: *Save as Template*, hiding URL/method/auth, FEEL pre-fill, custom groups, the SWAPI-style worked example, and a brief link to template-generator tools
+- [connector-sdk-outbound.md](references/connector-sdk-outbound.md) — `OutboundConnectorProvider` + `@Operation` (modern), `OutboundConnectorFunction` (legacy), `@Variable` / `@Header`, `ConnectorException`, Jakarta Validation
+- [connector-sdk-inbound.md](references/connector-sdk-inbound.md) — `InboundConnectorExecutable`, three flavours, lifecycle, `correlateWithResult` / `CorrelationResult`
+- [element-template-json.md](references/element-template-json.md) — schema reference: top-level fields, property types, binding types, property features, template variants per BPMN attachment
+- [element-template-generator.md](references/element-template-generator.md) — Maven plugin configuration, `@ElementTemplate` annotation, `generateHybridTemplates`, `versionHistoryEnabled`, `writeMetaInfFileGeneration`
+- [registration-and-hosting.md](references/registration-and-hosting.md) — SPI vs Spring Bean registration; SaaS / SM standalone / SM embedded / Hybrid hosting models

--- a/skills/camunda-connectors-development/SKILL.md
+++ b/skills/camunda-connectors-development/SKILL.md
@@ -7,7 +7,7 @@ description: |
 
   Do not use for: applying an OOTB connector (use camunda-connectors), worker-vs-connector decisions (use camunda-development), or job-worker handlers (use camunda-job-workers).
 
-  **Build skill** — pick a path, write the template (and Java if Path B), register, host. Java 17+ on Path B.
+  **Workflow skill** — pick a path, write the template (and Java if Path B), register, host. Java 17+ on Path B.
 ---
 
 # Camunda Connectors Development

--- a/skills/camunda-connectors-development/SKILL.md
+++ b/skills/camunda-connectors-development/SKILL.md
@@ -108,7 +108,7 @@ When Path B will run via the standalone runtime against a SaaS cluster (Hybrid h
 
 For detail, read from `references/`:
 
-- [protocol-connector-templates.md](references/protocol-connector-templates.md) — Path A walkthrough: *Save as Template*, hiding URL/method/auth, FEEL pre-fill, custom groups, the SWAPI-style worked example, and a brief link to template-generator tools
+- [protocol-connector-templates.md](references/protocol-connector-templates.md) — Path A walkthrough: *Save as Template*, hiding URL/method/auth, FEEL pre-fill, custom groups, a REST Countries worked example, and a brief link to template-generator tools
 - [connector-sdk-outbound.md](references/connector-sdk-outbound.md) — `OutboundConnectorProvider` + `@Operation` (modern), `OutboundConnectorFunction` (legacy), `@Variable` / `@Header`, `ConnectorException`, Jakarta Validation
 - [connector-sdk-inbound.md](references/connector-sdk-inbound.md) — `InboundConnectorExecutable`, three flavours, lifecycle, `correlateWithResult` / `CorrelationResult`
 - [element-template-json.md](references/element-template-json.md) — schema reference: top-level fields, property types, binding types, property features, template variants per BPMN attachment

--- a/skills/camunda-connectors-development/references/connector-sdk-inbound.md
+++ b/skills/camunda-connectors-development/references/connector-sdk-inbound.md
@@ -50,19 +50,19 @@ Every inbound connector implements this interface. The runtime calls `activate` 
 
 ```java
 @InboundConnector(
-    name = "Star Wars updates",
-    type = "io.example.connector.swapi.updates:1"
+    name = "Currency rate watcher",
+    type = "io.example.connector.fxrates:1"
 )
 @ElementTemplate(
-    id = "io.example.connector.swapi.updates.v1",
-    name = "Star Wars updates",
+    id = "io.example.connector.fxrates.v1",
+    name = "Currency rate watcher",
     version = 1,
     inbound = @ElementTemplate.ConnectorElementType(
         appliesTo = {"bpmn:StartEvent"},
         elementType = "bpmn:StartEvent"
     )
 )
-public class SwapiUpdatesExecutable implements InboundConnectorExecutable {
+public class FxRateWatcherExecutable implements InboundConnectorExecutable {
 
   private ScheduledExecutorService scheduler;
   private InboundConnectorContext context;
@@ -84,15 +84,15 @@ public class SwapiUpdatesExecutable implements InboundConnectorExecutable {
   }
 
   private void poll() {
-    Person person = ...; // poll the external system
-    var result = context.correlateWithResult(person);
+    FxRate rate = ...; // fetch the latest rate from the external provider
+    var result = context.correlateWithResult(rate);
     if (result instanceof CorrelationResult.Failure failure) {
       context.log(Activity.level(Severity.WARNING)
           .tag("correlation").message("failed: " + failure));
     }
   }
 
-  public record Config(int pollIntervalSeconds, String resource) {}
+  public record Config(int pollIntervalSeconds, String baseCurrency, String quoteCurrency) {}
 }
 ```
 
@@ -185,7 +185,7 @@ Inbound templates differ from outbound on two key bindings:
 ```json
 {
   "type": "Hidden",
-  "value": "io.example.connector.swapi.updates:1",
+  "value": "io.example.connector.fxrates:1",
   "binding": { "type": "zeebe:property", "name": "inbound.type" }
 },
 {

--- a/skills/camunda-connectors-development/references/connector-sdk-inbound.md
+++ b/skills/camunda-connectors-development/references/connector-sdk-inbound.md
@@ -1,0 +1,224 @@
+# Connectors SDK — inbound (Path B)
+
+Inbound connectors push external events *into* the process engine. Three flavours by trigger source: webhook (HTTP), subscription (message queue), polling (periodic call). All share the `InboundConnectorExecutable` interface and the same `correlateWithResult` contract.
+
+Inbound is connector-only — workers cannot serve inbound. Java 17+.
+
+## Element-attachment variants
+
+An inbound connector ships as a *family* of templates, one per BPMN element the connector can attach to. The connector class is the same; the templates differ only in element-type metadata and binding shape.
+
+| Variant | BPMN element | Effect |
+|---|---|---|
+| **Start event** | `bpmn:StartEvent` (none-start) | Creates a new process instance per event |
+| **Message start event** | `bpmn:StartEvent` (with `bpmn:MessageEventDefinition`) | Creates a new instance, deduplicates by message ID |
+| **Intermediate catch event** | `bpmn:IntermediateCatchEvent` | Correlates to a waiting instance via correlation key |
+| **Boundary event** | `bpmn:BoundaryEvent` | Interrupting / non-interrupting event attached to an activity |
+| **Receive task** | `bpmn:ReceiveTask` | Correlates to a waiting receive task via correlation key |
+
+The `appliesTo` and `elementType` fields in each template select which variant Modeler offers. A polling inbound connector that supports both *intermediate catch* and *receive task* ships two templates with different IDs (e.g. `*.intermediate.v1` and `*.receive.v1`) pointing at the same Java class.
+
+## Dependencies
+
+```xml
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-core</artifactId>
+  <version>${version.connectors}</version>
+</dependency>
+
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>element-template-generator-annotations</artifactId>
+  <version>${version.connectors}</version>
+</dependency>
+```
+
+For webhook inbound connectors that ride on the built-in webhook framework, add:
+
+```xml
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-webhook</artifactId>
+  <version>${version.connectors}</version>
+</dependency>
+```
+
+## `InboundConnectorExecutable`
+
+Every inbound connector implements this interface. The runtime calls `activate` once per process-definition deployment that uses the connector and `deactivate` when the deployment is removed or the runtime shuts down. Both methods may be called from arbitrary threads.
+
+```java
+@InboundConnector(
+    name = "Star Wars updates",
+    type = "io.example.connector.swapi.updates:1"
+)
+@ElementTemplate(
+    id = "io.example.connector.swapi.updates.v1",
+    name = "Star Wars updates",
+    version = 1,
+    inbound = @ElementTemplate.ConnectorElementType(
+        appliesTo = {"bpmn:StartEvent"},
+        elementType = "bpmn:StartEvent"
+    )
+)
+public class SwapiUpdatesExecutable implements InboundConnectorExecutable {
+
+  private ScheduledExecutorService scheduler;
+  private InboundConnectorContext context;
+
+  @Override
+  public void activate(InboundConnectorContext context) {
+    this.context = context;
+    var config = context.bindProperties(Config.class);
+    scheduler = Executors.newSingleThreadScheduledExecutor();
+    scheduler.scheduleAtFixedRate(this::poll, 0, config.pollIntervalSeconds(), TimeUnit.SECONDS);
+  }
+
+  @Override
+  public void deactivate() {
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+      scheduler = null;
+    }
+  }
+
+  private void poll() {
+    Person person = ...; // poll the external system
+    var result = context.correlateWithResult(person);
+    if (result instanceof CorrelationResult.Failure failure) {
+      context.log(Activity.level(Severity.WARNING)
+          .tag("correlation").message("failed: " + failure));
+    }
+  }
+
+  public record Config(int pollIntervalSeconds, String resource) {}
+}
+```
+
+### Lifecycle
+
+- **`activate(InboundConnectorContext)`** — runtime invokes after the process definition referencing the connector is deployed. The connector should start its subscription (webhook listener registration, message-broker consumer, polling thread). Throw to signal activation failure; the runtime logs and the connector stays inactive.
+- **`deactivate()`** — runtime invokes when the deployment is removed, the runtime stops, or the connector is re-activated with new configuration. Release all resources. The runtime may call `activate` again immediately (config rotation), so deactivation should leave nothing behind that prevents re-startup.
+
+### `InboundConnectorContext`
+
+Threading-safe helper the connector receives in `activate`. Common surface:
+
+- `bindProperties(Class<T>)` — deserialise the inbound element template properties into a record/POJO. Jakarta Validation applies.
+- `correlateWithResult(Object payload)` — push an event to the engine. Returns a `CorrelationResult` describing what the engine did.
+- `correlate(Object payload)` — fire-and-forget variant where you don't need the result.
+- `cancel(Throwable)` — signal that the connector has hit an unrecoverable error; the runtime deactivates it.
+- `log(Activity)` — emit a structured log line surfaced in Operate's connector activity view.
+- `getDefinition()` — metadata about the deployment that activated the connector (process definition key, element ID, tenant).
+
+## `correlateWithResult` and `CorrelationResult`
+
+```java
+CorrelationResult result = context.correlateWithResult(event);
+
+switch (result) {
+  case CorrelationResult.Success success -> {
+    // engine accepted the event; success.activatedElement() tells you which element
+  }
+  case CorrelationResult.Failure failure -> {
+    switch (failure.handlingStrategy()) {
+      case Pause pause -> /* runtime will retry after pause.duration() */ ;
+      case ForwardErrorToUpstream f -> /* propagate back to the source system */ ;
+      case Discard d -> /* event was malformed; drop it */ ;
+    }
+  }
+}
+```
+
+The handling strategy is determined by the kind of failure (no waiting instance, correlation key mismatch, activation condition false). Webhook flavours typically respond with the strategy's HTTP semantics; polling and subscription flavours respect it as part of the consumer loop (pause = back off, forward = ack with error, discard = ack and move on).
+
+## The three flavours
+
+### Webhook
+
+The runtime exposes an HTTP endpoint per deployed process definition. External systems POST to it; the connector parses the request, validates the signature/auth, and `correlateWithResult`s the payload.
+
+The `connector-webhook` library provides a webhook executable scaffold — your connector extends or composes it rather than implementing the HTTP listening loop yourself. The element template carries the path segment (typically a deployment-scoped suffix to a runtime base URL), the authentication scheme (HMAC, JWT, none), and the response shape.
+
+Inbound webhook templates are the *only* shape where the URL is published by the runtime, not configured by the modeller — the runtime mints the path from deployment metadata.
+
+### Subscription
+
+The runtime opens a connection to a message broker on `activate` and consumes messages until `deactivate`. Examples: Kafka consumer, RabbitMQ subscriber, AWS SQS receiver.
+
+```java
+@Override
+public void activate(InboundConnectorContext context) {
+  var config = context.bindProperties(KafkaConfig.class);
+  consumer = new KafkaConsumer<>(toKafkaProps(config));
+  consumer.subscribe(List.of(config.topic()));
+  pollThread = Thread.ofVirtual().start(this::consumeLoop);
+}
+
+private void consumeLoop() {
+  while (!Thread.currentThread().isInterrupted()) {
+    var records = consumer.poll(Duration.ofSeconds(1));
+    for (var record : records) {
+      var result = context.correlateWithResult(record.value());
+      handleResult(record, result);
+    }
+  }
+}
+```
+
+Acknowledgement strategy (commit on every event vs. on success vs. on batch) is exposed via the template's *Subscription* group when supported by the connector — see the `<features><ACKNOWLEDGEMENT_STRATEGY_SELECTION>` Maven plugin flag for templates that should surface this control.
+
+### Polling
+
+The runtime schedules the connector to call an external system on a cadence. Use a `ScheduledExecutorService`, `Thread.ofVirtual().scheduleAtFixedRate` (8.10+), or a similar scheduler. Each tick fetches, transforms, and `correlateWithResult`s.
+
+Polling connectors typically also offer deduplication via `INBOUND_DEDUPLICATION` (Maven plugin feature flag) — the runtime tracks payload IDs and suppresses duplicate correlations.
+
+## Inbound element template — binding differences
+
+Inbound templates differ from outbound on two key bindings:
+
+- **Connector type binding**: `zeebe:property` with `name: "inbound.type"` instead of `zeebe:taskDefinition`.
+- **Property values**: typically bound via `zeebe:property` with `name: "<key>"` instead of `zeebe:input`.
+
+```json
+{
+  "type": "Hidden",
+  "value": "io.example.connector.swapi.updates:1",
+  "binding": { "type": "zeebe:property", "name": "inbound.type" }
+},
+{
+  "id": "pollIntervalSeconds",
+  "label": "Poll interval (seconds)",
+  "type": "String",
+  "feel": "optional",
+  "binding": { "type": "zeebe:property", "name": "pollIntervalSeconds" }
+}
+```
+
+For message-correlated variants (intermediate catch, receive task, message start), the template also needs message-correlation properties:
+
+- `bpmn:Message#property` for the message name
+- `bpmn:Message#zeebe:subscription#property` for the correlation-key expression
+
+Schema-level detail is in `element-template-json.md`.
+
+## SPI registration
+
+```
+META-INF/services/io.camunda.connector.api.inbound.InboundConnectorExecutable
+```
+
+One class name per line. The Maven plugin writes this file automatically when `writeMetaInfFileGeneration` is left at its default (`true`).
+
+## Hybrid hosting and inbound
+
+When the runtime hosting the inbound connector runs *outside* the Camunda cluster (Hybrid mode — standalone runtime against SaaS), the external system pointing at the webhook must reach the standalone runtime's network address, not the SaaS cluster's. Plan the public DNS / firewall accordingly. Subscription and polling flavours don't have this caveat — the runtime initiates the connections outbound.
+
+## Where to look next
+
+- Outbound counterpart (`OutboundConnectorProvider`, `@Operation`): `connector-sdk-outbound.md`
+- Element template schema for inbound variants: `element-template-json.md`
+- Auto-generating inbound templates from `@ElementTemplate`: `element-template-generator.md`
+- Picking SPI vs Spring Bean registration and a hosting model: `registration-and-hosting.md`

--- a/skills/camunda-connectors-development/references/connector-sdk-outbound.md
+++ b/skills/camunda-connectors-development/references/connector-sdk-outbound.md
@@ -34,43 +34,43 @@ One class can declare multiple operations. The connector type identifies the cla
 
 ```java
 @OutboundConnector(
-    name = "Star Wars API",
-    type = "io.example.connector.swapi:1",
-    inputVariables = { "resource", "index" }
+    name = "Country lookup",
+    type = "io.example.connector.countries:1",
+    inputVariables = { "lookupBy", "query" }
 )
 @ElementTemplate(
-    id = "io.example.connector.swapi.v1",
-    name = "Star Wars API",
+    id = "io.example.connector.countries.v1",
+    name = "Country lookup",
     version = 1,
-    documentationRef = "https://swapi.dev",
-    icon = "swapi.svg"
+    documentationRef = "https://restcountries.com",
+    icon = "countries.svg"
 )
-public class SwapiConnector implements OutboundConnectorProvider {
+public class CountryLookupConnector implements OutboundConnectorProvider {
 
   private final HttpClient http = HttpClient.newHttpClient();
 
   @Operation(id = "lookup")
-  public Person lookup(
-      @Variable @NotEmpty String resource,
-      @Variable @NotEmpty String index
+  public List<Country> lookup(
+      @Variable @NotEmpty String lookupBy,
+      @Variable @NotEmpty String query
   ) throws ConnectorException {
-    var uri = URI.create("https://swapi.dev/api/" + resource + "/" + index);
+    var uri = URI.create("https://restcountries.com/v3.1/" + lookupBy + "/" + query);
     var request = HttpRequest.newBuilder(uri).GET().build();
     try {
       var response = http.send(request, BodyHandlers.ofString());
       if (response.statusCode() == 404) {
-        throw new ConnectorException("NOT_FOUND", "No " + resource + "/" + index);
+        throw new ConnectorException("NOT_FOUND", "No country matched " + lookupBy + "=" + query);
       }
       if (response.statusCode() >= 400) {
-        throw new ConnectorException("SWAPI_ERROR", "Status " + response.statusCode());
+        throw new ConnectorException("UPSTREAM_ERROR", "Status " + response.statusCode());
       }
-      return new ObjectMapper().readValue(response.body(), Person.class);
+      return new ObjectMapper().readValue(response.body(), new TypeReference<>() {});
     } catch (IOException | InterruptedException e) {
-      throw new ConnectorException("SWAPI_UNREACHABLE", e.getMessage(), e);
+      throw new ConnectorException("UPSTREAM_UNREACHABLE", e.getMessage(), e);
     }
   }
 
-  public record Person(String name, String birthYear, String gender) {}
+  public record Country(String name, String capital, List<String> currencies) {}
 }
 ```
 
@@ -99,8 +99,8 @@ Validation failures throw before the method body runs, surfacing as a `Connector
 `ConnectorException(code, message)` is the typed channel that the element template's `errorExpression` taps into. Users wire `errorExpression` to map specific codes to BPMN errors:
 
 ```feel
-if error.code = "NOT_FOUND"   then bpmnError("NOT_FOUND", error.message) else
-if error.code = "SWAPI_ERROR" then bpmnError("UPSTREAM",  error.message) else
+if error.code = "NOT_FOUND"       then bpmnError("NOT_FOUND", error.message) else
+if error.code = "UPSTREAM_ERROR"  then bpmnError("UPSTREAM",  error.message) else
 null
 ```
 
@@ -112,22 +112,22 @@ Older connectors and the historical `connector-template-outbound` GitHub-templat
 
 ```java
 @OutboundConnector(
-    name = "Star Wars API",
-    type = "io.example.connector.swapi:1",
-    inputVariables = { "resource", "index" }
+    name = "Country lookup",
+    type = "io.example.connector.countries:1",
+    inputVariables = { "lookupBy", "query" }
 )
-@ElementTemplate(id = "io.example.connector.swapi.v1", name = "Star Wars API", version = 1)
-public class SwapiFunction implements OutboundConnectorFunction {
+@ElementTemplate(id = "io.example.connector.countries.v1", name = "Country lookup", version = 1)
+public class CountryLookupFunction implements OutboundConnectorFunction {
 
   @Override
   public Object execute(OutboundConnectorContext context) throws Exception {
-    var request = context.bindVariables(SwapiRequest.class);
-    var uri = URI.create("https://swapi.dev/api/" + request.resource() + "/" + request.index());
+    var request = context.bindVariables(LookupRequest.class);
+    var uri = URI.create("https://restcountries.com/v3.1/" + request.lookupBy() + "/" + request.query());
     // ...
-    return new Person(...);
+    return new Country(...);
   }
 
-  public record SwapiRequest(@NotEmpty String resource, @NotEmpty String index) {}
+  public record LookupRequest(@NotEmpty String lookupBy, @NotEmpty String query) {}
 }
 ```
 

--- a/skills/camunda-connectors-development/references/connector-sdk-outbound.md
+++ b/skills/camunda-connectors-development/references/connector-sdk-outbound.md
@@ -1,0 +1,186 @@
+# Connectors SDK — outbound (Path B)
+
+Build a custom outbound connector in Java. The SDK provides input binding, secrets resolution, output mapping, and BPMN-error semantics; the auto-generated element template gives users a Modeler UI. Java 17+.
+
+## Dependencies
+
+```xml
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-core</artifactId>
+  <version>${version.connectors}</version>
+</dependency>
+
+<!-- enables Jakarta Validation on @Variable / property bindings -->
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-validation</artifactId>
+  <version>${version.connectors}</version>
+</dependency>
+
+<!-- annotations for @ElementTemplate-driven template generation -->
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>element-template-generator-annotations</artifactId>
+  <version>${version.connectors}</version>
+</dependency>
+```
+
+`${version.connectors}` should match the runtime image / starter you intend to deploy against. Pin it explicitly — connectors and the engine version together to support new binding types and template features.
+
+## Modern pattern — `OutboundConnectorProvider` + `@Operation`
+
+One class can declare multiple operations. The connector type identifies the class; the operation identifies which method to call. Element template generation produces one template per `@Operation`.
+
+```java
+@OutboundConnector(
+    name = "Star Wars API",
+    type = "io.example.connector.swapi:1",
+    inputVariables = { "resource", "index" }
+)
+@ElementTemplate(
+    id = "io.example.connector.swapi.v1",
+    name = "Star Wars API",
+    version = 1,
+    documentationRef = "https://swapi.dev",
+    icon = "swapi.svg"
+)
+public class SwapiConnector implements OutboundConnectorProvider {
+
+  private final HttpClient http = HttpClient.newHttpClient();
+
+  @Operation(id = "lookup")
+  public Person lookup(
+      @Variable @NotEmpty String resource,
+      @Variable @NotEmpty String index
+  ) throws ConnectorException {
+    var uri = URI.create("https://swapi.dev/api/" + resource + "/" + index);
+    var request = HttpRequest.newBuilder(uri).GET().build();
+    try {
+      var response = http.send(request, BodyHandlers.ofString());
+      if (response.statusCode() == 404) {
+        throw new ConnectorException("NOT_FOUND", "No " + resource + "/" + index);
+      }
+      if (response.statusCode() >= 400) {
+        throw new ConnectorException("SWAPI_ERROR", "Status " + response.statusCode());
+      }
+      return new ObjectMapper().readValue(response.body(), Person.class);
+    } catch (IOException | InterruptedException e) {
+      throw new ConnectorException("SWAPI_UNREACHABLE", e.getMessage(), e);
+    }
+  }
+
+  public record Person(String name, String birthYear, String gender) {}
+}
+```
+
+The return value is serialised and merged into the process scope per the element template's *Output mapping* group.
+
+### `@Variable` and `@Header`
+
+- **`@Variable`** binds a process variable into the parameter. Add `@Variable(name = "...")` if the parameter name and the variable name differ. Complex types (records, POJOs) auto-bind by property name and accept Jakarta Validation annotations on their fields.
+- **`@Header`** binds a static task header declared via `zeebe:taskHeader` (typically pre-filled by the template — protocol selection, output mode, retry policy).
+
+```java
+@Operation(id = "send")
+public SendResult send(
+    @Variable @Valid Message message,
+    @Variable @NotEmpty String channelId,
+    @Header("priority") String priority
+) { ... }
+
+public record Message(@NotBlank String subject, @NotBlank String body) {}
+```
+
+Validation failures throw before the method body runs, surfacing as a `ConnectorException` with code `VALIDATION_FAILED`.
+
+### `ConnectorException`
+
+`ConnectorException(code, message)` is the typed channel that the element template's `errorExpression` taps into. Users wire `errorExpression` to map specific codes to BPMN errors:
+
+```feel
+if error.code = "NOT_FOUND"   then bpmnError("NOT_FOUND", error.message) else
+if error.code = "SWAPI_ERROR" then bpmnError("UPSTREAM",  error.message) else
+null
+```
+
+Returning `null` from `errorExpression` lets the engine fall through to incident-raising. Codes used should be stable — they're part of the connector's contract with process modellers.
+
+## Legacy pattern — `OutboundConnectorFunction`
+
+Older connectors and the historical `connector-template-outbound` GitHub-template scaffolds use a single-method interface. Still supported; prefer the modern pattern for new code, but recognise this shape in brownfield repos.
+
+```java
+@OutboundConnector(
+    name = "Star Wars API",
+    type = "io.example.connector.swapi:1",
+    inputVariables = { "resource", "index" }
+)
+@ElementTemplate(id = "io.example.connector.swapi.v1", name = "Star Wars API", version = 1)
+public class SwapiFunction implements OutboundConnectorFunction {
+
+  @Override
+  public Object execute(OutboundConnectorContext context) throws Exception {
+    var request = context.bindVariables(SwapiRequest.class);
+    var uri = URI.create("https://swapi.dev/api/" + request.resource() + "/" + request.index());
+    // ...
+    return new Person(...);
+  }
+
+  public record SwapiRequest(@NotEmpty String resource, @NotEmpty String index) {}
+}
+```
+
+`context.bindVariables(...)` deserialises the variable map into a record/POJO and applies Jakarta Validation. `context.getJobContext().getCustomHeaders()` reads `zeebe:taskHeader` values.
+
+The legacy pattern hosts only one operation per class. Multi-operation connectors must split classes (or migrate to `OutboundConnectorProvider`).
+
+### SPI file — legacy vs. modern
+
+The SPI file path differs between the two patterns:
+
+- Modern: `META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorProvider`
+- Legacy: `META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorFunction`
+
+Each file lists fully-qualified class names, one per line. The `element-template-generator-maven-plugin` writes the file automatically; set `<writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>` when using Spring Bean registration instead (see `registration-and-hosting.md`).
+
+## Secrets
+
+The SDK resolves `{{secrets.NAME}}` placeholders during `bindVariables` / parameter binding — the connector code never sees raw placeholder strings. The standalone runtime (8.9+) reads secret values from environment variables prefixed `SECRET_` (configurable via `CAMUNDA_CONNECTOR_SECRET_PROVIDER_*` env vars). Document secret names in the connector's README so operators know what to set.
+
+```java
+@Operation(id = "send")
+public SendResult send(@Variable @NotEmpty String apiKey, ...) {
+  // apiKey holds the resolved secret value, never "{{secrets.MY_KEY}}"
+}
+```
+
+## Camunda Documents
+
+For payloads that produce or consume binary content, accept / return `CamundaDocument` (or its reference type, depending on SDK version) instead of byte arrays. The runtime handles upload, download, and reference passing. Plain Java byte arrays force the operator to pre-stage data via custom variables — a much rougher seam.
+
+## Jakarta Validation
+
+Connector parameter binding flows through Hibernate Validator (via the optional `connector-validation` dependency). Standard annotations:
+
+- `@NotNull`, `@NotEmpty`, `@NotBlank` — field presence
+- `@Pattern(regexp = "...")` — string shape
+- `@Min`, `@Max`, `@Size` — numeric / collection bounds
+- `@Valid` — recurse into nested records / POJOs
+
+Combine on records to validate the entire input atomically:
+
+```java
+public record SendRequest(
+    @NotBlank @Email String recipient,
+    @NotBlank @Size(max = 256) String subject,
+    @NotNull @Valid Body body
+) {}
+```
+
+## Where to look next
+
+- Element template generation from `@ElementTemplate`: `element-template-generator.md`
+- Element template schema reference (property types, bindings): `element-template-json.md`
+- Inbound counterpart (`InboundConnectorExecutable`): `connector-sdk-inbound.md`
+- Registering the connector (SPI vs Spring Bean) and choosing a hosting model: `registration-and-hosting.md`

--- a/skills/camunda-connectors-development/references/element-template-generator.md
+++ b/skills/camunda-connectors-development/references/element-template-generator.md
@@ -19,22 +19,22 @@ Provides `@ElementTemplate`, `@PropertyGroup`, `@TemplateProperty`, and the supp
 ## `@ElementTemplate` on the connector class
 
 ```java
-@OutboundConnector(name = "Star Wars API", type = "io.example.connector.swapi:1",
-    inputVariables = { "resource", "index" })
+@OutboundConnector(name = "Country lookup", type = "io.example.connector.countries:1",
+    inputVariables = { "lookupBy", "query" })
 @ElementTemplate(
-    id = "io.example.connector.swapi.v1",
-    name = "Star Wars API",
+    id = "io.example.connector.countries.v1",
+    name = "Country lookup",
     version = 1,
-    description = "Look up Star Wars resources via the SWAPI REST API",
-    documentationRef = "https://swapi.dev",
-    icon = "swapi.svg",
-    inputDataClass = SwapiRequest.class,
+    description = "Look up country reference data via the REST Countries API",
+    documentationRef = "https://restcountries.com",
+    icon = "countries.svg",
+    inputDataClass = LookupRequest.class,
     propertyGroups = {
-      @PropertyGroup(id = "endpoint", label = "Star Wars resource"),
-      @PropertyGroup(id = "output",   label = "Output mapping")
+      @PropertyGroup(id = "lookup", label = "Country lookup"),
+      @PropertyGroup(id = "output", label = "Output mapping")
     }
 )
-public class SwapiConnector implements OutboundConnectorProvider { ... }
+public class CountryLookupConnector implements OutboundConnectorProvider { ... }
 ```
 
 The `inputDataClass` points to the record/POJO whose `@TemplateProperty`-annotated fields drive the template's `properties` array. Inbound connectors add an `inbound = @ElementTemplate.ConnectorElementType(...)` clause per element variant; multi-element connectors declare one variant per BPMN attachment.
@@ -42,23 +42,24 @@ The `inputDataClass` points to the record/POJO whose `@TemplateProperty`-annotat
 `@TemplateProperty` on the input class:
 
 ```java
-public record SwapiRequest(
+public record LookupRequest(
     @TemplateProperty(
-        id = "resource",
-        label = "Resource",
-        group = "endpoint",
+        id = "lookupBy",
+        label = "Lookup by",
+        group = "lookup",
         type = TemplateProperty.PropertyType.Dropdown,
         choices = {
-            @TemplateProperty.PropertyChoice(label = "People",    value = "people"),
-            @TemplateProperty.PropertyChoice(label = "Planets",   value = "planets"),
-            @TemplateProperty.PropertyChoice(label = "Starships", value = "starships")
+            @TemplateProperty.PropertyChoice(label = "Name",            value = "name"),
+            @TemplateProperty.PropertyChoice(label = "Capital",         value = "capital"),
+            @TemplateProperty.PropertyChoice(label = "ISO 3166-1 code", value = "alpha"),
+            @TemplateProperty.PropertyChoice(label = "Currency",        value = "currency")
         }
     )
-    @NotEmpty String resource,
+    @NotEmpty String lookupBy,
 
-    @TemplateProperty(id = "index", label = "Resource ID", group = "endpoint",
+    @TemplateProperty(id = "query", label = "Query value", group = "lookup",
                       feel = TemplateProperty.FeelMode.optional)
-    @NotEmpty String index
+    @NotEmpty String query
 ) {}
 ```
 
@@ -74,11 +75,11 @@ The annotation surface mirrors the element template JSON schema — see `element
   <configuration>
     <connectors>
       <connector>
-        <connectorClass>io.example.connector.swapi.SwapiConnector</connectorClass>
+        <connectorClass>io.example.connector.countries.CountryLookupConnector</connectorClass>
         <files>
           <file>
-            <templateId>io.example.connector.swapi.v1</templateId>
-            <templateFileName>swapi-outbound-connector.json</templateFileName>
+            <templateId>io.example.connector.countries.v1</templateId>
+            <templateFileName>countries-outbound-connector.json</templateFileName>
           </file>
         </files>
         <generateHybridTemplates>true</generateHybridTemplates>
@@ -96,25 +97,25 @@ Run `mvn package` (or `mvn process-classes` to skip tests) and the templates lan
 ```xml
 <connectors>
   <connector>
-    <connectorClass>io.example.connector.swapi.SwapiConnector</connectorClass>
+    <connectorClass>io.example.connector.countries.CountryLookupConnector</connectorClass>
     <files>
       <file>
-        <templateId>io.example.connector.swapi.v1</templateId>
-        <templateFileName>swapi-outbound-connector.json</templateFileName>
+        <templateId>io.example.connector.countries.v1</templateId>
+        <templateFileName>countries-outbound-connector.json</templateFileName>
       </file>
     </files>
     <generateHybridTemplates>true</generateHybridTemplates>
   </connector>
   <connector>
-    <connectorClass>io.example.connector.swapi.SwapiInboundExecutable</connectorClass>
+    <connectorClass>io.example.connector.fxrates.FxRateWatcherExecutable</connectorClass>
     <files>
       <file>
-        <templateId>io.example.connector.swapi.inbound.intermediate.v1</templateId>
-        <templateFileName>swapi-inbound-intermediate.json</templateFileName>
+        <templateId>io.example.connector.fxrates.intermediate.v1</templateId>
+        <templateFileName>fxrates-inbound-intermediate.json</templateFileName>
       </file>
       <file>
-        <templateId>io.example.connector.swapi.inbound.receive.v1</templateId>
-        <templateFileName>swapi-inbound-receive.json</templateFileName>
+        <templateId>io.example.connector.fxrates.receive.v1</templateId>
+        <templateFileName>fxrates-inbound-receive.json</templateFileName>
       </file>
     </files>
     <generateHybridTemplates>false</generateHybridTemplates>
@@ -136,7 +137,7 @@ One `<connector>` per Java class. Multiple `<file>` entries on the same connecto
 
 ### Top-level
 
-- **`<versionHistoryEnabled>`** — `true` writes a versioned copy of each template alongside the current one (e.g. `swapi-outbound-connector.json` plus `swapi-outbound-connector-v1.json`). Lets older process versions stay pinned to their template version after the connector ships a new one.
+- **`<versionHistoryEnabled>`** — `true` writes a versioned copy of each template alongside the current one (e.g. `countries-outbound-connector.json` plus `countries-outbound-connector-v1.json`). Lets older process versions stay pinned to their template version after the connector ships a new one.
 - **`<includeDependencies>`** — `groupId:artifactId` pairs whose classpath should be scanned for additional `@ElementTemplate` classes. Used when the connector inherits template structure from a base module (e.g. webhook connectors riding on `connector-webhook`).
 
 ## Hybrid templates
@@ -170,9 +171,9 @@ target/
 ├── classes/
 │   └── META-INF/services/...           (SPI files, if writeMetaInfFileGeneration=true)
 └── generated-resources/element-templates/
-    ├── swapi-outbound-connector.json
-    ├── swapi-outbound-connector-hybrid.json   (if generateHybridTemplates=true)
-    └── swapi-outbound-connector-v1.json       (if versionHistoryEnabled=true)
+    ├── countries-outbound-connector.json
+    ├── countries-outbound-connector-hybrid.json   (if generateHybridTemplates=true)
+    └── countries-outbound-connector-v1.json       (if versionHistoryEnabled=true)
 ```
 
 Commit the generated templates to your repo (or copy them into Modeler's resources directory) so process developers can pick them up without running the build first. Treat them as build artefacts checked in for convenience — re-run the plugin and re-commit on every annotation change.

--- a/skills/camunda-connectors-development/references/element-template-generator.md
+++ b/skills/camunda-connectors-development/references/element-template-generator.md
@@ -1,0 +1,185 @@
+# Element-template generator (Maven plugin)
+
+The `element-template-generator-maven-plugin` reads `@ElementTemplate`-annotated classes and emits one or more element template JSON files at build time. Saves writing the template by hand and keeps the Java code and the JSON in lock-step.
+
+Path B only. Path A templates are hand-edited JSON.
+
+## Annotation dependency
+
+```xml
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>element-template-generator-annotations</artifactId>
+  <version>${version.connectors}</version>
+</dependency>
+```
+
+Provides `@ElementTemplate`, `@PropertyGroup`, `@TemplateProperty`, and the supporting types referenced from the connector class.
+
+## `@ElementTemplate` on the connector class
+
+```java
+@OutboundConnector(name = "Star Wars API", type = "io.example.connector.swapi:1",
+    inputVariables = { "resource", "index" })
+@ElementTemplate(
+    id = "io.example.connector.swapi.v1",
+    name = "Star Wars API",
+    version = 1,
+    description = "Look up Star Wars resources via the SWAPI REST API",
+    documentationRef = "https://swapi.dev",
+    icon = "swapi.svg",
+    inputDataClass = SwapiRequest.class,
+    propertyGroups = {
+      @PropertyGroup(id = "endpoint", label = "Star Wars resource"),
+      @PropertyGroup(id = "output",   label = "Output mapping")
+    }
+)
+public class SwapiConnector implements OutboundConnectorProvider { ... }
+```
+
+The `inputDataClass` points to the record/POJO whose `@TemplateProperty`-annotated fields drive the template's `properties` array. Inbound connectors add an `inbound = @ElementTemplate.ConnectorElementType(...)` clause per element variant; multi-element connectors declare one variant per BPMN attachment.
+
+`@TemplateProperty` on the input class:
+
+```java
+public record SwapiRequest(
+    @TemplateProperty(
+        id = "resource",
+        label = "Resource",
+        group = "endpoint",
+        type = TemplateProperty.PropertyType.Dropdown,
+        choices = {
+            @TemplateProperty.PropertyChoice(label = "People",    value = "people"),
+            @TemplateProperty.PropertyChoice(label = "Planets",   value = "planets"),
+            @TemplateProperty.PropertyChoice(label = "Starships", value = "starships")
+        }
+    )
+    @NotEmpty String resource,
+
+    @TemplateProperty(id = "index", label = "Resource ID", group = "endpoint",
+                      feel = TemplateProperty.FeelMode.optional)
+    @NotEmpty String index
+) {}
+```
+
+The annotation surface mirrors the element template JSON schema — see `element-template-json.md` for the underlying fields.
+
+## Plugin configuration — SPI shape (default)
+
+```xml
+<plugin>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>element-template-generator-maven-plugin</artifactId>
+  <version>${version.connectors}</version>
+  <configuration>
+    <connectors>
+      <connector>
+        <connectorClass>io.example.connector.swapi.SwapiConnector</connectorClass>
+        <files>
+          <file>
+            <templateId>io.example.connector.swapi.v1</templateId>
+            <templateFileName>swapi-outbound-connector.json</templateFileName>
+          </file>
+        </files>
+        <generateHybridTemplates>true</generateHybridTemplates>
+      </connector>
+    </connectors>
+    <versionHistoryEnabled>true</versionHistoryEnabled>
+  </configuration>
+</plugin>
+```
+
+Run `mvn package` (or `mvn process-classes` to skip tests) and the templates land in `target/generated-resources/element-templates/`.
+
+### Multiple connector classes
+
+```xml
+<connectors>
+  <connector>
+    <connectorClass>io.example.connector.swapi.SwapiConnector</connectorClass>
+    <files>
+      <file>
+        <templateId>io.example.connector.swapi.v1</templateId>
+        <templateFileName>swapi-outbound-connector.json</templateFileName>
+      </file>
+    </files>
+    <generateHybridTemplates>true</generateHybridTemplates>
+  </connector>
+  <connector>
+    <connectorClass>io.example.connector.swapi.SwapiInboundExecutable</connectorClass>
+    <files>
+      <file>
+        <templateId>io.example.connector.swapi.inbound.intermediate.v1</templateId>
+        <templateFileName>swapi-inbound-intermediate.json</templateFileName>
+      </file>
+      <file>
+        <templateId>io.example.connector.swapi.inbound.receive.v1</templateId>
+        <templateFileName>swapi-inbound-receive.json</templateFileName>
+      </file>
+    </files>
+    <generateHybridTemplates>false</generateHybridTemplates>
+  </connector>
+</connectors>
+```
+
+One `<connector>` per Java class. Multiple `<file>` entries on the same connector emit different template variants from the same `@ElementTemplate` — typically used for inbound connectors that support both intermediate catch and receive task.
+
+## Configuration fields
+
+### Per-connector
+
+- **`<connectorClass>`** — fully-qualified class name of the `OutboundConnectorProvider` / `OutboundConnectorFunction` / `InboundConnectorExecutable`.
+- **`<files>`** — one or more `<file>` blocks; each declares `<templateId>` (must match `@ElementTemplate.id` or a per-variant id) and `<templateFileName>` (output JSON name).
+- **`<generateHybridTemplates>`** — `true` to additionally emit `*-hybrid.json` for each `<file>`. Hybrid templates rewrite the connector binding to a form a SaaS engine can route to a standalone runtime. Set `false` on inbound polling/webhook variants where Hybrid mode isn't supported by the connector.
+- **`<writeMetaInfFileGeneration>`** — `true` (default) writes `META-INF/services/...` for SPI registration. **Set to `false` when registering the connector as a Spring Bean** (`@Component`) inside `connector-runtime-spring`; otherwise the bean and the SPI both register the class and you get duplicate instances.
+- **`<features>`** — per-feature toggles surfaced as additional template properties. Common keys: `ACKNOWLEDGEMENT_STRATEGY_SELECTION` (subscription connectors), `INBOUND_DEDUPLICATION` (inbound polling/webhook).
+
+### Top-level
+
+- **`<versionHistoryEnabled>`** — `true` writes a versioned copy of each template alongside the current one (e.g. `swapi-outbound-connector.json` plus `swapi-outbound-connector-v1.json`). Lets older process versions stay pinned to their template version after the connector ships a new one.
+- **`<includeDependencies>`** — `groupId:artifactId` pairs whose classpath should be scanned for additional `@ElementTemplate` classes. Used when the connector inherits template structure from a base module (e.g. webhook connectors riding on `connector-webhook`).
+
+## Hybrid templates
+
+`<generateHybridTemplates>true</generateHybridTemplates>` emits a parallel `*-hybrid.json` for each output. The hybrid variant flips the connector's `zeebe:taskDefinition.type` (or `zeebe:property name="inbound.type"` for inbound) to a job-worker-style binding the SaaS engine can route to a standalone runtime running outside SaaS.
+
+Without the hybrid template, deploying the standard template to SaaS and trying to drive it from a self-hosted runtime produces a runtime that can never receive jobs — the SaaS engine looks for the connector internally and finds nothing.
+
+Drop the flag (or set it to `false`) when:
+
+- The connector will only run on SaaS managed runtime (impossible for custom connectors — SaaS managed only runs the OOTB set), or
+- The connector will only run on Self-Managed (no Hybrid use case), or
+- The connector flavour doesn't support Hybrid (inbound polling and webhook flavours often don't, because the external system has to reach the standalone runtime's network).
+
+## Auto-generated SPI files
+
+When `<writeMetaInfFileGeneration>` is left `true`, the plugin writes:
+
+- `target/classes/META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorProvider` (modern outbound)
+- `target/classes/META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorFunction` (legacy outbound)
+- `target/classes/META-INF/services/io.camunda.connector.api.inbound.InboundConnectorExecutable` (inbound)
+
+Each lists fully-qualified class names. Don't hand-write these unless you've disabled the plugin's generation — they'll drift.
+
+## Output layout
+
+After `mvn package`:
+
+```
+target/
+├── classes/
+│   └── META-INF/services/...           (SPI files, if writeMetaInfFileGeneration=true)
+└── generated-resources/element-templates/
+    ├── swapi-outbound-connector.json
+    ├── swapi-outbound-connector-hybrid.json   (if generateHybridTemplates=true)
+    └── swapi-outbound-connector-v1.json       (if versionHistoryEnabled=true)
+```
+
+Commit the generated templates to your repo (or copy them into Modeler's resources directory) so process developers can pick them up without running the build first. Treat them as build artefacts checked in for convenience — re-run the plugin and re-commit on every annotation change.
+
+## Where to look next
+
+- `@ElementTemplate` annotation surface and JSON schema parity: `element-template-json.md`
+- Outbound connector class shape: `connector-sdk-outbound.md`
+- Inbound connector class shape: `connector-sdk-inbound.md`
+- Pairing the plugin with Spring Bean registration (`writeMetaInfFileGeneration=false`): `registration-and-hosting.md`

--- a/skills/camunda-connectors-development/references/element-template-json.md
+++ b/skills/camunda-connectors-development/references/element-template-json.md
@@ -13,7 +13,7 @@ The element template is the JSON document that gives a connector (or a worker) i
 | Field | Purpose |
 |---|---|
 | `$schema` | JSON schema URL Modeler validates against |
-| `id` | Unique template identifier (reverse-DNS recommended, e.g. `io.example.connector.swapi.v1`) |
+| `id` | Unique template identifier (reverse-DNS recommended, e.g. `io.example.connector.countries.v1`) |
 | `name` | Human-readable template name in the Modeler element picker |
 | `version` | Integer version. New versions allow processes to opt in; old versions remain pinned to existing elements |
 | `description` | One-line subtitle in the element picker |
@@ -29,21 +29,21 @@ The element template is the JSON document that gives a connector (or a worker) i
 
 ```json
 {
-  "id": "resource",
-  "label": "Resource",
-  "description": "Which SWAPI resource to look up",
+  "id": "lookupBy",
+  "label": "Lookup by",
+  "description": "Which REST Countries endpoint to query",
   "type": "Dropdown",
-  "group": "endpoint",
-  "value": "people",
+  "group": "lookup",
+  "value": "name",
   "feel": "optional",
   "optional": false,
-  "tooltip": "All SWAPI endpoints share this shape",
+  "tooltip": "All REST Countries endpoints share the /v3.1/<key>/<query> shape",
   "constraints": { "notEmpty": true },
   "condition": { "property": "mode", "equals": "lookup" },
-  "binding": { "type": "zeebe:input", "name": "resource" },
+  "binding": { "type": "zeebe:input", "name": "lookupBy" },
   "choices": [
-    { "name": "People",   "value": "people" },
-    { "name": "Planets",  "value": "planets" }
+    { "name": "Name",    "value": "name" },
+    { "name": "Capital", "value": "capital" }
   ]
 }
 ```
@@ -138,7 +138,7 @@ The binding writes the property value into the BPMN element XML when the templat
 
 A minimal outbound template wires three bindings:
 
-1. `zeebe:taskDefinition` `property: "type"` — value is the connector's registered type (e.g. `io.example.connector.swapi:1`). This is the load-bearing line that routes the job to the connector.
+1. `zeebe:taskDefinition` `property: "type"` — value is the connector's registered type (e.g. `io.example.connector.countries:1`). This is the load-bearing line that routes the job to the connector.
 2. `zeebe:input` `name: "<var>"` — per-property input variables.
 3. `zeebe:taskHeader` `key: "resultExpression"` (and `errorExpression`) — output mapping and error mapping.
 
@@ -147,7 +147,7 @@ A minimal outbound template wires three bindings:
 Inbound templates use `zeebe:property` instead of `zeebe:taskDefinition`:
 
 ```json
-{ "type": "Hidden", "value": "io.example.connector.swapi.updates:1",
+{ "type": "Hidden", "value": "io.example.connector.fxrates:1",
   "binding": { "type": "zeebe:property", "name": "inbound.type" } }
 ```
 

--- a/skills/camunda-connectors-development/references/element-template-json.md
+++ b/skills/camunda-connectors-development/references/element-template-json.md
@@ -1,0 +1,220 @@
+# Element template JSON schema reference
+
+The element template is the JSON document that gives a connector (or a worker) its Modeler UI. Same schema across Path A (hand-edited customisation of an OOTB template) and Path B (auto-generated from `@ElementTemplate`).
+
+`$schema` declares the shape Modeler validates against:
+
+```json
+"$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json"
+```
+
+## Top-level fields
+
+| Field | Purpose |
+|---|---|
+| `$schema` | JSON schema URL Modeler validates against |
+| `id` | Unique template identifier (reverse-DNS recommended, e.g. `io.example.connector.swapi.v1`) |
+| `name` | Human-readable template name in the Modeler element picker |
+| `version` | Integer version. New versions allow processes to opt in; old versions remain pinned to existing elements |
+| `description` | One-line subtitle in the element picker |
+| `documentationRef` | URL surfaced as a *Documentation* link in the properties panel |
+| `category` | Optional `{ id, name }` for grouping templates in the Modeler picker |
+| `appliesTo` | BPMN element types the template can attach to (e.g. `["bpmn:Task"]`, `["bpmn:StartEvent"]`) |
+| `elementType` | Concrete element type to morph the host into (e.g. `{ "value": "bpmn:ServiceTask" }`) |
+| `icon` | Inline data-URL or relative path for the element icon in Modeler |
+| `groups` | Ordered list of property groups (sections in the properties panel) |
+| `properties` | Ordered list of property definitions (declaration order matters — see Field ordering) |
+
+## Property structure
+
+```json
+{
+  "id": "resource",
+  "label": "Resource",
+  "description": "Which SWAPI resource to look up",
+  "type": "Dropdown",
+  "group": "endpoint",
+  "value": "people",
+  "feel": "optional",
+  "optional": false,
+  "tooltip": "All SWAPI endpoints share this shape",
+  "constraints": { "notEmpty": true },
+  "condition": { "property": "mode", "equals": "lookup" },
+  "binding": { "type": "zeebe:input", "name": "resource" },
+  "choices": [
+    { "name": "People",   "value": "people" },
+    { "name": "Planets",  "value": "planets" }
+  ]
+}
+```
+
+### Property types
+
+| `type` | UI shape |
+|---|---|
+| `String` | Single-line text input |
+| `Text` | Multi-line text area |
+| `Boolean` | Checkbox |
+| `Dropdown` | Select from `choices` (each `{ name, value }`) |
+| `Hidden` | No UI; the connector still receives the bound `value` |
+
+### `feel`
+
+Controls whether the property accepts FEEL expressions:
+
+- `"optional"` — both literal and FEEL accepted. Most fields use this.
+- `"required"` — only FEEL (leading `=`) is accepted. Result expressions, error expressions, and computed inputs.
+
+Omit the field if FEEL has no meaning for the property (e.g. a `Boolean`).
+
+### `optional`
+
+- `false` (default) — the field is required to deploy a process using the template.
+- `true` — the field can be left blank.
+
+`optional: true` plus `feel: "optional"` is the lightest-touch combination — accepts anything, including absent.
+
+### `constraints`
+
+Validation applied in Modeler at save / deploy time:
+
+```json
+"constraints": {
+  "notEmpty": true,
+  "pattern": {
+    "value": "^[a-z0-9-]+$",
+    "message": "Lowercase letters, digits, and hyphens only"
+  }
+}
+```
+
+`pattern.message` is the error string Modeler shows on violation. The runtime does *not* re-validate — these are UX-side guards.
+
+### `condition`
+
+Show or hide the property based on another property's value. The conditioned property is hidden (and its value is omitted from the binding) when the condition is false.
+
+```json
+"condition": { "property": "authMode", "equals": "bearer" }
+```
+
+Multi-value match:
+
+```json
+"condition": { "property": "method", "oneOf": ["POST", "PUT", "PATCH"] }
+```
+
+The referenced `property` field must be declared *earlier* in the `properties` array — same field-ordering rule as FEEL value references.
+
+### `generatedValue`
+
+Auto-fills the property when the user creates a fresh element. Used for message-name uniqueness on inbound intermediate-catch / boundary events:
+
+```json
+"generatedValue": { "type": "uuid" }
+```
+
+Without this, two parallel inbound events in the same process would share a message name and collide.
+
+### `tooltip`
+
+Hover text in the Modeler property panel. One sentence; longer prose belongs in `description` (rendered above the field) or `documentationRef`.
+
+## Binding types
+
+The binding writes the property value into the BPMN element XML when the template is applied. The binding type determines *where* the value lands.
+
+| Binding | Shape | Used for |
+|---|---|---|
+| `zeebe:taskDefinition` | `{ "type": "zeebe:taskDefinition", "property": "type" }` | Outbound connector type (job type). The `value` is the connector's registered type. |
+| `zeebe:taskHeader` | `{ "type": "zeebe:taskHeader", "key": "<header>" }` | Static task headers. Standard keys: `resultVariable`, `resultExpression`, `errorExpression`, `retryBackoff`. |
+| `zeebe:input` | `{ "type": "zeebe:input", "name": "<var>" }` | Input mappings — values the connector receives as variables. |
+| `zeebe:output` | `{ "type": "zeebe:output", "source": "=...", "target": "<var>" }` | Output mappings — emit a value into the process scope (rare; usually done via `resultExpression`). |
+| `zeebe:property` | `{ "type": "zeebe:property", "name": "<key>" }` | **Inbound** connector properties (type, config, correlation). |
+| `bpmn:Message#property` | `{ "type": "bpmn:Message#property", "name": "name" }` | Inbound message name (intermediate catch, message start, receive task). |
+| `bpmn:Message#zeebe:subscription#property` | `{ ..., "name": "correlationKey" }` | Inbound correlation-key FEEL expression for catch/receive variants. |
+
+### Outbound bindings, end to end
+
+A minimal outbound template wires three bindings:
+
+1. `zeebe:taskDefinition` `property: "type"` — value is the connector's registered type (e.g. `io.example.connector.swapi:1`). This is the load-bearing line that routes the job to the connector.
+2. `zeebe:input` `name: "<var>"` — per-property input variables.
+3. `zeebe:taskHeader` `key: "resultExpression"` (and `errorExpression`) — output mapping and error mapping.
+
+### Inbound bindings, end to end
+
+Inbound templates use `zeebe:property` instead of `zeebe:taskDefinition`:
+
+```json
+{ "type": "Hidden", "value": "io.example.connector.swapi.updates:1",
+  "binding": { "type": "zeebe:property", "name": "inbound.type" } }
+```
+
+For message-correlated variants (intermediate catch event, receive task, message start event), add:
+
+```json
+{ "id": "messageName", "label": "Message name", "type": "Hidden",
+  "generatedValue": { "type": "uuid" },
+  "binding": { "type": "bpmn:Message#property", "name": "name" } },
+
+{ "id": "correlationKey", "label": "Correlation key", "type": "String",
+  "feel": "required",
+  "binding": { "type": "bpmn:Message#zeebe:subscription#property", "name": "correlationKey" } }
+```
+
+The correlation key binds to a FEEL expression that the engine evaluates against process variables; the message name is the deduplication key the engine uses to match events to instances.
+
+## Template variants per BPMN attachment
+
+The same connector usually ships multiple template files, one per BPMN element it can attach to. Each declares its own `appliesTo` + `elementType`:
+
+| Variant | `appliesTo` | `elementType` |
+|---|---|---|
+| Outbound service task | `["bpmn:Task"]` | `{ "value": "bpmn:ServiceTask" }` |
+| Inbound start event | `["bpmn:StartEvent"]` | `{ "value": "bpmn:StartEvent" }` |
+| Inbound message start event | `["bpmn:StartEvent"]` | `{ "value": "bpmn:StartEvent", "eventDefinition": "bpmn:MessageEventDefinition" }` |
+| Inbound intermediate catch event | `["bpmn:IntermediateCatchEvent"]` | `{ "value": "bpmn:IntermediateCatchEvent" }` |
+| Inbound boundary event | `["bpmn:BoundaryEvent"]` | `{ "value": "bpmn:BoundaryEvent" }` |
+| Inbound receive task | `["bpmn:ReceiveTask"]` | `{ "value": "bpmn:ReceiveTask" }` |
+
+Modeler offers the template only on matching elements; one connector class can back several templates via the `@ElementTemplate` annotation's per-variant configuration in the Maven plugin.
+
+## Field ordering
+
+> Properties referenced by another property's FEEL `value` or `condition.property` must be declared *earlier* in the `properties` array.
+
+Out-of-order references silently evaluate to `null` at runtime (FEEL) or always-false (condition). Modeler does not flag this. When customising a Path A template, double-check ordering after edits — `Save as Template` preserves it, but manual reorders can break it.
+
+The Maven plugin orders by annotation source order; if hand-authored templates need to mix generated and manual sections, put computed `Hidden` properties last.
+
+## Output mapping — `resultVariable` vs. `resultExpression`
+
+The standard *Output mapping* group exposes:
+
+- **`resultVariable`** (`String`, `zeebe:taskHeader` with key `resultVariable`) — name a variable that receives the entire connector return value.
+- **`resultExpression`** (`Text`, `feel: "required"`, `zeebe:taskHeader` with key `resultExpression`) — FEEL expression evaluated against the return value; the resulting context is merged into the process scope.
+
+Templates should expose both; users pick one (or neither) per element.
+
+## Error handling — `errorExpression`
+
+```json
+{
+  "id": "errorExpression",
+  "label": "Error expression",
+  "type": "Text",
+  "group": "errors",
+  "feel": "required",
+  "binding": { "type": "zeebe:taskHeader", "key": "errorExpression" }
+}
+```
+
+The FEEL expression receives a context with `error.code` and `error.message` (populated from `ConnectorException`) and returns either `bpmnError(code, message)` or `null`. The element template should pre-populate sensible mappings for documented error codes; users can override.
+
+## Where to look next
+
+- Path A walkthrough (customising an OOTB template): `protocol-connector-templates.md`
+- Auto-generating templates from Java annotations: `element-template-generator.md`
+- Path B outbound code (where the bindings show up as `@Variable` / `@Header`): `connector-sdk-outbound.md`
+- Path B inbound code (where `zeebe:property` bindings show up via `bindProperties`): `connector-sdk-inbound.md`

--- a/skills/camunda-connectors-development/references/protocol-connector-templates.md
+++ b/skills/camunda-connectors-development/references/protocol-connector-templates.md
@@ -1,0 +1,228 @@
+# Path A — JSON-only template on a protocol connector
+
+Customise an existing protocol connector (REST, SOAP, GraphQL, Kafka, RabbitMQ, AWS SQS/SNS/EventBridge) into a domain-specific template by editing JSON only. No Java, no extra runtime, no separate deployment — the customised template lives in your repo as a single `.json` file and is uploaded to Web Modeler.
+
+## When this path applies
+
+The integration is a single call over one of the protocols above, AND you want a polished domain-specific UI in Modeler (named fields, hidden infrastructure, sensible defaults). Multi-step orchestration, proprietary protocols, or non-HTTP/non-messaging I/O require Path B.
+
+## Canonical workflow
+
+1. **Model the call once in Web Modeler.** Drop the OOTB protocol connector (e.g. *REST Outbound*) onto a service task and fill in URL, method, headers, body, auth — everything the call needs.
+2. **Save as Template.** Right-click the configured element → *Save as Template* (Web Modeler Desktop and SaaS). Modeler emits a JSON file mirroring the configured connector with the same property structure.
+3. **Edit the JSON.** Hide infrastructure properties, pre-fill them with FEEL, expose only the domain inputs, group them into custom groups.
+4. **Upload as a template** to the Modeler project (SaaS) or place under `resources/element-templates/` (Desktop), then attach it to elements in a process.
+
+## Hiding infrastructure properties
+
+Properties the consumer should never see — URL, HTTP method, internal headers — get `"type": "Hidden"` with a `value` baked in. The UI no longer renders them, but the connector still receives them at runtime.
+
+```json
+{
+  "id": "method",
+  "type": "Hidden",
+  "value": "GET",
+  "binding": { "type": "zeebe:taskHeader", "key": "method" }
+}
+```
+
+Use the same shape to lock the URL down to a single base path, force-set authentication, or set fixed query/header values.
+
+## Pre-filling URL with FEEL
+
+The URL field accepts FEEL expressions (leading `=`) so you can compute it from earlier domain inputs. Bake a SWAPI-style example:
+
+```json
+{
+  "id": "url",
+  "type": "Hidden",
+  "value": "=\"https://swapi.dev/api/\" + resource + \"/\" + index",
+  "binding": { "type": "zeebe:taskHeader", "key": "url" }
+}
+```
+
+`resource` and `index` are domain properties declared elsewhere in the template's `properties` array. The user picks a *resource* from a dropdown and types an *index*; the connector receives the fully-formed URL.
+
+### URL constraint regex
+
+The URL property in the REST template enforces:
+
+```
+^(=|(http://|https://|secrets|\{\{).*$
+```
+
+— a FEEL expression (`=...`), an absolute `http://` or `https://` URL, the deprecated `secrets.NAME` form, or a `{{secrets.NAME}}` placeholder. Anything else fails the Modeler-side validation. Preserve this constraint when customising; loosening it lets users save broken templates.
+
+## Field-ordering rule
+
+> Any property whose FEEL `value` references another property must appear *after* the referenced property in the `properties` array.
+
+Out-of-order references silently evaluate to `null` at runtime. The Modeler does not flag this. The `resource` and `index` properties in the SWAPI example must appear *before* the hidden `url` property that references them.
+
+This rule applies to all Path A customisations, all hand-authored templates, and the auto-generated templates from `@ElementTemplate` — though in the auto-generated case the plugin orders properties by annotation source order.
+
+## Suppressing the auth UI
+
+The REST template's `authentication.type` defaults to a `Dropdown` with options like `noAuth`, `basic`, `bearer`, `oauth-client-credentials`. To force one auth type and hide the picker:
+
+```json
+{
+  "id": "authentication.type",
+  "type": "Hidden",
+  "value": "bearer",
+  "binding": { "type": "zeebe:input", "name": "authentication.type" }
+},
+{
+  "id": "authentication.token",
+  "type": "String",
+  "label": "API token",
+  "value": "{{secrets.MY_API_TOKEN}}",
+  "binding": { "type": "zeebe:input", "name": "authentication.token" }
+}
+```
+
+The user sees the token field only; `noAuth` is the analogous value for unauthenticated APIs.
+
+## Custom groups
+
+Group domain properties into labelled sections so the Modeler's properties panel groups them visually:
+
+```json
+{
+  "groups": [
+    { "id": "endpoint", "label": "Star Wars resource" },
+    { "id": "output",   "label": "Output mapping" }
+  ],
+  "properties": [
+    {
+      "id": "resource",
+      "label": "Resource",
+      "type": "Dropdown",
+      "group": "endpoint",
+      "choices": [
+        { "name": "People",    "value": "people" },
+        { "name": "Planets",   "value": "planets" },
+        { "name": "Starships", "value": "starships" }
+      ],
+      "binding": { "type": "zeebe:input", "name": "resource" }
+    },
+    {
+      "id": "index",
+      "label": "Resource ID",
+      "type": "String",
+      "group": "endpoint",
+      "feel": "optional",
+      "binding": { "type": "zeebe:input", "name": "index" }
+    }
+  ]
+}
+```
+
+The pre-existing *Output mapping* group from the REST template should be kept (or re-declared) so users can still bind `resultVariable` / `resultExpression`.
+
+## Worked example — the full SWAPI template
+
+A minimal but complete customisation:
+
+```json
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Star Wars API",
+  "id": "io.example.connector.swapi.v1",
+  "description": "Look up Star Wars resources via the SWAPI REST API",
+  "appliesTo": ["bpmn:Task"],
+  "elementType": { "value": "bpmn:ServiceTask" },
+  "groups": [
+    { "id": "endpoint", "label": "SWAPI resource" },
+    { "id": "output",   "label": "Output mapping" }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:http-json:1",
+      "binding": { "type": "zeebe:taskDefinition", "property": "type" }
+    },
+    {
+      "id": "resource",
+      "label": "Resource",
+      "type": "Dropdown",
+      "group": "endpoint",
+      "choices": [
+        { "name": "People",    "value": "people" },
+        { "name": "Planets",   "value": "planets" },
+        { "name": "Starships", "value": "starships" }
+      ],
+      "binding": { "type": "zeebe:input", "name": "resource" }
+    },
+    {
+      "id": "index",
+      "label": "Resource ID",
+      "type": "String",
+      "group": "endpoint",
+      "feel": "optional",
+      "binding": { "type": "zeebe:input", "name": "index" }
+    },
+    {
+      "type": "Hidden",
+      "value": "GET",
+      "binding": { "type": "zeebe:input", "name": "method" }
+    },
+    {
+      "type": "Hidden",
+      "value": "=\"https://swapi.dev/api/\" + resource + \"/\" + index",
+      "binding": { "type": "zeebe:input", "name": "url" }
+    },
+    {
+      "type": "Hidden",
+      "value": "noAuth",
+      "binding": { "type": "zeebe:input", "name": "authentication.type" }
+    },
+    {
+      "id": "resultVariable",
+      "label": "Result variable",
+      "type": "String",
+      "group": "output",
+      "binding": { "type": "zeebe:taskHeader", "key": "resultVariable" }
+    },
+    {
+      "id": "resultExpression",
+      "label": "Result expression",
+      "type": "Text",
+      "group": "output",
+      "feel": "required",
+      "binding": { "type": "zeebe:taskHeader", "key": "resultExpression" }
+    }
+  ]
+}
+```
+
+The user sees: a *Resource* dropdown, a *Resource ID* string field, and the output-mapping group. Everything else is hidden. The connector receives a fully-formed `GET https://swapi.dev/api/people/1` — without the user knowing it's a REST connector underneath.
+
+The hidden `zeebe:taskDefinition` `type` is what binds the element to the underlying protocol connector (`io.camunda:http-json:1` for the REST connector). Verify the exact `type` value of the protocol connector you're layering on with `c8ctl element-template get-properties <id>` before hard-coding it — it's the load-bearing line.
+
+## Tools that generate templates from API specs
+
+Sometimes the OpenAPI / Postman spec for the target system is the starting point, not Web Modeler. Two tools in the connectors ecosystem produce REST templates from specs:
+
+- **`congen-cli`** — Postman collection → REST connector template. CLI tool in the `camunda/connectors` repository, not currently distributed as a standalone binary. Verify availability before recommending.
+- **Web Modeler's OpenAPI/Swagger/Postman generator** — the SaaS / Desktop UI has a *Create from REST API* flow that ingests a spec and produces an initial template.
+
+Both produce a template you then refine using the same JSON edits described above. Treat their output as the *Save as Template* starting point, not a finished artefact.
+
+## Validating the template
+
+Upload to Modeler and apply it to a service task; the Modeler validates the schema and surfaces errors inline. For repo-side validation, the JSON schema linked via `$schema` is the same one Modeler uses — most JSON-schema-aware editors will flag malformed properties without needing to round-trip through Modeler.
+
+To round-trip a template against `c8ctl`:
+
+```bash
+c8ctl element-template apply -i my-template.json <element-id> <bpmn-file>
+```
+
+prints the resulting BPMN (omit `-i` to print, include `-i` to write back). Confirms the binding writes the expected `zeebe:taskDefinition` + `zeebe:input` + `zeebe:taskHeaders` XML.
+
+## Where to look next
+
+- Element template schema (property types, binding types, FEEL features): `element-template-json.md`
+- If Path A doesn't fit (multi-step logic, proprietary protocol, inbound): `connector-sdk-outbound.md` / `connector-sdk-inbound.md`
+- Discovering the OOTB catalog you're extending: **camunda-connectors**

--- a/skills/camunda-connectors-development/references/protocol-connector-templates.md
+++ b/skills/camunda-connectors-development/references/protocol-connector-templates.md
@@ -30,18 +30,18 @@ Use the same shape to lock the URL down to a single base path, force-set authent
 
 ## Pre-filling URL with FEEL
 
-The URL field accepts FEEL expressions (leading `=`) so you can compute it from earlier domain inputs. Bake a SWAPI-style example:
+The URL field accepts FEEL expressions (leading `=`) so you can compute it from earlier domain inputs. A REST Countries lookup template that exposes only the lookup mode and the query value:
 
 ```json
 {
   "id": "url",
   "type": "Hidden",
-  "value": "=\"https://swapi.dev/api/\" + resource + \"/\" + index",
+  "value": "=\"https://restcountries.com/v3.1/\" + lookupBy + \"/\" + query",
   "binding": { "type": "zeebe:taskHeader", "key": "url" }
 }
 ```
 
-`resource` and `index` are domain properties declared elsewhere in the template's `properties` array. The user picks a *resource* from a dropdown and types an *index*; the connector receives the fully-formed URL.
+`lookupBy` and `query` are domain properties declared elsewhere in the template's `properties` array. The user picks a *lookup mode* (`name` / `capital` / `alpha` / `currency`) from a dropdown and types a *query* string; the connector receives the fully-formed URL.
 
 ### URL constraint regex
 
@@ -57,7 +57,7 @@ The URL property in the REST template enforces:
 
 > Any property whose FEEL `value` references another property must appear *after* the referenced property in the `properties` array.
 
-Out-of-order references silently evaluate to `null` at runtime. The Modeler does not flag this. The `resource` and `index` properties in the SWAPI example must appear *before* the hidden `url` property that references them.
+Out-of-order references silently evaluate to `null` at runtime. The Modeler does not flag this. The `lookupBy` and `query` properties in the REST Countries example must appear *before* the hidden `url` property that references them.
 
 This rule applies to all Path A customisations, all hand-authored templates, and the auto-generated templates from `@ElementTemplate` — though in the auto-generated case the plugin orders properties by annotation source order.
 
@@ -90,29 +90,30 @@ Group domain properties into labelled sections so the Modeler's properties panel
 ```json
 {
   "groups": [
-    { "id": "endpoint", "label": "Star Wars resource" },
-    { "id": "output",   "label": "Output mapping" }
+    { "id": "lookup", "label": "Country lookup" },
+    { "id": "output", "label": "Output mapping" }
   ],
   "properties": [
     {
-      "id": "resource",
-      "label": "Resource",
+      "id": "lookupBy",
+      "label": "Lookup by",
       "type": "Dropdown",
-      "group": "endpoint",
+      "group": "lookup",
       "choices": [
-        { "name": "People",    "value": "people" },
-        { "name": "Planets",   "value": "planets" },
-        { "name": "Starships", "value": "starships" }
+        { "name": "Name",            "value": "name" },
+        { "name": "Capital",         "value": "capital" },
+        { "name": "ISO 3166-1 code", "value": "alpha" },
+        { "name": "Currency",        "value": "currency" }
       ],
-      "binding": { "type": "zeebe:input", "name": "resource" }
+      "binding": { "type": "zeebe:input", "name": "lookupBy" }
     },
     {
-      "id": "index",
-      "label": "Resource ID",
+      "id": "query",
+      "label": "Query value",
       "type": "String",
-      "group": "endpoint",
+      "group": "lookup",
       "feel": "optional",
-      "binding": { "type": "zeebe:input", "name": "index" }
+      "binding": { "type": "zeebe:input", "name": "query" }
     }
   ]
 }
@@ -120,21 +121,21 @@ Group domain properties into labelled sections so the Modeler's properties panel
 
 The pre-existing *Output mapping* group from the REST template should be kept (or re-declared) so users can still bind `resultVariable` / `resultExpression`.
 
-## Worked example — the full SWAPI template
+## Worked example — the full REST Countries template
 
 A minimal but complete customisation:
 
 ```json
 {
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name": "Star Wars API",
-  "id": "io.example.connector.swapi.v1",
-  "description": "Look up Star Wars resources via the SWAPI REST API",
+  "name": "Country lookup",
+  "id": "io.example.connector.countries.v1",
+  "description": "Look up country reference data via the REST Countries API",
   "appliesTo": ["bpmn:Task"],
   "elementType": { "value": "bpmn:ServiceTask" },
   "groups": [
-    { "id": "endpoint", "label": "SWAPI resource" },
-    { "id": "output",   "label": "Output mapping" }
+    { "id": "lookup", "label": "Country lookup" },
+    { "id": "output", "label": "Output mapping" }
   ],
   "properties": [
     {
@@ -143,24 +144,25 @@ A minimal but complete customisation:
       "binding": { "type": "zeebe:taskDefinition", "property": "type" }
     },
     {
-      "id": "resource",
-      "label": "Resource",
+      "id": "lookupBy",
+      "label": "Lookup by",
       "type": "Dropdown",
-      "group": "endpoint",
+      "group": "lookup",
       "choices": [
-        { "name": "People",    "value": "people" },
-        { "name": "Planets",   "value": "planets" },
-        { "name": "Starships", "value": "starships" }
+        { "name": "Name",            "value": "name" },
+        { "name": "Capital",         "value": "capital" },
+        { "name": "ISO 3166-1 code", "value": "alpha" },
+        { "name": "Currency",        "value": "currency" }
       ],
-      "binding": { "type": "zeebe:input", "name": "resource" }
+      "binding": { "type": "zeebe:input", "name": "lookupBy" }
     },
     {
-      "id": "index",
-      "label": "Resource ID",
+      "id": "query",
+      "label": "Query value",
       "type": "String",
-      "group": "endpoint",
+      "group": "lookup",
       "feel": "optional",
-      "binding": { "type": "zeebe:input", "name": "index" }
+      "binding": { "type": "zeebe:input", "name": "query" }
     },
     {
       "type": "Hidden",
@@ -169,7 +171,7 @@ A minimal but complete customisation:
     },
     {
       "type": "Hidden",
-      "value": "=\"https://swapi.dev/api/\" + resource + \"/\" + index",
+      "value": "=\"https://restcountries.com/v3.1/\" + lookupBy + \"/\" + query",
       "binding": { "type": "zeebe:input", "name": "url" }
     },
     {
@@ -196,7 +198,7 @@ A minimal but complete customisation:
 }
 ```
 
-The user sees: a *Resource* dropdown, a *Resource ID* string field, and the output-mapping group. Everything else is hidden. The connector receives a fully-formed `GET https://swapi.dev/api/people/1` — without the user knowing it's a REST connector underneath.
+The user sees: a *Lookup by* dropdown, a *Query value* string field, and the output-mapping group. Everything else is hidden. The connector receives a fully-formed `GET https://restcountries.com/v3.1/name/germany` — without the user knowing it's a REST connector underneath.
 
 The hidden `zeebe:taskDefinition` `type` is what binds the element to the underlying protocol connector (`io.camunda:http-json:1` for the REST connector). Verify the exact `type` value of the protocol connector you're layering on with `c8ctl element-template get-properties <id>` before hard-coding it — it's the load-bearing line.
 

--- a/skills/camunda-connectors-development/references/registration-and-hosting.md
+++ b/skills/camunda-connectors-development/references/registration-and-hosting.md
@@ -17,7 +17,7 @@ The Java ServiceLoader pattern. A file at `META-INF/services/<interface>` lists 
 META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorProvider
 ```
 ```
-io.example.connector.swapi.SwapiConnector
+io.example.connector.countries.CountryLookupConnector
 ```
 
 The element-template-generator Maven plugin writes this file automatically (`<writeMetaInfFileGeneration>true</writeMetaInfFileGeneration>`, default). The connector requires only `connector-core` and (optionally) `connector-validation` on its compile classpath.
@@ -36,7 +36,7 @@ The connector class is a `@Component` (or any Spring bean) inside an application
 @Component
 @OutboundConnector(name = "...", type = "...", inputVariables = {...})
 @ElementTemplate(id = "...", name = "...", version = 1)
-public class SwapiConnector implements OutboundConnectorProvider { ... }
+public class CountryLookupConnector implements OutboundConnectorProvider { ... }
 ```
 
 Required dependencies:
@@ -61,7 +61,7 @@ Required dependencies:
 <configuration>
   <connectors>
     <connector>
-      <connectorClass>io.example.connector.swapi.SwapiConnector</connectorClass>
+      <connectorClass>io.example.connector.countries.CountryLookupConnector</connectorClass>
       <writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>
       ...
     </connector>
@@ -92,7 +92,7 @@ Mount the connector JAR into `/opt/app/`:
 
 ```bash
 docker run --rm --name=connectors -d \
-  -v $PWD/swapi-connector.jar:/opt/app/swapi-connector.jar \
+  -v $PWD/countries-connector.jar:/opt/app/countries-connector.jar \
   -e CAMUNDA_CLIENT_MODE=self-managed \
   -e CAMUNDA_CLIENT_GRPC_ADDRESS=http://localhost:26500 \
   -e CAMUNDA_CLIENT_REST_ADDRESS=http://localhost:8080 \

--- a/skills/camunda-connectors-development/references/registration-and-hosting.md
+++ b/skills/camunda-connectors-development/references/registration-and-hosting.md
@@ -1,0 +1,179 @@
+# Registration and hosting
+
+Two orthogonal decisions every Path B connector has to make:
+
+1. **Registration** — how does the connector runtime *find* your connector class? SPI file or Spring Bean.
+2. **Hosting** — where does the runtime run? SaaS, Self-Managed standalone, Self-Managed embedded, or Hybrid.
+
+The two interact: Spring Bean registration only works inside an embedded Spring Boot runtime; SPI works in both standalone and embedded.
+
+## Registration: SPI vs. Spring Bean
+
+### SPI (default)
+
+The Java ServiceLoader pattern. A file at `META-INF/services/<interface>` lists the implementing class names, one per line:
+
+```
+META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorProvider
+```
+```
+io.example.connector.swapi.SwapiConnector
+```
+
+The element-template-generator Maven plugin writes this file automatically (`<writeMetaInfFileGeneration>true</writeMetaInfFileGeneration>`, default). The connector requires only `connector-core` and (optionally) `connector-validation` on its compile classpath.
+
+SPI is the right choice for:
+
+- Connectors shipped as standalone JARs for the **Self-Managed standalone** runtime.
+- Connectors deployed in **Hybrid** mode.
+- Anything you want to keep small (no Spring transitives in the JAR).
+
+### Spring Bean
+
+The connector class is a `@Component` (or any Spring bean) inside an application built on `connector-runtime-spring`. Discovery is via Spring's component scan, not via the SPI file.
+
+```java
+@Component
+@OutboundConnector(name = "...", type = "...", inputVariables = {...})
+@ElementTemplate(id = "...", name = "...", version = 1)
+public class SwapiConnector implements OutboundConnectorProvider { ... }
+```
+
+Required dependencies:
+
+```xml
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-runtime-spring</artifactId>
+  <version>${version.connectors}</version>
+</dependency>
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>connector-runtime-core</artifactId>
+  <version>${version.connectors}</version>
+</dependency>
+<!-- plus the standard Spring Boot starters the host application needs -->
+```
+
+**Always disable SPI file generation when registering as a Spring Bean.** Both mechanisms registering the same class causes the runtime to instantiate two distinct instances of the connector — they share class but not state, and the second silently shadows the first for routing purposes. Set:
+
+```xml
+<configuration>
+  <connectors>
+    <connector>
+      <connectorClass>io.example.connector.swapi.SwapiConnector</connectorClass>
+      <writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>
+      ...
+    </connector>
+  </connectors>
+</configuration>
+```
+
+Spring Bean is the right choice for:
+
+- Connectors shipped as part of an **embedded** Spring Boot application where workers and connectors coexist.
+- Connectors that need to take advantage of Spring DI (inject services, configuration properties, observability hooks).
+
+## Hosting
+
+Four runtime environments. Path B can target any of them.
+
+### SaaS managed runtime
+
+Camunda runs the standard OOTB connectors on SaaS. **Custom connectors are not supported on the managed runtime** — there is no mechanism to upload a custom JAR to SaaS. Path B on a SaaS engine requires Hybrid mode.
+
+Path A protocol-template customisations work fine on SaaS because they layer on OOTB protocol connectors that the SaaS runtime already hosts.
+
+### Self-Managed standalone
+
+The `camunda/connectors:X.Y.Z` Docker image. Runs separately from the Zeebe broker; pulls jobs over the standard client API.
+
+Mount the connector JAR into `/opt/app/`:
+
+```bash
+docker run --rm --name=connectors -d \
+  -v $PWD/swapi-connector.jar:/opt/app/swapi-connector.jar \
+  -e CAMUNDA_CLIENT_MODE=self-managed \
+  -e CAMUNDA_CLIENT_GRPC_ADDRESS=http://localhost:26500 \
+  -e CAMUNDA_CLIENT_REST_ADDRESS=http://localhost:8080 \
+  -e CAMUNDA_CLIENT_AUTH_METHOD=none \
+  camunda/connectors:X.Y.Z
+```
+
+A single mount path (`/opt/app/`) handles both outbound and inbound JARs. Drop multiple JARs into the same path to host several custom connectors in one runtime.
+
+Auth and cluster wiring use the same `CAMUNDA_CLIENT_*` env vars as `c8ctl` and the Java client (`CAMUNDA_CLIENT_AUTH_METHOD` = `none` | `basic` | `oidc`; OIDC pulls `CAMUNDA_CLIENT_AUTH_CLIENTID` + `CAMUNDA_CLIENT_AUTH_CLIENTSECRET` + `CAMUNDA_CLIENT_AUTH_TOKENURL`).
+
+Secrets: the 8.9+ runtime reads from environment variables prefixed `SECRET_` by default. `{{secrets.MY_KEY}}` in a template defaults to `$SECRET_MY_KEY` at runtime. The prefix is configurable via `CAMUNDA_CONNECTOR_SECRET_PROVIDER_*` env vars.
+
+Use SPI registration. The standalone runtime is not a Spring Boot application that scans your beans.
+
+### Self-Managed embedded
+
+A Spring Boot application that hosts both connectors and your own business code. The starter provides the connector runtime and registers SPI- and bean-discovered connectors against the cluster.
+
+```xml
+<dependency>
+  <groupId>io.camunda.connector</groupId>
+  <artifactId>spring-boot-starter-camunda-connectors</artifactId>
+  <version>${version.connectors}</version>
+</dependency>
+```
+
+Spring Bean or SPI registration both work in this mode (don't combine the two for the same class). Cluster wiring is via the standard `camunda.client.*` Spring properties — same shape the Camunda Spring Boot Starter uses for job workers.
+
+### Hybrid
+
+The standalone Docker runtime running in your environment, connected to a SaaS cluster. Required when:
+
+- The engine has to be SaaS (managed) but the connector needs to reach a system inside your network perimeter (private API, on-prem database, internal queue).
+- You want SaaS's managed engine but Path B connectors that aren't part of the OOTB catalog.
+
+Run the same `camunda/connectors:X.Y.Z` image as Self-Managed standalone, but point it at the SaaS cluster:
+
+```bash
+docker run ... \
+  -e CAMUNDA_CLIENT_MODE=saas \
+  -e CAMUNDA_CLIENT_CLOUD_CLUSTERID=<cluster-id> \
+  -e CAMUNDA_CLIENT_CLOUD_REGION=<region> \
+  -e CAMUNDA_CLIENT_AUTH_CLIENTID=<saas-client-id> \
+  -e CAMUNDA_CLIENT_AUTH_CLIENTSECRET=<saas-client-secret> \
+  camunda/connectors:X.Y.Z
+```
+
+**Deploy the `-hybrid.json` template variant**, not the standard one. The hybrid template rewrites the connector binding so the SaaS engine routes jobs to your standalone runtime rather than looking for the connector internally. Generated via `<generateHybridTemplates>true</generateHybridTemplates>` (see `element-template-generator.md`).
+
+**Inbound caveat for Hybrid**: webhook inbound connectors expose an HTTP endpoint on the runtime hosting them. In Hybrid, that's your standalone runtime — the external caller must be able to reach *your* address, not SaaS's. Plan DNS/firewall accordingly. Subscription and polling inbound flavours don't have this caveat because the runtime initiates the connections outbound.
+
+## Matrix
+
+| Hosting | Registration | Maven plugin flags |
+|---|---|---|
+| SaaS managed | n/a (custom unsupported — use Hybrid) | n/a |
+| SM standalone | SPI | `<generateHybridTemplates>` may be `false` |
+| SM embedded | SPI **or** Spring Bean (not both) | Spring Bean needs `<writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>` |
+| Hybrid (standalone runtime → SaaS) | SPI | `<generateHybridTemplates>true</generateHybridTemplates>`, deploy the `-hybrid.json` variant |
+
+## Configuring secrets
+
+Element templates and Java code reference secrets via `{{secrets.NAME}}`. The runtime resolves them at execution time.
+
+- **Standalone / Hybrid (8.9+)**: environment variables with the `SECRET_` prefix. `{{secrets.MY_KEY}}` resolves to `$SECRET_MY_KEY`. The prefix is configurable (`CAMUNDA_CONNECTOR_SECRET_PROVIDER_ENVIRONMENT_PREFIX`); also pluggable for vault providers.
+- **Embedded**: Spring application configures secret providers via `camunda.connector.secret-providers.*` properties.
+- **SaaS**: secret values are managed via the SaaS console; templates reference the same `{{secrets.NAME}}` shape.
+
+Never put secret material in template defaults, BPMN attributes, or hard-coded Java strings — the `{{secrets.NAME}}` placeholder is the only safe path.
+
+## Picking a combination
+
+- **Most common for an organisation already running Self-Managed**: SM standalone + SPI registration. Smallest connector JARs, no Spring transitives, one runtime image hosts many connectors.
+- **Java-team-internal connector inside an existing Spring Boot job-worker app**: SM embedded + Spring Bean registration. The connector lives in the same codebase as the workers; CI ships one artefact.
+- **SaaS engine, custom connector for an internal system**: Hybrid + SPI registration + `generateHybridTemplates=true`. The runtime runs inside your perimeter; the engine doesn't.
+- **OOTB-only deployment**: no Path B at all — see **camunda-connectors**.
+
+## Where to look next
+
+- Maven plugin flags (`writeMetaInfFileGeneration`, `generateHybridTemplates`, `versionHistoryEnabled`): `element-template-generator.md`
+- Outbound connector class shape: `connector-sdk-outbound.md`
+- Inbound connector class shape (`activate`/`deactivate` lifecycle and the three flavours): `connector-sdk-inbound.md`
+- Element template schema (for the hybrid-template differences in `zeebe:taskDefinition`/`zeebe:property`): `element-template-json.md`

--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -36,7 +36,7 @@ Element templates (also called **connector templates** — the terms are used in
 - **Constraints** validating user input (required fields, URL patterns, etc.)
 - **Groups** organizing properties into logical sections (authentication, endpoint, output, error handling)
 
-Read `references/element-template-schema.md` for the binding-types-and-XML-mapping deep dive.
+Read `references/element-template-schema.md` for the reader's guide to property fields and the binding → BPMN XML mapping. The full authoring schema lives in **camunda-connectors-development**.
 
 ### Discovering Connectors via Search
 
@@ -187,4 +187,4 @@ After applying, validate with `c8ctl bpmn lint process.bpmn`.
 ## References
 
 For detailed reference material, read from `references/`:
-- [element-template-schema.md](references/element-template-schema.md) — element template JSON schema: binding types, conditions, constraints, FEEL support, property-to-XML mapping
+- [element-template-schema.md](references/element-template-schema.md) — reader's guide for configuring OOTB templates via `apply --set`: property-reading checklist, binding → BPMN XML mapping table, HTTP worked example. For the full authoring schema, see **camunda-connectors-development**

--- a/skills/camunda-connectors/references/element-template-schema.md
+++ b/skills/camunda-connectors/references/element-template-schema.md
@@ -1,344 +1,70 @@
-# Element Template Schema Reference
+# Element template schema — reader's guide
 
-Element templates are JSON files that define how connectors are configured. Understanding the schema is essential for reading templates, knowing what values to provide, and correctly mapping properties to BPMN XML.
+This file covers what you need to *read* an existing OOTB element template well enough to configure it with `c8ctl element-template apply --set`. For the full authoring schema — every property type, binding type, conditional shape, inbound variant — see `camunda-connectors-development/references/element-template-json.md`.
 
-## Template Structure Overview
+## Reading a property — decision order
 
-```json
-{
-  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name": "REST Outbound Connector",
-  "id": "io.camunda.connectors.HttpJson.v2",
-  "description": "Invoke REST API",
-  "version": 12,
-  "appliesTo": ["bpmn:Task"],
-  "elementType": { "value": "bpmn:ServiceTask" },
-  "groups": [ ... ],
-  "properties": [ ... ],
-  "icon": { "contents": "data:image/svg+xml;base64,..." }
-}
-```
+When inspecting a template property (typically via `c8ctl element-template get-properties <id> --detailed <name>`), answer these in order:
 
-### Top-Level Fields
+1. **Is `type` `Hidden`?** → fixed technical value. Don't override; the template owns it.
+2. **Does `constraints.notEmpty` apply?** → the property is required; `apply` will fail without a value.
+3. **Does `condition` apply?** → the property is active only when another property equals (or `oneOf`s) a specific value. Set the parent first.
+4. **What is `binding.type`?** → determines the BPMN XML the value lands in (`zeebe:input`, `zeebe:taskHeader`, etc. — see the mapping table below).
+5. **What is `feel`?** → `required` ⇒ value must start with `=`. `optional` ⇒ plain literal or FEEL. `static` ⇒ raw value, persisted as FEEL automatically (Boolean, Number).
+6. **Is there a `value`?** → that's the default. Override only if needed.
+7. **Are there `choices`?** → the value must be one of them.
 
-| Field | Purpose |
-|-------|---------|
-| `name` | Human-readable connector name |
-| `id` | Unique template identifier (used in `zeebe:modelerTemplate`) |
-| `version` | Integer version number (used in `zeebe:modelerTemplateVersion`) |
-| `appliesTo` | BPMN element types this template works with (e.g., `bpmn:Task`, `bpmn:StartEvent`) |
-| `elementType.value` | The BPMN element type is changed to this when the template is applied (e.g., `bpmn:ServiceTask`) |
-| `groups` | Logical groupings for properties in the UI (authentication, endpoint, output, etc.) |
-| `properties` | The array of configurable properties — the heart of the template |
-| `icon` | SVG/PNG icon (often large base64 — avoid reading into context) |
-| `engines` | Minimum Camunda version compatibility (e.g., `{"camunda": "^8.3"}`) |
-| `documentationRef` | URL to official connector documentation |
+Reach for `--detailed` rather than the condensed listing whenever an `apply --set` call fails or you're unsure about the FEEL prefix.
 
-## Properties Array
+## Property → BPMN XML mapping
 
-Each property object in the `properties` array defines one configurable field. The key concept: each property maps a user-facing input to an underlying BPMN XML binding.
+The `binding.type` on each property determines where the value lands in the resulting BPMN XML.
 
-### Property Fields
+| Template binding | BPMN XML element | Source / target |
+|---|---|---|
+| `zeebe:input` with `name: "url"` | `<zeebe:input source="..." target="url" />` | user value → `source` |
+| `zeebe:output` with `source: "= body"` | `<zeebe:output source="= body" target="..." />` | user value → `target` |
+| `zeebe:taskHeader` with `key: "resultExpression"` | `<zeebe:header key="resultExpression" value="..." />` | user value → `value` |
+| `zeebe:taskDefinition` with `property: "type"` | `<zeebe:taskDefinition type="..." />` | template-owned, almost always `Hidden` |
+| `zeebe:property` with `name: "inbound.type"` | `<zeebe:property name="inbound.type" value="..." />` | inbound; template-owned |
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `binding` | Yes | How this property maps to BPMN XML (see Binding Types below) |
-| `type` | No | Input type: `String`, `Text`, `Boolean`, `Number`, `Dropdown`, `Hidden` |
-| `label` | No | Display label in the properties panel |
-| `description` | No | Help text below the input field |
-| `value` | No | Default value. If `type` is `Hidden`, this is the fixed value |
-| `id` | No | Identifier used by other properties' `condition` references |
-| `group` | No | Which group this property appears in |
-| `feel` | No | FEEL expression support: `"required"`, `"optional"`, or `"static"` |
-| `optional` | No | If `true`, empty values are NOT persisted in XML |
-| `constraints` | No | Validation rules (see Constraints below) |
-| `condition` | No | Show this property only when a condition is met (see Conditions below) |
-| `choices` | No | For `Dropdown` type: array of `{name, value}` pairs |
-| `editable` | No | If `false`, the user cannot change this value |
+Nested input names use dot notation: `name: "authentication.token"` produces `target="authentication.token"` and the connector deserialises it into a nested object.
 
-### How to Read a Property
+When the same name appears across binding types (e.g. an outbound + inbound connector both with `correlationKey`), `--set` accepts a prefix to disambiguate: `input:`, `output:`, `header:`, `property:`, `taskDefinition:`.
 
-When examining a template property, answer these questions in order:
+## Common task headers
 
-1. **Is it `Hidden`?** → This is a technical value set automatically. Do not change it. The `value` is fixed.
-2. **Does it have `constraints.notEmpty: true`?** → This property is required. A value must be provided.
-3. **Does it have a `condition`?** → This property only applies when another property has a specific value.
-4. **What is the `binding.type`?** → This determines what BPMN XML element is created (see below).
-5. **What is the `feel` value?** → This determines whether the value can/must be a FEEL expression.
-6. **Does it have a `value`?** → This is the default. Override only if needed.
-7. **Does it have `choices`?** → The value must be one of the listed options.
+The headers most often set on outbound connector templates:
 
-## Binding Types
+| Header | Purpose |
+|---|---|
+| `resultVariable` | Name a process variable that receives the raw connector response |
+| `resultExpression` | FEEL expression evaluated against the response; result merged into the process scope |
+| `errorExpression` | FEEL expression mapping connector errors to BPMN errors (returns `bpmnError(...)` or `null`) |
+| `retryBackoff` | ISO 8601 duration between retries (e.g. `PT5S`) |
 
-The `binding` object is the bridge between the template property and the BPMN XML. Each binding type produces a different XML structure.
+Inbound connectors surface `resultVariable` and `resultExpression` under the same **Output mapping** group — the engine writes the event payload into the process scope when the trigger fires, identically to how outbound writes the response.
 
-### `zeebe:input` — Input Mapping
-
-Creates `<zeebe:input source="[value]" target="[name]" />` inside `<zeebe:ioMapping>`.
-
-```json
-{
-  "label": "URL",
-  "type": "String",
-  "feel": "optional",
-  "binding": { "type": "zeebe:input", "name": "url" }
-}
-```
-
-**Result XML:**
-```xml
-<zeebe:ioMapping>
-  <zeebe:input source="https://api.example.com" target="url" />
-</zeebe:ioMapping>
-```
-
-The `name` in the binding becomes the `target` attribute. The user-provided value (or FEEL expression) becomes the `source` attribute.
-
-**Nested properties** use dot notation: `"name": "authentication.token"` creates `target="authentication.token"`. The connector runtime deserializes this into a nested object.
-
-### `zeebe:output` — Output Mapping
-
-Creates `<zeebe:output source="[source]" target="[value]" />`.
-
-```json
-{
-  "label": "Result Variable",
-  "type": "String",
-  "binding": { "type": "zeebe:output", "source": "= body" }
-}
-```
-
-**Result XML:**
-```xml
-<zeebe:ioMapping>
-  <zeebe:output source="= body" target="response" />
-</zeebe:ioMapping>
-```
-
-Note the inversion: `binding.source` is fixed (what to extract from task output), and the user provides the `target` (process variable name).
-
-### `zeebe:taskHeader` — Task Header
-
-Creates `<zeebe:header key="[key]" value="[value]" />` inside `<zeebe:taskHeaders>`.
-
-```json
-{
-  "label": "Result Expression",
-  "type": "Text",
-  "feel": "required",
-  "binding": { "type": "zeebe:taskHeader", "key": "resultExpression" }
-}
-```
-
-**Result XML:**
-```xml
-<zeebe:taskHeaders>
-  <zeebe:header key="resultExpression" value="={user: response.body}" />
-</zeebe:taskHeaders>
-```
-
-Common task headers in connectors:
-- `resultVariable` — name of process variable to store raw response
-- `resultExpression` — FEEL expression to extract specific fields from the response
-- `errorExpression` — FEEL expression to throw BPMN errors on failure
-- `retryBackoff` — ISO 8601 duration between retries
-
-### `zeebe:taskDefinition` — Task Definition
-
-Sets `<zeebe:taskDefinition type="[value]" />` or retries.
-
-```json
-{
-  "type": "Hidden",
-  "value": "io.camunda:http-json:1",
-  "binding": { "type": "zeebe:taskDefinition", "property": "type" }
-}
-```
-
-**Result XML:**
-```xml
-<zeebe:taskDefinition type="io.camunda:http-json:1" retries="3" />
-```
-
-This is almost always `Hidden` — the task type identifies which connector runtime handles the job. The `property` parameter can be `type` or `retries`.
-
-### `zeebe:property` — Extension Property
-
-Creates `<zeebe:property name="[name]" value="[value]" />`. Used primarily by inbound connectors.
-
-```json
-{
-  "type": "Hidden",
-  "value": "io.camunda:webhook:1",
-  "binding": { "type": "zeebe:property", "name": "inbound.type" }
-}
-```
-
-## Conditions
-
-Properties can be shown/hidden based on other property values. This is how templates handle different modes (e.g., authentication types).
-
-### Simple condition
-
-```json
-{
-  "label": "Bearer Token",
-  "condition": {
-    "property": "authentication.type",
-    "equals": "bearer"
-  }
-}
-```
-
-This property only appears (and only gets persisted to XML) when `authentication.type` equals `"bearer"`.
-
-### oneOf condition
-
-```json
-{
-  "label": "Request Body",
-  "condition": {
-    "property": "method",
-    "oneOf": ["POST", "PUT", "PATCH"]
-  }
-}
-```
-
-### allMatch (multiple conditions)
-
-```json
-{
-  "condition": {
-    "allMatch": [
-      { "property": "method", "equals": "chat.postMessage" },
-      { "property": "data.messageType", "equals": "plainText" }
-    ]
-  }
-}
-```
-
-### Why conditions matter for configuration
-
-When setting property values in BPMN XML, only set values for properties whose conditions are met. For example, if `authentication.type` is `"noAuth"`, do NOT set `authentication.token`, `authentication.username`, or `authentication.password` — those properties are inactive and their values would be meaningless.
-
-## Constraints
-
-Validation rules that define what values are acceptable.
-
-```json
-{
-  "constraints": {
-    "notEmpty": true,
-    "minLength": 1,
-    "maxLength": 255,
-    "pattern": {
-      "value": "^(=|(http://|https://|secrets|\\{\\{).*$)",
-      "message": "Must be a http(s) URL"
-    }
-  }
-}
-```
-
-| Constraint | Meaning |
-|-----------|---------|
-| `notEmpty: true` | Value is required — must not be empty |
-| `minLength` / `maxLength` | String length limits |
-| `pattern.value` | Regex the value must match |
-| `pattern.message` | Error message shown when pattern fails |
-
-### Common patterns in connector templates
-
-- URL: `^(=|(http://|https://|secrets|\\{\\{).*$)` — accepts URLs, FEEL expressions (`=...`), or secrets (`{{secrets.X}}`)
-- Numbers: `^\\d+$` — digits only
-
-## FEEL Expression Support
-
-The `feel` field controls how values interact with FEEL:
-
-| Value | Behavior |
-|-------|----------|
-| `"required"` | Value must be a FEEL expression (prefixed with `=`). Used for `resultExpression`, `errorExpression`, complex mappings. |
-| `"optional"` | Value can be a plain string OR a FEEL expression. Used for most input fields (URL, auth tokens, etc.) |
-| `"static"` | Value is persisted as FEEL but no expression editor is shown. Used for `Boolean` and `Number` fields. |
-| (absent) | For `zeebe:input`/`zeebe:output` bindings, defaults to `"static"`. For others, no FEEL support. |
-
-### Providing values based on `feel`
-
-- **`feel: "required"`**: Always prefix the value with `=`: `={user: response.body}`
-- **`feel: "optional"`**: Use plain values for static content (`GET`, `noAuth`), prefix with `=` for dynamic content (`="https://api.example.com/users/" + string(userId)`)
-- **`feel: "static"`**: Provide the raw value (e.g., `20`, `true`) — it will be treated as FEEL automatically
-
-## Groups
-
-Groups organize properties into collapsible sections in the properties panel. Common groups across connector templates:
-
-| Group ID | Purpose | Typical Properties |
-|----------|---------|-------------------|
-| `authentication` | Auth configuration | Token, username/password, OAuth settings |
-| `endpoint` | Target configuration | URL, method, headers, query parameters |
-| `payload` | Request body | Body content, content type |
-| `output` | Response handling | resultVariable, resultExpression |
-| `error` | Error handling | errorExpression |
-| `retries` | Retry configuration | Retry count, backoff duration |
-| `connector` | Template metadata | Hidden version/ID fields |
-
-## Reading a Template: Step-by-Step Workflow
-
-To configure a connector after applying a template:
-
-1. **Read the template JSON** (but avoid the `icon` field — it's a large base64 string)
-2. **Identify the groups** to understand the structure
-3. **Find the task definition** — the `Hidden` property with `zeebe:taskDefinition` binding tells you the connector type
-4. **Identify required properties** — look for `constraints.notEmpty: true` or properties without `optional: true`
-5. **Check conditions** — some properties only apply when other properties have specific values. Start with the "parent" dropdown properties (authentication type, method, etc.)
-6. **Decide on the parent values first** (e.g., `authentication.type = "bearer"`) — this determines which child properties become active
-7. **Set values for active required properties** — use real values, FEEL expressions, or `{{secrets.X}}` for credentials
-8. **Set values for active optional properties** as needed
-9. **Skip inactive properties** — do not set values for properties whose conditions are not met
-
-## Configuring Properties in BPMN XML
-
-After `c8ctl element-template apply` applies the template, it creates default `zeebe:ioMapping` entries and `zeebe:taskHeaders`. Use `--set key=value` flags at apply time for straightforward configuration, or edit the BPMN XML manually for complex cases.
-
-To inspect what properties are settable on a given template, run:
+## Worked example — HTTP REST connector with `apply --set`
 
 ```bash
-c8ctl element-template get-properties <template-id>             # condensed: name + description per property, grouped
-c8ctl element-template get-properties <template-id> --detailed  # full cards: Required, FEEL, Active when, Pattern, Default, Choices
+c8ctl element-template apply -i io.camunda.connectors.HttpJson.v2 Task_FetchUser process.bpmn \
+  --set authentication.type=bearer \
+  --set authentication.token='{{secrets.API_TOKEN}}' \
+  --set method=GET \
+  --set url='="https://api.example.com/users/" + string(userId)' \
+  --set resultVariable=apiResponse \
+  --set resultExpression='={user: response.body}' \
+  --set errorExpression='=if response.statusCode >= 400 then bpmnError("HTTP_ERROR", string(response.statusCode)) else null'
 ```
 
-The condensed default skips `Hidden` properties. `--detailed` is the full per-property card with everything `--set` needs to pick a value.
-
-### Mapping from template property to BPMN XML
-
-| Template Binding | BPMN XML Element | Source/Target |
-|-----------------|------------------|---------------|
-| `zeebe:input` with `name: "url"` | `<zeebe:input source="..." target="url" />` | User value → `source` |
-| `zeebe:output` with `source: "= body"` | `<zeebe:output source="= body" target="..." />` | User value → `target` |
-| `zeebe:taskHeader` with `key: "resultExpression"` | `<zeebe:header key="resultExpression" value="..." />` | User value → `value` |
-| `zeebe:taskDefinition` with `property: "type"` | `<zeebe:taskDefinition type="..." />` | Fixed by template |
-
-### Example: Configuring an HTTP Connector
-
-Apply with values inline using `c8ctl element-template apply ... --set ...`. The template defines these key properties:
-
-```
-authentication.type  → zeebe:input, name="authentication.type"  (Dropdown: noAuth, basic, bearer, apiKey, oauth)
-method               → zeebe:input, name="method"               (Dropdown: GET, POST, PUT, DELETE, PATCH)
-url                  → zeebe:input, name="url"                  (String, feel: optional, required)
-headers              → zeebe:input, name="headers"              (String, feel: required, optional)
-body                 → zeebe:input, name="body"                 (Text, feel: optional, condition: method in POST/PUT/PATCH)
-resultVariable       → zeebe:taskHeader, key="resultVariable"   (String)
-resultExpression     → zeebe:taskHeader, key="resultExpression" (Text, feel: required)
-errorExpression      → zeebe:taskHeader, key="errorExpression"  (Text, feel: required)
-```
-
-Resulting BPMN XML for a GET request with bearer auth:
+Resulting BPMN (the `data:image/svg+xml;base64,...` icon blob is elided here for readability — leave it in place in the real file):
 
 ```xml
 <bpmn:serviceTask id="Task_FetchUser" name="Fetch user data"
   zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2"
-  zeebe:modelerTemplateVersion="12">
+  zeebe:modelerTemplateVersion="13"
+  zeebe:modelerTemplateIcon="data:image/svg+xml;base64,...">
   <bpmn:extensionElements>
     <zeebe:taskDefinition type="io.camunda:http-json:1" retries="3" />
     <zeebe:ioMapping>
@@ -346,15 +72,20 @@ Resulting BPMN XML for a GET request with bearer auth:
       <zeebe:input source="{{secrets.API_TOKEN}}" target="authentication.token" />
       <zeebe:input source="GET" target="method" />
       <zeebe:input source="=&quot;https://api.example.com/users/&quot; + string(userId)" target="url" />
-      <zeebe:input source="20" target="connectionTimeoutInSeconds" />
-      <zeebe:input source="20" target="readTimeoutInSeconds" />
     </zeebe:ioMapping>
     <zeebe:taskHeaders>
       <zeebe:header key="resultVariable" value="apiResponse" />
       <zeebe:header key="resultExpression" value="={user: response.body}" />
       <zeebe:header key="errorExpression" value="=if response.statusCode &gt;= 400 then bpmnError(&quot;HTTP_ERROR&quot;, string(response.statusCode)) else null" />
-      <zeebe:header key="retryBackoff" value="PT0S" />
     </zeebe:taskHeaders>
   </bpmn:extensionElements>
 </bpmn:serviceTask>
 ```
+
+Validate with `c8ctl bpmn lint process.bpmn` after applying.
+
+## Where to look next
+
+- Full element-template authoring schema (property types, all binding types, inbound variants, FEEL features, the field-ordering rule): `camunda-connectors-development/references/element-template-json.md`
+- Discovering OOTB templates: the main `SKILL.md` (`c8ctl element-template search` / `info` / `get-properties`)
+- Building a *custom* connector template: **camunda-connectors-development**


### PR DESCRIPTION
## Summary

- Adds the `camunda-connectors-development` skill (PR 3 of 3 in the connector / worker / dev-meta trio) covering both paths for building custom Camunda 8 connectors:
  - **Path A** — JSON-only element template layered on a protocol connector (REST, SOAP, GraphQL, Kafka, RabbitMQ, AWS messaging). No Java, no extra runtime.
  - **Path B** — Custom Java connector via the Connectors SDK; outbound (`OutboundConnectorProvider` + `@Operation`, plus the legacy `OutboundConnectorFunction`) and inbound (`InboundConnectorExecutable` for webhook / subscription / polling flavours).
- SKILL.md stays abstract per the [no-ref-duplication](../../tree/main/.claude/projects/-Users-mathias-geat-code-camunda-skills/memory) lesson from PR #9 — Path A vs B routing table, inbound flavour overview, registration-vs-hosting orthogonality, common pitfalls. No code snippets in the body.
- Six self-contained references own the concrete content: `protocol-connector-templates`, `connector-sdk-outbound`, `connector-sdk-inbound`, `element-template-json`, `element-template-generator`, `registration-and-hosting`.
- Reverse cross-refs from peer skills (`camunda-bpmn`, `camunda-process-mgmt`, `camunda-process-test`) into both new build skills are deferred to a follow-up sweep once PR #9 also lands.

## Test plan

- [x] `make lint SKILL=camunda-connectors-development` clean (spec 9/9, links 9/9, 2711/5000 tokens)
- [x] All technical claims verified against `docs.camunda.io` (connector-templates, create-connector-from-rest, connector-sdk, inbound use-connectors) before writing
- [x] Maven plugin config shapes verified against local connector reference poms (SPI shape from `jdbc/pom.xml`, Spring Bean shape from `agentic-ai/pom.xml`)
- [x] Field-ordering rule and URL constraint regex `^(=|(http://|https://|secrets|\{\{).*$)` captured verbatim from create-connector-from-rest docs
- [x] README + AGENTS rows added (AGENTS.md only — CLAUDE.md is a symlink)