### PR TITLE
chore: cross-ref the build skills from BPMN / process-mgmt / process-test

### DIFF
--- a/skills/camunda-bpmn/SKILL.md
+++ b/skills/camunda-bpmn/SKILL.md
@@ -24,6 +24,9 @@ Create and edit executable BPMN 2.0 processes for Camunda 8.8+. Generates valid 
 - **camunda-feel**: Use for FEEL expressions in gateway conditions, input/output mappings, timer definitions
 - **camunda-forms**: Use for creating Camunda Form JSON schemas linked to user tasks
 - **camunda-connectors**: Use for configuring pre-built connectors (REST, Slack, Kafka, etc.) via element templates
+- **camunda-development**: Use to decide whether a service task should be backed by an OOTB connector, a custom connector, or a job worker
+- **camunda-job-workers**: Use to implement the handler code that a service task's `zeebe:taskDefinition type` activates
+- **camunda-connectors-development**: Use to build a custom connector (JSON-only template or Java SDK) that attaches to a service task or event element
 - **camunda-process-test**: Use for testing processes against an embedded Zeebe engine
 - **camunda-process-mgmt**: Use for deploying to a cluster and running instances
 - **camunda-ai-agent**: Use when modeling an AI agent — ad-hoc subprocess hosting tools driven by the AI Agent connector

--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -24,6 +24,8 @@ Runtime operations for Camunda 8.8+ clusters via c8ctl: deploy resources, start 
 - **camunda-c8ctl**: Use for c8ctl install, profile management, local cluster operations, and cluster-safety rules
 - **camunda-bpmn**: Use for fixing BPMN process issues found during debugging
 - **camunda-connectors**: Use for fixing connector configuration issues found during debugging
+- **camunda-job-workers**: Use when an incident traces back to handler code rather than the process model — the worker side of `zeebe:taskDefinition type`
+- **camunda-connectors-development**: Use when an incident traces back to a custom connector's runtime / registration / hosting rather than its template configuration
 - **camunda-feel**: Use for diagnosing FEEL evaluation errors (EXTRACT_VALUE_ERROR, CONDITION_ERROR) in incidents
 - **camunda-process-test**: Use for testing processes against an embedded Zeebe engine
 

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -24,6 +24,8 @@ Author and run Camunda Process Test suites for Camunda 8.8+ that reach **100% BP
 
 - **camunda-bpmn**: Run `c8ctl bpmn lint` on the process under test before authoring scenarios — failing lints surface as deploy-time `@TestDeployment` failures.
 - **camunda-feel**: Use when a gateway condition or DMN entry is unclear; FEEL semantics drive which segment hits which branch.
+- **camunda-job-workers**: Use when the handler code that backs a service task is itself under test — CPT drives BPMN reachability; worker unit tests drive handler behaviour.
+- **camunda-connectors-development**: Use when a custom connector is the unit under test — CPT exercises it from the BPMN side; SDK-side tests cover the connector class directly.
 - **camunda-process-mgmt**: CPT runs against an **embedded** Zeebe engine — it does **not** use the c8ctl-managed cluster or any profile. No `c8ctl` call deploys a process under test.
 
 ## Scope boundaries


### PR DESCRIPTION
## Summary

- Reverse cross-refs from `camunda-bpmn`, `camunda-process-mgmt`, and `camunda-process-test` into the three dev-skill trio entries (`camunda-development`, `camunda-job-workers`, `camunda-connectors-development`).
- Name-only one-line pointers per the established style — no inline restatement, no section anchors.

## Test plan

- [x] \`make lint SKILL=camunda-bpmn\` → High
- [x] \`make lint SKILL=camunda-process-mgmt\` → High
- [x] \`make lint SKILL=camunda-process-test\` → High