### PR TITLE
feat(camunda-dmn): add DMN authoring skill with dmnlint loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ AI skills for Camunda 8.8+ development. Use these skills to create, deploy, and 
 | **camunda-docs** | Verifying a Camunda 8 technical fact against the official docs (FEEL signatures, BPMN extension shapes, API endpoints, version requirements) before writing it down |
 | **camunda-bpmn** | Creating or editing BPMN 2.0 processes (elements, flows, gateways, events, subprocesses) |
 | **camunda-feel** | Writing FEEL expressions (gateway conditions, input/output mappings, timer definitions) |
+| **camunda-dmn** | Authoring DMN decisions for business-rule tasks — decision tables (UNIQUE/ANY/FIRST/RULE ORDER/COLLECT), literal expressions, DRG linking, structural validation via `npx dmnlint` |
 | **camunda-forms** | Creating Camunda Form JSON schemas for user tasks |
 | **camunda-connectors** | Configuring pre-built connectors (REST, Slack, Kafka, etc.) via element templates |
 | **camunda-development** | Choosing between OOTB connectors, custom connector templates, custom Java connectors, and job workers before writing integration code |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ These skills follow the [Agent Skills](https://agentskills.io) open standard and
 | **camunda-docs** | Look up the official Camunda 8 docs via the camunda-docs MCP server (with `llms.txt` fallback) |
 | **camunda-bpmn** | Create and edit BPMN 2.0 processes for Camunda 8/Zeebe |
 | **camunda-feel** | Write and debug FEEL expressions |
+| **camunda-dmn** | Author DMN decisions — decision tables, hit policies, literal expressions, business-rule task wiring |
 | **camunda-forms** | Create Camunda Form JSON schemas for user tasks |
 | **camunda-connectors** | Browse and configure pre-built connectors via element templates |
 | **camunda-development** | Choose between OOTB connectors, custom connector templates, custom Java connectors, and job workers before writing integration code |

--- a/skills/camunda-bpmn/SKILL.md
+++ b/skills/camunda-bpmn/SKILL.md
@@ -22,6 +22,7 @@ Create and edit executable BPMN 2.0 processes for Camunda 8.8+. Generates valid 
 ## Cross-References
 
 - **camunda-feel**: Use for FEEL expressions in gateway conditions, input/output mappings, timer definitions
+- **camunda-dmn**: Use for authoring the DMN decision behind a business rule task — `<zeebe:calledDecision decisionId="..." resultVariable="..."/>`
 - **camunda-forms**: Use for creating Camunda Form JSON schemas linked to user tasks
 - **camunda-connectors**: Use for configuring pre-built connectors (REST, Slack, Kafka, etc.) via element templates
 - **camunda-development**: Use to decide whether a service task should be backed by an OOTB connector, a custom connector, or a job worker

--- a/skills/camunda-dmn/SKILL.md
+++ b/skills/camunda-dmn/SKILL.md
@@ -3,42 +3,31 @@ name: camunda-dmn
 description: |
   Use this skill to author and validate DMN (Decision Model and Notation) decisions for Camunda 8 — decision tables and literal expressions inside a Decision Requirements Diagram (DRD).
 
-  Use for: creating new DMN files, editing decision tables (inputs, outputs, rules, hit policies), authoring decision literal expressions, linking decisions via informationRequirement, wiring a business rule task in BPMN to a DMN decision, validating decision files structurally with `npx dmnlint` and behaviourally by execution (CPT preferred, deploy fallback).
+  Use for: creating or editing `.dmn` files, picking the right hit policy, wiring a business rule task in BPMN to a DMN decision, validating decisions structurally (`npx dmnlint`) and behaviourally (CPT preferred, deploy fallback).
 
-  Do not use for: writing FEEL syntax in detail (use camunda-feel), modelling the BPMN side of a business rule task (use camunda-bpmn), authoring CPT test scenarios that exercise the decision (use camunda-process-test), deploying DMN to a cluster outside the validation loop (use camunda-process-mgmt).
+  Do not use for: writing FEEL syntax in detail (use camunda-feel), modelling the BPMN around a business rule task (use camunda-bpmn), authoring CPT test scenarios (use camunda-process-test).
 
-  **Workflow skill** — DRD planning, decision-table authoring, then a two-stage validation loop: `npx dmnlint` for structure, CPT or deploy for behaviour.
+  **Workflow skill** — author the decision, lint it, run it.
 ---
 
 # Camunda DMN
 
-Author executable DMN 1.3 decisions for Camunda 8.8+. DMN files (`.dmn`) hold one Decision Requirements Diagram with one or more decisions; each decision contains either a decision table or a literal expression. A BPMN business rule task references a decision by ID and gets the decision result back as a process variable.
-
-## Prerequisites
-
-- Camunda 8.8+ cluster — local via c8run is recommended for the behaviour validation loop; SaaS or Self-Managed work too
-- Node.js + `npx` available for `dmnlint` (no install step — `npx --yes dmnlint` fetches on first run)
-- For the CPT behaviour path: Java 21+, Maven, Docker — see **camunda-process-test**
+Author executable DMN 1.3 decisions for Camunda 8.8+. A `.dmn` file holds one Decision Requirements Diagram with one or more decisions; each decision is either a decision table or a literal expression. A BPMN business rule task references a decision by ID and gets the result back as a process variable.
 
 ## Cross-References
 
-- **camunda-bpmn**: Use for the business rule task that calls the DMN decision (`<zeebe:calledDecision decisionId="..." resultVariable="..."/>`)
-- **camunda-feel**: Use for FEEL syntax in input expressions, output entries, and literal expressions
-- **camunda-process-test**: **Preferred behaviour validation path** — CPT runs the decision against an embedded Zeebe engine via the calling BPMN process. Fast feedback loop, no cluster needed.
-- **camunda-process-mgmt**: Fallback behaviour validation — deploy and run on a real cluster (prefer local c8run; safety check before any shared cluster)
-- **camunda-c8ctl**: Always pass `--profile=<name>` on deploy commands and confirm with the user before touching anything that isn't local c8run
+- **camunda-bpmn**: Business rule task wiring (`<zeebe:calledDecision decisionId="..." resultVariable="..."/>`)
+- **camunda-feel**: FEEL syntax inside input expressions, output entries, literal expressions
+- **camunda-process-test**: Preferred behaviour validation — CPT exercises the decision via the calling BPMN
+- **camunda-process-mgmt**: Fallback behaviour validation — deploy and run on a cluster (prefer local c8run)
 
-## Instructions
+## Authoring
 
-### XML structure
-
-Every DMN file declares the DMN 1.3 namespace and a `definitions` element (the Decision Requirements Graph) wrapping one or more `decision` elements:
+A DMN file declares the DMN 1.3 namespace and wraps one or more `<decision>` elements:
 
 ```xml
-<?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
-             id="DinnerDecisions"
-             name="Dinner Decisions"
+             id="DinnerDecisions" name="Dinner Decisions"
              namespace="http://camunda.org/schema/1.0/dmn">
   <decision id="dish" name="Dish">
     <decisionTable id="decisionTable_dish" hitPolicy="UNIQUE">
@@ -48,212 +37,33 @@ Every DMN file declares the DMN 1.3 namespace and a `definitions` element (the D
 </definitions>
 ```
 
-The default namespace `https://www.omg.org/spec/DMN/20191111/MODEL/` and the `namespace="http://camunda.org/schema/1.0/dmn"` attribute are mandatory for Camunda to recognise the file.
+The default namespace and the `namespace="http://camunda.org/schema/1.0/dmn"` attribute are mandatory.
 
-### IDs and names — strict rules
+A decision contains either a `<decisionTable>` (inputs / outputs / rules + hit policy) or a `<literalExpression>` (single FEEL expression — useful for combining upstream decisions). Multi-decision files link decisions with `<informationRequirement><requiredDecision href="#upstream"/></informationRequirement>`; Camunda evaluates only the root decision referenced from BPMN and pulls in required decisions transparently.
 
-- **Decision ID**, **output `name`**, and decision table column names: alphanumeric and `_` only. No whitespace, no `-`, no other special characters. `camelCase` or `snake_case`; `kebab-case` is rejected because `-` is a FEEL operator.
-- **`name` attributes** (the human-readable label shown in Modeler and lint output) can be any string. `dmnlint` flags missing `name` on every Decision, InputData, BusinessKnowledgeModel, KnowledgeSource, or DecisionService — set one even when an `id` already conveys intent.
-- An ID that violates these rules silently breaks dependent decisions and BPMN references — the value comes back as `null` at runtime.
+See [references/decision-tables.md](references/decision-tables.md) for the full XML of input/output clauses, unary-test grammar, worked examples per hit policy, COLLECT aggregators, type table, and DRG linking.
 
-### Decision tables
+### ID and naming rules
 
-A decision table consists of inputs (conditions), outputs (conclusions), rules (rows), and a hit policy.
+- **Decision `id`**, **output `name`**, decision-table column names: alphanumeric + `_` only. No whitespace, no `-` (which is a FEEL operator), no other special characters. A violation silently breaks BPMN references — the resolved value is `null` at runtime.
+- **`name` attributes** (Decision, InputData, BusinessKnowledgeModel, KnowledgeSource, DecisionService): any string. `dmnlint` flags missing `name` — set one even when `id` already conveys intent.
+- **String output entries must be quoted.** `"HIGH"` is a string literal; bare `HIGH` parses as a variable reference and evaluates to `null` — no parse error, no lint warning.
 
-**Inputs.** Each `input` clause has an `inputExpression` written in FEEL. The expression references a process variable available at evaluation time:
+### Hit policies (Camunda-supported set)
 
-```xml
-<input id="input_season" label="Season">
-  <inputExpression id="inputExpression_season" typeRef="string">
-    <text>season</text>
-  </inputExpression>
-</input>
-```
+Set on the `decisionTable` element (default `UNIQUE`). Camunda 8 supports five; the DMN spec defines more — `PRIORITY` and `OUTPUT ORDER` are **not** supported.
 
-`typeRef` is optional but recommended — it converts the evaluated input to the declared DMN data type (`string`, `number`, `boolean`, `date`, `time`, `dateTime`, `dayTimeDuration`, `yearMonthDuration`).
-
-**Outputs.** Each `output` clause defines a result column with a `name` (referenced by BPMN, must follow the ID rules above) and an optional `typeRef`:
-
-```xml
-<output id="output_dish" label="Dish" name="desiredDish" typeRef="string"/>
-```
-
-If the table has only **one output**, omit `name` — the BPMN process accesses the result directly via the decision ID. If the table has **multiple outputs**, give each a unique `name`; BPMN then accesses them via `decisionId.outputName`.
-
-**Rules.** Each `rule` is one row. Input entries are FEEL **unary tests** (e.g. `"Winter"`, `<= 8`, `[1..10]`, `not("Winter", "Spring")`, or `-` for "any value"). Output entries are full FEEL expressions:
-
-```xml
-<rule id="rule_winter_party">
-  <inputEntry id="ie_season"><text>"Winter"</text></inputEntry>
-  <inputEntry id="ie_guests"><text><![CDATA[<= 8]]></text></inputEntry>
-  <outputEntry id="oe_dish"><text>"Roastbeef"</text></outputEntry>
-</rule>
-```
-
-Wrap entries containing XML special characters (`<`, `>`, `&`) in `<![CDATA[...]]>` or escape them (`&lt;`, `&gt;`, `&amp;`).
-
-**Output strings must be quoted.** `"HIGH"` is a FEEL string literal; bare `HIGH` is parsed as a variable reference and evaluates to `null` at runtime — no parse error, no lint warning, just a silently-broken decision. Always quote string output entries.
-
-### Hit policies — Camunda-supported set
-
-The hit policy goes on the `decisionTable` element: `<decisionTable id="..." hitPolicy="UNIQUE">`. Default is `UNIQUE` when omitted.
-
-**Camunda 8 supports five hit policies** (the DMN spec defines more — Camunda does **not** support `PRIORITY` or `OUTPUT ORDER`):
-
-| Hit policy | Single/multi result | Behaviour |
+| Hit policy | Result | Behaviour |
 |---|---|---|
-| `UNIQUE` (default) | single | Exactly one rule must match. More than one match is a runtime error. Best when the table is meant to partition the input space without overlap. |
-| `ANY` | single | Multiple rules may match, but they must all produce the same output. Different outputs from overlapping rules → runtime error. Useful when several conditions converge on the same conclusion. |
-| `FIRST` | single | Rules evaluated top-to-bottom; the first match wins. Use when overlap is intentional and the order encodes priority (e.g. "blocklist first, then accept rules"). |
-| `RULE ORDER` | multi | All matching rules' outputs in rule order, as a list. |
-| `COLLECT` | multi | All matching rules' outputs in arbitrary order, as a list. Can be combined with an aggregator: `aggregation="SUM" \| "MIN" \| "MAX" \| "COUNT"` — collapses the list to a single value. |
+| `UNIQUE` | single | Exactly one rule must match; multi-match = runtime error. |
+| `ANY` | single | Multiple may match, must all produce the same output; otherwise runtime error. |
+| `FIRST` | single | Top-to-bottom; first match wins. |
+| `RULE ORDER` | list | All matching rules' outputs, in rule order. |
+| `COLLECT` | list / scalar | All matches in arbitrary order. With `aggregation="SUM" \| "MIN" \| "MAX" \| "COUNT"`, collapses to a single value. |
 
-Pick `UNIQUE` first; switch to `FIRST` only when the table has hard-then-soft semantics, and `COLLECT` (with or without aggregator) when you genuinely want a list back. See [references/decision-tables.md](references/decision-tables.md) for worked examples per hit policy.
+Default to `UNIQUE`. Use `FIRST` for hard-then-soft semantics (e.g. "blocklist first, then accept rules"). Use `COLLECT` when a list output is genuinely the goal. See [references/decision-tables.md](references/decision-tables.md) for worked examples per policy.
 
-### Decision literal expressions
-
-When a decision is a single FEEL expression rather than a table — for example, combining the outputs of two upstream decisions — use `literalExpression`:
-
-```xml
-<decision id="season" name="Season">
-  <variable name="season" typeRef="string"/>
-  <literalExpression>
-    <text>if month(date) in [12, 1, 2] then "Winter" else "Other"</text>
-  </literalExpression>
-</decision>
-```
-
-The `variable` element declares the result name and type. The `text` inside `literalExpression` is full FEEL.
-
-### Linking decisions (Decision Requirements Graph)
-
-One decision can depend on another. Declare the dependency with `informationRequirement` → `requiredDecision`:
-
-```xml
-<decision id="beverages" name="Beverages">
-  <informationRequirement>
-    <requiredDecision href="#dish"/>
-  </informationRequirement>
-  <decisionTable id="decisionTable_beverages">
-    <input id="input_dish" label="Dish">
-      <inputExpression id="inputExpression_dish" typeRef="string">
-        <text>dish</text>
-      </inputExpression>
-    </input>
-    <!-- ... -->
-  </decisionTable>
-</decision>
-```
-
-The required decision is evaluated first; its result is then in scope under its decision ID (or `decisionId.outputName` for multi-output tables). Camunda only evaluates the **root decision** referenced from BPMN — required decisions are pulled in transparently. Duplicate `informationRequirement` edges to the same upstream decision are flagged by `dmnlint` (`no-duplicate-requirements`) — keep one.
-
-### Wiring a business rule task in BPMN
-
-The BPMN side is a service-of-decision: a `bpmn:businessRuleTask` with `zeebe:calledDecision`:
-
-```xml
-<bpmn:businessRuleTask id="DecideMenu" name="Decide menu">
-  <bpmn:extensionElements>
-    <zeebe:calledDecision decisionId="beverages" resultVariable="menuChoice"/>
-  </bpmn:extensionElements>
-  <!-- incoming/outgoing flows -->
-</bpmn:businessRuleTask>
-```
-
-`decisionId` matches the DMN `decision id`. `resultVariable` is the process variable that receives the decision result. The structure of that variable depends on the hit policy — a single result for `UNIQUE`/`ANY`/`FIRST`, a list for `RULE ORDER`/`COLLECT` (or a scalar for `COLLECT` with aggregator).
-
-**`resultVariable` overwrites.** The decision result lands in the process variable named by `resultVariable`. If that name matches an existing input variable, the input is **clobbered**. Pick a distinct result name (e.g. `discountPercent` not `customer`) so downstream activities can still read the input.
-
-`<zeebe:calledDecision>` also accepts a `bindingType` attribute — `latest` (default), `deployment`, or `versionTag` — controlling which deployed version of the decision is resolved at runtime. See **camunda-bpmn** for the binding-type table; `deployment` is the right choice when BPMN and DMN are co-deployed.
-
-See **camunda-bpmn** for the surrounding BPMN structure.
-
-### Validation — two-stage loop
-
-DMN validation has two layers, both required before declaring a file done.
-
-#### Stage 1: structural lint — `dmnlint`
-
-Camunda's CI/CD guide ([docs.camunda.io › modeler › web-modeler › integrate-web-modeler-in-ci-cd](https://docs.camunda.io/docs/components/modeler/web-modeler/integrate-web-modeler-in-ci-cd/#test-stage)) recommends `dmnlint` alongside `bpmnlint` for verifying decision files in CI — the same library Web Modeler uses for inline validation.
-
-A DMN edit is **not structurally done** until `npx dmnlint` reports zero errors AND zero warnings. Treat this as the closing structural step of every DMN task.
-
-1. Ensure a `.dmnlintrc` exists in the project root (idempotent):
-
-   ```bash
-   [ -f .dmnlintrc ] || echo '{ "extends": "dmnlint:recommended" }' > .dmnlintrc
-   ```
-
-2. Run the linter against the file you touched:
-
-   ```bash
-   npx --yes dmnlint path/to/decision.dmn
-   ```
-
-   For a directory of DMN files, pass the discovered file list explicitly so build directories (`target/`, `build/`, `node_modules/`, `.git/`) are skipped.
-
-3. If output is non-empty, fix every reported issue and re-run. Common categories — see [references/dmnlint.md](references/dmnlint.md) for the full rule → fix mapping:
-
-   - **label-required** — add a descriptive `name` attribute to the flagged element
-   - **no-duplicate-requirements** — remove the duplicate `informationRequirement` / `knowledgeRequirement` / `authorityRequirement` edge
-
-4. Loop until the linter is clean. Do not advance to stage 2 while warnings remain — they typically point at modelling oversights (unnamed decisions, broken DRG references) that will produce confusing incidents at evaluation time.
-
-If a warning is genuinely a false positive, suppress it explicitly in `.dmnlintrc` and flag the suppression in your final message — never silently ignore.
-
-#### Stage 2: behaviour validation — by execution
-
-`dmnlint` catches structure, not runtime behaviour (FEEL errors, hit-policy violations, type mismatches, missing variables). Validate behaviour by **running the decision**.
-
-**Path A — Camunda Process Test (preferred).** If the repo already has a CPT setup, that's the best feedback loop — fastest, no cluster, embedded Zeebe runs the decision via the calling BPMN business rule task. Write or extend a `.test.json` scenario that exercises the rules that matter (each `UNIQUE` partition, each `FIRST` cascade, each `COLLECT` aggregator path) and run `mvn test`.
-
-See **camunda-process-test** for authoring scenarios and the segment-based coverage approach.
-
-**Path B — deploy and start an instance.** For ad-hoc validation or projects without CPT, deploy the BPMN + DMN together and start an instance with representative input. The cluster parses both files and evaluates the decision (catching FEEL errors, hit-policy violations, type mismatches).
-
-Cluster safety — prefer local c8run, always pass `--profile=` explicitly, confirm with the user before deploying to anything shared. See **camunda-process-mgmt** for the deploy-and-run flow and **camunda-c8ctl** for the cluster-safety rules.
-
-```bash
-c8ctl cluster status || c8ctl cluster start
-c8ctl deploy decision.dmn process.bpmn --profile=local
-c8ctl await pi --id MyProcess --variables '{"customer":{"tier":"gold"}}' --profile=local
-```
-
-If the instance raises an incident, inspect with `c8ctl search inc --state=ACTIVE` — `EXTRACT_VALUE_ERROR` points at a FEEL problem, `DECISION_EVALUATION_FAILED` at a hit-policy violation.
-
-Iterate: fix the DMN, re-lint, redeploy, restart.
-
-### Minimal worked example
-
-A two-rule table that drives a business rule task:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
-             id="DiscountDecisions" name="Discount Decisions"
-             namespace="http://camunda.org/schema/1.0/dmn">
-  <decision id="discount" name="Discount">
-    <decisionTable id="dt_discount" hitPolicy="UNIQUE">
-      <input id="input_tier" label="Customer tier">
-        <inputExpression id="ie_tier" typeRef="string">
-          <text>customer.tier</text>
-        </inputExpression>
-      </input>
-      <output id="output_discount" label="Discount %" name="discountPercent" typeRef="number"/>
-      <rule id="rule_gold">
-        <inputEntry id="ie_gold"><text>"gold"</text></inputEntry>
-        <outputEntry id="oe_gold"><text>15</text></outputEntry>
-      </rule>
-      <rule id="rule_silver">
-        <inputEntry id="ie_silver"><text>"silver"</text></inputEntry>
-        <outputEntry id="oe_silver"><text>5</text></outputEntry>
-      </rule>
-    </decisionTable>
-  </decision>
-</definitions>
-```
-
-BPMN side:
+## Wiring the BPMN side
 
 ```xml
 <bpmn:businessRuleTask id="ApplyDiscount" name="Apply discount">
@@ -263,12 +73,40 @@ BPMN side:
 </bpmn:businessRuleTask>
 ```
 
-Validate: `npx --yes dmnlint discount.dmn` → clean → deploy both files together with `c8ctl deploy ./*.dmn ./*.bpmn` (see **camunda-process-mgmt**).
+`decisionId` matches the DMN `decision id`. `resultVariable` receives the result — single-result for `UNIQUE`/`ANY`/`FIRST`, list for `RULE ORDER`/`COLLECT` (or scalar with aggregator).
+
+**`resultVariable` overwrites.** If the name matches an existing input variable, the input is clobbered — pick a distinct name (e.g. `discountPercent` not `customer`) so downstream activities can still read the input.
+
+`<zeebe:calledDecision>` also accepts `bindingType` — `latest` (default), `deployment`, `versionTag`. See **camunda-bpmn** for the binding-type table; `deployment` is the right choice when BPMN and DMN are co-deployed.
+
+## FEEL inside DMN
+
+DMN uses FEEL in `inputExpression`, `inputEntry` (unary tests), `outputEntry`, and `literalExpression`. Unlike BPMN, **no `=` prefix** — every `text` element is parsed as FEEL.
+
+Input entries use the **unary tests** subset: the input value is implicit, `< 5` means `? < 5`, comma-separated literals are OR, comma-separated comparisons are AND, ranges are `[1..10]` / `(1..10)`, `not(...)` negates, `-` matches anything.
+
+See [references/feel-in-dmn.md](references/feel-in-dmn.md) for the unary-test grammar, what you cannot do in a unary test, variable scope across linked decisions, and DMN-specific FEEL features.
+
+## Validation
+
+Two layers — run both before declaring a file done.
+
+**1. Structural lint.** A DMN edit is not structurally done until `npx dmnlint` reports zero issues.
+
+```bash
+[ -f .dmnlintrc ] || echo '{ "extends": "dmnlint:recommended" }' > .dmnlintrc
+npx --yes dmnlint path/to/decision.dmn
+```
+
+Common rules: `label-required` (add a `name`), `no-duplicate-requirements` (drop the duplicate `informationRequirement` edge). See [references/dmnlint.md](references/dmnlint.md) for the full rule → fix mapping.
+
+**2. Behaviour validation by execution.** `dmnlint` does not understand FEEL, hit-policy correctness, or type matches. Run the decision:
+
+- Preferred — write or extend a CPT scenario that exercises each `UNIQUE` partition / `FIRST` cascade / `COLLECT` path. See **camunda-process-test**.
+- Fallback — deploy `c8ctl deploy decision.dmn process.bpmn --profile=local` and start an instance with `c8ctl await pi --id MyProcess --variables '{...}' --profile=local`. Incidents surface as `EXTRACT_VALUE_ERROR` (FEEL problem) or `DECISION_EVALUATION_FAILED` (hit-policy violation). See **camunda-process-mgmt**.
 
 ## References
 
-For detailed reference material, read from `references/`:
-
-- [decision-tables.md](references/decision-tables.md) — input clauses, output clauses, FEEL unary tests, hit-policy worked examples, COLLECT aggregators, decision table data types
-- [feel-in-dmn.md](references/feel-in-dmn.md) — where FEEL appears in DMN, unary-tests grammar vs. full FEEL, variable scope across linked decisions
-- [dmnlint.md](references/dmnlint.md) — `dmnlint:recommended` rule set, rule → fix mapping, `.dmnlintrc` shape, CI integration
+- [decision-tables.md](references/decision-tables.md) — input/output clause shapes, unary-test forms, worked examples per hit policy, type table, pitfalls
+- [feel-in-dmn.md](references/feel-in-dmn.md) — FEEL contexts in DMN, unary-tests vs full FEEL, scope across linked decisions
+- [dmnlint.md](references/dmnlint.md) — `dmnlint:recommended` rules, rule → fix mapping, common pitfalls beyond what the linter catches

--- a/skills/camunda-dmn/SKILL.md
+++ b/skills/camunda-dmn/SKILL.md
@@ -105,8 +105,11 @@ Common rules: `label-required` (add a `name`), `no-duplicate-requirements` (drop
 - Preferred — write or extend a CPT scenario that exercises each `UNIQUE` partition / `FIRST` cascade / `COLLECT` path. See **camunda-process-test**.
 - Fallback — deploy `c8ctl deploy decision.dmn process.bpmn --profile=local` and start an instance with `c8ctl await pi --id MyProcess --variables '{...}' --profile=local`. Incidents surface as `EXTRACT_VALUE_ERROR` (FEEL problem) or `DECISION_EVALUATION_FAILED` (hit-policy violation). See **camunda-process-mgmt**.
 
+A green BPMN-completes test only proves the decision didn't fail — not that the right rules fired. For *behavioural correctness* assertions (`assertThatDecision`, rule-ordinal matching per hit policy, DRG coverage), see [references/testing-decisions.md](references/testing-decisions.md).
+
 ## References
 
-- [decision-tables.md](references/decision-tables.md) — input/output clause shapes, unary-test forms, worked examples per hit policy, type table, pitfalls
+- [decision-tables.md](references/decision-tables.md) — input/output clause shapes, unary-test forms, worked examples per hit policy, decision-level `<variable>` rules, type table, pitfalls
 - [feel-in-dmn.md](references/feel-in-dmn.md) — FEEL contexts in DMN, unary-tests vs full FEEL, scope across linked decisions
 - [dmnlint.md](references/dmnlint.md) — `dmnlint:recommended` rules, rule → fix mapping, common pitfalls beyond what the linter catches
+- [testing-decisions.md](references/testing-decisions.md) — `assertThatDecision`, rule-ordinal matching, strategy by hit policy, DRG coverage, mock-vs-test

--- a/skills/camunda-dmn/SKILL.md
+++ b/skills/camunda-dmn/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: camunda-dmn
+description: |
+  Use this skill to author and validate DMN (Decision Model and Notation) decisions for Camunda 8 — decision tables and literal expressions inside a Decision Requirements Diagram (DRD).
+
+  Use for: creating new DMN files, editing decision tables (inputs, outputs, rules, hit policies), authoring decision literal expressions, linking decisions via informationRequirement, wiring a business rule task in BPMN to a DMN decision, validating decision files structurally with `npx dmnlint` and behaviourally by execution (CPT preferred, deploy fallback).
+
+  Do not use for: writing FEEL syntax in detail (use camunda-feel), modelling the BPMN side of a business rule task (use camunda-bpmn), authoring CPT test scenarios that exercise the decision (use camunda-process-test), deploying DMN to a cluster outside the validation loop (use camunda-process-mgmt).
+
+  **Workflow skill** — DRD planning, decision-table authoring, then a two-stage validation loop: `npx dmnlint` for structure, CPT or deploy for behaviour.
+---
+
+# Camunda DMN
+
+Author executable DMN 1.3 decisions for Camunda 8.8+. DMN files (`.dmn`) hold one Decision Requirements Diagram with one or more decisions; each decision contains either a decision table or a literal expression. A BPMN business rule task references a decision by ID and gets the decision result back as a process variable.
+
+## Prerequisites
+
+- Camunda 8.8+ cluster — local via c8run is recommended for the behaviour validation loop; SaaS or Self-Managed work too
+- Node.js + `npx` available for `dmnlint` (no install step — `npx --yes dmnlint` fetches on first run)
+- For the CPT behaviour path: Java 21+, Maven, Docker — see **camunda-process-test**
+
+## Cross-References
+
+- **camunda-bpmn**: Use for the business rule task that calls the DMN decision (`<zeebe:calledDecision decisionId="..." resultVariable="..."/>`)
+- **camunda-feel**: Use for FEEL syntax in input expressions, output entries, and literal expressions
+- **camunda-process-test**: **Preferred behaviour validation path** — CPT runs the decision against an embedded Zeebe engine via the calling BPMN process. Fast feedback loop, no cluster needed.
+- **camunda-process-mgmt**: Fallback behaviour validation — deploy and run on a real cluster (prefer local c8run; safety check before any shared cluster)
+- **camunda-c8ctl**: Always pass `--profile=<name>` on deploy commands and confirm with the user before touching anything that isn't local c8run
+
+## Instructions
+
+### XML structure
+
+Every DMN file declares the DMN 1.3 namespace and a `definitions` element (the Decision Requirements Graph) wrapping one or more `decision` elements:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="DinnerDecisions"
+             name="Dinner Decisions"
+             namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="dish" name="Dish">
+    <decisionTable id="decisionTable_dish" hitPolicy="UNIQUE">
+      <!-- inputs, outputs, rules -->
+    </decisionTable>
+  </decision>
+</definitions>
+```
+
+The default namespace `https://www.omg.org/spec/DMN/20191111/MODEL/` and the `namespace="http://camunda.org/schema/1.0/dmn"` attribute are mandatory for Camunda to recognise the file.
+
+### IDs and names — strict rules
+
+- **Decision ID**, **output `name`**, and decision table column names: alphanumeric and `_` only. No whitespace, no `-`, no other special characters. `camelCase` or `snake_case`; `kebab-case` is rejected because `-` is a FEEL operator.
+- **`name` attributes** (the human-readable label shown in Modeler and lint output) can be any string. `dmnlint` flags missing `name` on every Decision, InputData, BusinessKnowledgeModel, KnowledgeSource, or DecisionService — set one even when an `id` already conveys intent.
+- An ID that violates these rules silently breaks dependent decisions and BPMN references — the value comes back as `null` at runtime.
+
+### Decision tables
+
+A decision table consists of inputs (conditions), outputs (conclusions), rules (rows), and a hit policy.
+
+**Inputs.** Each `input` clause has an `inputExpression` written in FEEL. The expression references a process variable available at evaluation time:
+
+```xml
+<input id="input_season" label="Season">
+  <inputExpression id="inputExpression_season" typeRef="string">
+    <text>season</text>
+  </inputExpression>
+</input>
+```
+
+`typeRef` is optional but recommended — it converts the evaluated input to the declared DMN data type (`string`, `number`, `boolean`, `date`, `time`, `dateTime`, `dayTimeDuration`, `yearMonthDuration`).
+
+**Outputs.** Each `output` clause defines a result column with a `name` (referenced by BPMN, must follow the ID rules above) and an optional `typeRef`:
+
+```xml
+<output id="output_dish" label="Dish" name="desiredDish" typeRef="string"/>
+```
+
+If the table has only **one output**, omit `name` — the BPMN process accesses the result directly via the decision ID. If the table has **multiple outputs**, give each a unique `name`; BPMN then accesses them via `decisionId.outputName`.
+
+**Rules.** Each `rule` is one row. Input entries are FEEL **unary tests** (e.g. `"Winter"`, `<= 8`, `[1..10]`, `not("Winter", "Spring")`, or `-` for "any value"). Output entries are full FEEL expressions:
+
+```xml
+<rule id="rule_winter_party">
+  <inputEntry id="ie_season"><text>"Winter"</text></inputEntry>
+  <inputEntry id="ie_guests"><text><![CDATA[<= 8]]></text></inputEntry>
+  <outputEntry id="oe_dish"><text>"Roastbeef"</text></outputEntry>
+</rule>
+```
+
+Wrap entries containing XML special characters (`<`, `>`, `&`) in `<![CDATA[...]]>` or escape them (`&lt;`, `&gt;`, `&amp;`).
+
+**Output strings must be quoted.** `"HIGH"` is a FEEL string literal; bare `HIGH` is parsed as a variable reference and evaluates to `null` at runtime — no parse error, no lint warning, just a silently-broken decision. Always quote string output entries.
+
+### Hit policies — Camunda-supported set
+
+The hit policy goes on the `decisionTable` element: `<decisionTable id="..." hitPolicy="UNIQUE">`. Default is `UNIQUE` when omitted.
+
+**Camunda 8 supports five hit policies** (the DMN spec defines more — Camunda does **not** support `PRIORITY` or `OUTPUT ORDER`):
+
+| Hit policy | Single/multi result | Behaviour |
+|---|---|---|
+| `UNIQUE` (default) | single | Exactly one rule must match. More than one match is a runtime error. Best when the table is meant to partition the input space without overlap. |
+| `ANY` | single | Multiple rules may match, but they must all produce the same output. Different outputs from overlapping rules → runtime error. Useful when several conditions converge on the same conclusion. |
+| `FIRST` | single | Rules evaluated top-to-bottom; the first match wins. Use when overlap is intentional and the order encodes priority (e.g. "blocklist first, then accept rules"). |
+| `RULE ORDER` | multi | All matching rules' outputs in rule order, as a list. |
+| `COLLECT` | multi | All matching rules' outputs in arbitrary order, as a list. Can be combined with an aggregator: `aggregation="SUM" \| "MIN" \| "MAX" \| "COUNT"` — collapses the list to a single value. |
+
+Pick `UNIQUE` first; switch to `FIRST` only when the table has hard-then-soft semantics, and `COLLECT` (with or without aggregator) when you genuinely want a list back. See [references/decision-tables.md](references/decision-tables.md) for worked examples per hit policy.
+
+### Decision literal expressions
+
+When a decision is a single FEEL expression rather than a table — for example, combining the outputs of two upstream decisions — use `literalExpression`:
+
+```xml
+<decision id="season" name="Season">
+  <variable name="season" typeRef="string"/>
+  <literalExpression>
+    <text>if month(date) in [12, 1, 2] then "Winter" else "Other"</text>
+  </literalExpression>
+</decision>
+```
+
+The `variable` element declares the result name and type. The `text` inside `literalExpression` is full FEEL.
+
+### Linking decisions (Decision Requirements Graph)
+
+One decision can depend on another. Declare the dependency with `informationRequirement` → `requiredDecision`:
+
+```xml
+<decision id="beverages" name="Beverages">
+  <informationRequirement>
+    <requiredDecision href="#dish"/>
+  </informationRequirement>
+  <decisionTable id="decisionTable_beverages">
+    <input id="input_dish" label="Dish">
+      <inputExpression id="inputExpression_dish" typeRef="string">
+        <text>dish</text>
+      </inputExpression>
+    </input>
+    <!-- ... -->
+  </decisionTable>
+</decision>
+```
+
+The required decision is evaluated first; its result is then in scope under its decision ID (or `decisionId.outputName` for multi-output tables). Camunda only evaluates the **root decision** referenced from BPMN — required decisions are pulled in transparently. Duplicate `informationRequirement` edges to the same upstream decision are flagged by `dmnlint` (`no-duplicate-requirements`) — keep one.
+
+### Wiring a business rule task in BPMN
+
+The BPMN side is a service-of-decision: a `bpmn:businessRuleTask` with `zeebe:calledDecision`:
+
+```xml
+<bpmn:businessRuleTask id="DecideMenu" name="Decide menu">
+  <bpmn:extensionElements>
+    <zeebe:calledDecision decisionId="beverages" resultVariable="menuChoice"/>
+  </bpmn:extensionElements>
+  <!-- incoming/outgoing flows -->
+</bpmn:businessRuleTask>
+```
+
+`decisionId` matches the DMN `decision id`. `resultVariable` is the process variable that receives the decision result. The structure of that variable depends on the hit policy — a single result for `UNIQUE`/`ANY`/`FIRST`, a list for `RULE ORDER`/`COLLECT` (or a scalar for `COLLECT` with aggregator).
+
+**`resultVariable` overwrites.** The decision result lands in the process variable named by `resultVariable`. If that name matches an existing input variable, the input is **clobbered**. Pick a distinct result name (e.g. `discountPercent` not `customer`) so downstream activities can still read the input.
+
+`<zeebe:calledDecision>` also accepts a `bindingType` attribute — `latest` (default), `deployment`, or `versionTag` — controlling which deployed version of the decision is resolved at runtime. See **camunda-bpmn** for the binding-type table; `deployment` is the right choice when BPMN and DMN are co-deployed.
+
+See **camunda-bpmn** for the surrounding BPMN structure.
+
+### Validation — two-stage loop
+
+DMN validation has two layers, both required before declaring a file done.
+
+#### Stage 1: structural lint — `dmnlint`
+
+Camunda's CI/CD guide ([docs.camunda.io › modeler › web-modeler › integrate-web-modeler-in-ci-cd](https://docs.camunda.io/docs/components/modeler/web-modeler/integrate-web-modeler-in-ci-cd/#test-stage)) recommends `dmnlint` alongside `bpmnlint` for verifying decision files in CI — the same library Web Modeler uses for inline validation.
+
+A DMN edit is **not structurally done** until `npx dmnlint` reports zero errors AND zero warnings. Treat this as the closing structural step of every DMN task.
+
+1. Ensure a `.dmnlintrc` exists in the project root (idempotent):
+
+   ```bash
+   [ -f .dmnlintrc ] || echo '{ "extends": "dmnlint:recommended" }' > .dmnlintrc
+   ```
+
+2. Run the linter against the file you touched:
+
+   ```bash
+   npx --yes dmnlint path/to/decision.dmn
+   ```
+
+   For a directory of DMN files, pass the discovered file list explicitly so build directories (`target/`, `build/`, `node_modules/`, `.git/`) are skipped.
+
+3. If output is non-empty, fix every reported issue and re-run. Common categories — see [references/dmnlint.md](references/dmnlint.md) for the full rule → fix mapping:
+
+   - **label-required** — add a descriptive `name` attribute to the flagged element
+   - **no-duplicate-requirements** — remove the duplicate `informationRequirement` / `knowledgeRequirement` / `authorityRequirement` edge
+
+4. Loop until the linter is clean. Do not advance to stage 2 while warnings remain — they typically point at modelling oversights (unnamed decisions, broken DRG references) that will produce confusing incidents at evaluation time.
+
+If a warning is genuinely a false positive, suppress it explicitly in `.dmnlintrc` and flag the suppression in your final message — never silently ignore.
+
+#### Stage 2: behaviour validation — by execution
+
+`dmnlint` catches structure, not runtime behaviour (FEEL errors, hit-policy violations, type mismatches, missing variables). Validate behaviour by **running the decision**.
+
+**Path A — Camunda Process Test (preferred).** If the repo already has a CPT setup, that's the best feedback loop — fastest, no cluster, embedded Zeebe runs the decision via the calling BPMN business rule task. Write or extend a `.test.json` scenario that exercises the rules that matter (each `UNIQUE` partition, each `FIRST` cascade, each `COLLECT` aggregator path) and run `mvn test`.
+
+See **camunda-process-test** for authoring scenarios and the segment-based coverage approach.
+
+**Path B — deploy and start an instance.** For ad-hoc validation or projects without CPT, deploy the BPMN + DMN together and start an instance with representative input. The cluster parses both files and evaluates the decision (catching FEEL errors, hit-policy violations, type mismatches).
+
+Cluster safety — prefer local c8run, always pass `--profile=` explicitly, confirm with the user before deploying to anything shared. See **camunda-process-mgmt** for the deploy-and-run flow and **camunda-c8ctl** for the cluster-safety rules.
+
+```bash
+c8ctl cluster status || c8ctl cluster start
+c8ctl deploy decision.dmn process.bpmn --profile=local
+c8ctl await pi --id MyProcess --variables '{"customer":{"tier":"gold"}}' --profile=local
+```
+
+If the instance raises an incident, inspect with `c8ctl search inc --state=ACTIVE` — `EXTRACT_VALUE_ERROR` points at a FEEL problem, `DECISION_EVALUATION_FAILED` at a hit-policy violation.
+
+Iterate: fix the DMN, re-lint, redeploy, restart.
+
+### Minimal worked example
+
+A two-rule table that drives a business rule task:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="DiscountDecisions" name="Discount Decisions"
+             namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="discount" name="Discount">
+    <decisionTable id="dt_discount" hitPolicy="UNIQUE">
+      <input id="input_tier" label="Customer tier">
+        <inputExpression id="ie_tier" typeRef="string">
+          <text>customer.tier</text>
+        </inputExpression>
+      </input>
+      <output id="output_discount" label="Discount %" name="discountPercent" typeRef="number"/>
+      <rule id="rule_gold">
+        <inputEntry id="ie_gold"><text>"gold"</text></inputEntry>
+        <outputEntry id="oe_gold"><text>15</text></outputEntry>
+      </rule>
+      <rule id="rule_silver">
+        <inputEntry id="ie_silver"><text>"silver"</text></inputEntry>
+        <outputEntry id="oe_silver"><text>5</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>
+```
+
+BPMN side:
+
+```xml
+<bpmn:businessRuleTask id="ApplyDiscount" name="Apply discount">
+  <bpmn:extensionElements>
+    <zeebe:calledDecision decisionId="discount" resultVariable="discountPercent"/>
+  </bpmn:extensionElements>
+</bpmn:businessRuleTask>
+```
+
+Validate: `npx --yes dmnlint discount.dmn` → clean → deploy both files together with `c8ctl deploy ./*.dmn ./*.bpmn` (see **camunda-process-mgmt**).
+
+## References
+
+For detailed reference material, read from `references/`:
+
+- [decision-tables.md](references/decision-tables.md) — input clauses, output clauses, FEEL unary tests, hit-policy worked examples, COLLECT aggregators, decision table data types
+- [feel-in-dmn.md](references/feel-in-dmn.md) — where FEEL appears in DMN, unary-tests grammar vs. full FEEL, variable scope across linked decisions
+- [dmnlint.md](references/dmnlint.md) — `dmnlint:recommended` rule set, rule → fix mapping, `.dmnlintrc` shape, CI integration

--- a/skills/camunda-dmn/references/decision-tables.md
+++ b/skills/camunda-dmn/references/decision-tables.md
@@ -1,0 +1,202 @@
+# Decision table reference
+
+Detailed reference for decision-table authoring beyond the SKILL.md basics.
+
+## Input clauses
+
+An `input` defines one column of conditions. The `inputExpression` is a FEEL expression (full FEEL, not unary tests) evaluated once per evaluation; its result is then compared against each rule's `inputEntry`.
+
+```xml
+<input id="input_amount" label="Order amount">
+  <inputExpression id="ie_amount" typeRef="number">
+    <text>order.totalAmount</text>
+  </inputExpression>
+</input>
+```
+
+- `text` is the FEEL expression. It usually references a variable from the process scope; it can also be a derived expression (`order.totalAmount * exchangeRate`).
+- `typeRef` declares the DMN data type. After evaluation, the result is converted to that type. Mismatches surface at evaluation time.
+- `label` is a human-readable column header shown in Modeler. The input expression is what the engine uses.
+
+A decision table with no inputs is legal — it always evaluates the same rule (useful for environment-flag decisions).
+
+## Output clauses
+
+```xml
+<output id="output_discount" label="Discount %" name="discountPercent" typeRef="number"/>
+```
+
+- `name` is the result key. It must be alphanumeric + `_`. Required when the table has more than one output; if only one output, leave `name` off and the BPMN process accesses the value directly via the decision ID.
+- `typeRef` validates output entries against the declared type.
+- Order: list outputs in the order rules will produce values; rule `outputEntry` elements bind positionally to outputs.
+
+When a multi-output table is referenced as a required decision, results are grouped under the decision ID: `dish.desiredDish`, `dish.preparationTime`.
+
+## Input entries — FEEL unary tests
+
+Input entries use the **unary tests** subset of FEEL. The implicit subject is the input value; the entry returns `true` if the value matches.
+
+| Form | Matches when input is | Example |
+|---|---|---|
+| `"Winter"` | equal to `"Winter"` | exact string match |
+| `42` | equal to `42` | exact number match |
+| `<= 8` | less than or equal to 8 | comparison |
+| `>= 18, < 65` | both: `>= 18 AND < 65` | comma = AND |
+| `"a", "b"` | `"a"` OR `"b"` | list of literals = OR |
+| `[1..10]` | in range 1 to 10 inclusive | closed range |
+| `(0..100)` | greater than 0 AND less than 100 | open range |
+| `[0..100)` | `>= 0` AND `< 100` | mixed open/closed |
+| `not("a", "b")` | neither `"a"` nor `"b"` | negation over a list |
+| `-` | always | wildcard |
+| (empty `<text/>`) | always | XML form of wildcard |
+
+Other forms:
+
+- **Variable comparison**: `< someVariable` works if the variable is in scope.
+- **FEEL function calls**: `starts with("PREFIX-")`, `contains(name, "smith")` (the implicit input fills the first argument when relevant — but explicit calls are clearer).
+- **Date / duration**: `< date("2026-01-01")`, `>= duration("P30D")`.
+
+The unary-tests grammar is narrower than full FEEL — see [feel-in-dmn.md](feel-in-dmn.md) for the exact subset.
+
+## Output entries — full FEEL
+
+Output entries are full FEEL expressions:
+
+```xml
+<outputEntry id="oe_invoice"><text>{ amount: input.amount * 1.19, currency: "EUR" }</text></outputEntry>
+```
+
+Any FEEL expression that evaluates to a value of the output's `typeRef` is valid: literals, variable references, arithmetic, function calls, contexts, lists. String literals **must** be quoted — bare identifiers are parsed as variable references.
+
+## Hit policies — worked examples
+
+### UNIQUE (default)
+
+Use when the table partitions the input space without overlap.
+
+```xml
+<decisionTable id="dt_tier" hitPolicy="UNIQUE">
+  <input id="i_age" label="Age">
+    <inputExpression typeRef="number"><text>age</text></inputExpression>
+  </input>
+  <output id="o_tier" label="Tier" name="tier" typeRef="string"/>
+  <rule><inputEntry><text><![CDATA[< 18]]></text></inputEntry><outputEntry><text>"minor"</text></outputEntry></rule>
+  <rule><inputEntry><text>[18..64]</text></inputEntry><outputEntry><text>"adult"</text></outputEntry></rule>
+  <rule><inputEntry><text><![CDATA[>= 65]]></text></inputEntry><outputEntry><text>"senior"</text></outputEntry></rule>
+</decisionTable>
+```
+
+If two rules can both match (e.g. an off-by-one in ranges), the engine raises an incident at runtime. Treat `UNIQUE` as a contract.
+
+### ANY
+
+Multiple rules may match, but they must all return the same output. Useful when several conditions imply the same conclusion:
+
+```xml
+<decisionTable hitPolicy="ANY">
+  <input label="Vacation days left"><inputExpression typeRef="number"><text>daysLeft</text></inputExpression></input>
+  <input label="Probation"><inputExpression typeRef="boolean"><text>probation</text></inputExpression></input>
+  <output name="approval" typeRef="string"/>
+  <rule><inputEntry><text>0</text></inputEntry><inputEntry><text>-</text></inputEntry><outputEntry><text>"refused"</text></outputEntry></rule>
+  <rule><inputEntry><text>-</text></inputEntry><inputEntry><text>true</text></inputEntry><outputEntry><text>"refused"</text></outputEntry></rule>
+  <rule><inputEntry><text><![CDATA[> 0]]></text></inputEntry><inputEntry><text>false</text></inputEntry><outputEntry><text>"approved"</text></outputEntry></rule>
+</decisionTable>
+```
+
+If overlapping rules produce different outputs at runtime, the engine raises an incident.
+
+### FIRST
+
+Top-to-bottom evaluation, first match wins. Use for hard-then-soft semantics:
+
+```xml
+<decisionTable hitPolicy="FIRST">
+  <input label="Customer"><inputExpression typeRef="string"><text>customer.id</text></inputExpression></input>
+  <input label="Credit score"><inputExpression typeRef="number"><text>creditScore</text></inputExpression></input>
+  <output name="decision" typeRef="string"/>
+  <rule><inputEntry><text>blocklist[item = customer.id] != null</text></inputEntry><inputEntry><text>-</text></inputEntry><outputEntry><text>"refused"</text></outputEntry></rule>
+  <rule><inputEntry><text>-</text></inputEntry><inputEntry><text><![CDATA[>= 700]]></text></inputEntry><outputEntry><text>"approved"</text></outputEntry></rule>
+  <rule><inputEntry><text>-</text></inputEntry><inputEntry><text>-</text></inputEntry><outputEntry><text>"refused"</text></outputEntry></rule>
+</decisionTable>
+```
+
+A catch-all final row makes the no-match path explicit. Without it, `FIRST` returns `null` when nothing matches.
+
+### RULE ORDER
+
+Returns all matching rules' outputs as a list, in rule order:
+
+```xml
+<decisionTable hitPolicy="RULE ORDER">
+  <input label="Age"><inputExpression typeRef="number"><text>age</text></inputExpression></input>
+  <output name="ad" typeRef="string"/>
+  <rule><inputEntry><text><![CDATA[>= 18]]></text></inputEntry><outputEntry><text>"Cars"</text></outputEntry></rule>
+  <rule><inputEntry><text><![CDATA[< 25]]></text></inputEntry><outputEntry><text>"Music"</text></outputEntry></rule>
+  <rule><inputEntry><text><![CDATA[> 12]]></text></inputEntry><outputEntry><text>"Gaming"</text></outputEntry></rule>
+</decisionTable>
+```
+
+For age 19, the BPMN result is `["Cars", "Music", "Gaming"]`.
+
+### COLLECT
+
+Returns all matching rules' outputs in **arbitrary order** as a list. Functionally similar to `RULE ORDER` when order does not matter — `COLLECT` is the right choice for permissions / groups / tags:
+
+```xml
+<decisionTable hitPolicy="COLLECT">
+  <input label="Order amount"><inputExpression typeRef="number"><text>amount</text></inputExpression></input>
+  <output name="reviewer" typeRef="string"/>
+  <rule><inputEntry><text><![CDATA[>= 1000]]></text></inputEntry><outputEntry><text>"sales"</text></outputEntry></rule>
+  <rule><inputEntry><text><![CDATA[>= 10000]]></text></inputEntry><outputEntry><text>"management"</text></outputEntry></rule>
+</decisionTable>
+```
+
+For amount 15000, both rules match; result is a list `["sales", "management"]` (order not guaranteed).
+
+### COLLECT with aggregators
+
+Add `aggregation="SUM" | "MIN" | "MAX" | "COUNT"` to collapse the list into a single value:
+
+```xml
+<decisionTable hitPolicy="COLLECT" aggregation="SUM">
+  <input label="Years at company"><inputExpression typeRef="number"><text>years</text></inputExpression></input>
+  <output name="bonus" typeRef="number"/>
+  <rule><inputEntry><text><![CDATA[>= 1]]></text></inputEntry><outputEntry><text>100</text></outputEntry></rule>
+  <rule><inputEntry><text><![CDATA[>= 3]]></text></inputEntry><outputEntry><text>200</text></outputEntry></rule>
+  <rule><inputEntry><text><![CDATA[>= 5]]></text></inputEntry><outputEntry><text>300</text></outputEntry></rule>
+</decisionTable>
+```
+
+For 4 years, rules 1 and 2 match; `SUM` aggregator returns `300`.
+
+`COLLECT` with aggregator requires the output to be a numeric type for `SUM`/`MIN`/`MAX`; `COUNT` works for any type and returns the number of matches.
+
+### Hit policies Camunda does NOT support
+
+The DMN spec defines `PRIORITY` and `OUTPUT ORDER`. **Camunda 8 does not support these.** If you need priority-based selection, use `COLLECT` and post-process the list in the calling BPMN — e.g. with a FEEL script task that selects by a priority field.
+
+## DMN data types
+
+`typeRef` accepts:
+
+| Type | FEEL literal | Notes |
+|---|---|---|
+| `string` | `"text"` | |
+| `number` | `42`, `3.14` | |
+| `boolean` | `true`, `false` | |
+| `date` | `date("2026-01-01")` | ISO 8601 |
+| `time` | `time("14:30:00")` | |
+| `dateTime` | `date and time("2026-01-01T14:30:00")` | |
+| `dayTimeDuration` | `duration("P30D")` | days/hours/minutes/seconds |
+| `yearMonthDuration` | `duration("P1Y6M")` | years/months |
+
+Type-checking is best-effort — DMN converts where it can and raises a runtime error where it cannot. Declare `typeRef` to catch shape mismatches early.
+
+## Common pitfalls
+
+- **Unquoted string output**: `HIGH` instead of `"HIGH"` parses as a variable reference and evaluates to `null` at runtime. `dmnlint` does not catch this; behaviour validation does.
+- **`null` result from BPMN**: the `resultVariable` name and decision ID/output name don't match (case-sensitive), or the ID/output name contains a forbidden character (`-`, whitespace) so the engine can't resolve it.
+- **`resultVariable` clobbering**: pick a name distinct from any input variable — DMN overwrites silently.
+- **Input wildcard inconsistency**: `-` and an empty `<text/>` both mean "any value" but mixing them in a file is noisy. Pick one — `-` is the conventional form in Modeler-generated DMN.
+- **CDATA wrapping**: input entries containing `<`, `>`, `&` should be wrapped in `<![CDATA[...]]>` to avoid XML escaping confusion. `<= 8` becomes `<![CDATA[<= 8]]>`.
+- **Hit policy violations at runtime, not deploy**: `UNIQUE` / `ANY` violations only surface when input data matches multiple rules. Test the table with the values that exercise overlap, not just the happy path.

--- a/skills/camunda-dmn/references/decision-tables.md
+++ b/skills/camunda-dmn/references/decision-tables.md
@@ -153,6 +153,36 @@ Returns all matching rules' outputs in **arbitrary order** as a list. Functional
 
 For amount 15000, both rules match; result is a list `["sales", "management"]` (order not guaranteed).
 
+### Worked example: BPMN-calls-COLLECT
+
+End-to-end pattern when a process needs a list of dishes routed by season:
+
+DMN (single output, no decision-level `<variable>` — see the next section for why):
+
+```xml
+<decision id="dish" name="Dish">
+  <decisionTable id="dt_dish" hitPolicy="COLLECT">
+    <input id="i_season"><inputExpression typeRef="string"><text>season</text></inputExpression></input>
+    <output id="o_dish" label="Dish" name="dishName" typeRef="string"/>
+    <rule><inputEntry><text>"Winter"</text></inputEntry><outputEntry><text>"Tortellini"</text></outputEntry></rule>
+    <rule><inputEntry><text>"Winter"</text></inputEntry><outputEntry><text>"Roastbeef"</text></outputEntry></rule>
+    <rule><inputEntry><text>"Summer"</text></inputEntry><outputEntry><text>"Gazpacho"</text></outputEntry></rule>
+  </decisionTable>
+</decision>
+```
+
+BPMN business rule task:
+
+```xml
+<bpmn:businessRuleTask id="ChooseDishes" name="Choose dishes">
+  <bpmn:extensionElements>
+    <zeebe:calledDecision decisionId="dish" resultVariable="candidateDishes"/>
+  </bpmn:extensionElements>
+</bpmn:businessRuleTask>
+```
+
+After evaluation with `season = "Winter"`, the process variable is `candidateDishes: ["Tortellini", "Roastbeef"]` — a list, in arbitrary order. Downstream FEEL can iterate, e.g. `=candidateDishes[1]` (first element) or `=count(candidateDishes)`.
+
 ### COLLECT with aggregators
 
 Add `aggregation="SUM" | "MIN" | "MAX" | "COUNT"` to collapse the list into a single value:
@@ -174,6 +204,24 @@ For 4 years, rules 1 and 2 match; `SUM` aggregator returns `300`.
 ### Hit policies Camunda does NOT support
 
 The DMN spec defines `PRIORITY` and `OUTPUT ORDER`. **Camunda 8 does not support these.** If you need priority-based selection, use `COLLECT` and post-process the list in the calling BPMN — e.g. with a FEEL script task that selects by a priority field.
+
+## Decision-level `<variable>` declarations
+
+A decision can carry a `<variable name="..." typeRef="..."/>` element that declares the result name and type. The rules differ between literal expressions and decision tables — getting the shape wrong is a `DECISION_EVALUATION_ERROR` at runtime, not a lint warning.
+
+**Literal expressions:** `<variable>` is mandatory. `typeRef` is the type of the single value the expression evaluates to.
+
+**Decision tables:** `<variable>` is optional. If present, `typeRef` must match the actual return shape:
+
+| Hit policy | Single-output return | Multi-output return |
+|---|---|---|
+| `UNIQUE` / `ANY` / `FIRST` | scalar (`string`, `number`, …) | context |
+| `RULE ORDER` / `COLLECT` (no aggregator) | **list** — DMN has no `list<T>` syntax, so omit `typeRef` or define a custom itemDefinition | list of contexts |
+| `COLLECT` with `aggregation="SUM"\|"MIN"\|"MAX"\|"COUNT"` | scalar (the aggregated value) | n/a (aggregators require single output) |
+
+A scalar `typeRef` on a list-returning policy raises `expected '<typeRef>' but found '[...]'` at evaluation time. The fix is either to drop the `<variable>` element on the decision table (the BPMN `resultVariable` mapping handles naming) or to remove the `typeRef` attribute so the engine accepts the list.
+
+Default recommendation: omit `<variable>` on decision tables unless you have a concrete reason to declare it.
 
 ## DMN data types
 

--- a/skills/camunda-dmn/references/dmnlint.md
+++ b/skills/camunda-dmn/references/dmnlint.md
@@ -1,0 +1,93 @@
+# dmnlint reference
+
+`dmnlint` is the [bpmn-io] DMN linter that Camunda's CI/CD documentation recommends alongside `bpmnlint` ([docs.camunda.io › modeler › web-modeler › integrate-web-modeler-in-ci-cd › Test stage](https://docs.camunda.io/docs/components/modeler/web-modeler/integrate-web-modeler-in-ci-cd/#test-stage)). It is the same rule library Web Modeler uses to flag issues in the editor.
+
+Install-free invocation:
+
+```bash
+npx --yes dmnlint path/to/decision.dmn
+```
+
+Exit codes: `0` clean, `1` lint issues found, `>1` tool failure.
+
+## Configuration — `.dmnlintrc`
+
+Drop a `.dmnlintrc` at the project root. The minimum useful contents:
+
+```json
+{ "extends": "dmnlint:recommended" }
+```
+
+`dmnlint` picks the file up automatically from the working directory. The skill creates it on the fly if missing:
+
+```bash
+[ -f .dmnlintrc ] || echo '{ "extends": "dmnlint:recommended" }' > .dmnlintrc
+```
+
+If your project already has a `.dmnlintrc` with a different `extends`, do not overwrite it — respect the project's choice and surface any rule disagreements in your final message.
+
+## Recommended rule set
+
+`dmnlint:recommended` enables these rules (both are errors by default):
+
+| Rule | Catches | Fix |
+|---|---|---|
+| `label-required` | Any Decision, InputData, BusinessKnowledgeModel, KnowledgeSource, or DecisionService missing a human-readable `name` attribute. The `id` is internal; `name` is what shows in Modeler and in error messages. | Add a descriptive `name=` to the flagged element. Pick something a domain reader can interpret without the diagram. |
+| `no-duplicate-requirements` | A decision that references the same upstream decision (or BKM / authority source) twice via `informationRequirement`, `knowledgeRequirement`, or `authorityRequirement`. | Remove the duplicate edge. The DRG must reference each upstream artifact at most once per decision. |
+
+`dmnlint` operates on the DMN XML — it catches the structural defects above but does not understand FEEL semantics, hit-policy correctness, or runtime variable resolution. Those are stage-2 concerns covered by execution (CPT or deploy-and-run) in the main SKILL.md.
+
+## Output format
+
+```
+decision.dmn
+  Decision_12    error  Element is missing label/name       label-required
+  Decision_15    error  Element is missing label/name       label-required
+
+✖ 2 problems (2 errors, 0 warnings)
+```
+
+Each report line is `<elementId>  <severity>  <message>  <ruleId>` — columns separated by two or more spaces. Lines starting with `✖` are summary only.
+
+## Targeting files
+
+**Single file:**
+
+```bash
+npx --yes dmnlint path/to/decision.dmn
+```
+
+**Directory:** pass discovered files explicitly so build / cache directories are skipped:
+
+```bash
+find src -name '*.dmn' -not -path '*/target/*' -not -path '*/node_modules/*' \
+  | xargs npx --yes dmnlint
+```
+
+Skip these directories during discovery: `.git`, `node_modules`, `target`, `build`, `.gradle`, `.mvn`, `.idea`.
+
+**Stdin** is supported by some bpmn-io linters; for `dmnlint`, stick to file arguments.
+
+## CI integration
+
+Camunda's CI/CD guide recommends running `dmnlint` (and `bpmnlint`) as a pipeline step before deploy. Minimal GitHub Actions example:
+
+```yaml
+- name: Lint DMN
+  run: |
+    [ -f .dmnlintrc ] || echo '{ "extends": "dmnlint:recommended" }' > .dmnlintrc
+    find src -name '*.dmn' -print0 | xargs -0 npx --yes dmnlint
+```
+
+The same shape works in any CI that gives you Node + a shell.
+
+## Limitations and what to layer on top
+
+`dmnlint` is structural-only and its rule set is small. The rules it does NOT have:
+
+- It does not flag unquoted string output entries (`HIGH` instead of `"HIGH"`) — those evaluate to `null` at runtime and are caught only by behaviour validation.
+- It does not check hit-policy correctness — `UNIQUE` tables with overlapping rules pass lint cleanly and fail at evaluation time.
+- It does not validate `typeRef` matches between input expression and input entries.
+- It does not check that BPMN `<zeebe:calledDecision decisionId>` references resolve to a deployed decision — cross-file references are out of scope.
+
+Treat `dmnlint` as the structural floor. Layer the by-execution validation (CPT or deploy) on top — see the main SKILL.md § Validation — two-stage loop.

--- a/skills/camunda-dmn/references/dmnlint.md
+++ b/skills/camunda-dmn/references/dmnlint.md
@@ -1,8 +1,6 @@
 # dmnlint reference
 
-`dmnlint` is the [bpmn-io] DMN linter that Camunda's CI/CD documentation recommends alongside `bpmnlint` ([docs.camunda.io › modeler › web-modeler › integrate-web-modeler-in-ci-cd › Test stage](https://docs.camunda.io/docs/components/modeler/web-modeler/integrate-web-modeler-in-ci-cd/#test-stage)). It is the same rule library Web Modeler uses to flag issues in the editor.
-
-Install-free invocation:
+`dmnlint` is the bpmn-io DMN linter — the same rule library Web Modeler uses to flag issues in the editor. Run it as a structural gate on every DMN edit.
 
 ```bash
 npx --yes dmnlint path/to/decision.dmn
@@ -12,7 +10,7 @@ Exit codes: `0` clean, `1` lint issues found, `>1` tool failure.
 
 ## Configuration — `.dmnlintrc`
 
-Drop a `.dmnlintrc` at the project root. The minimum useful contents:
+Drop a `.dmnlintrc` at the project root:
 
 ```json
 { "extends": "dmnlint:recommended" }
@@ -24,70 +22,33 @@ Drop a `.dmnlintrc` at the project root. The minimum useful contents:
 [ -f .dmnlintrc ] || echo '{ "extends": "dmnlint:recommended" }' > .dmnlintrc
 ```
 
-If your project already has a `.dmnlintrc` with a different `extends`, do not overwrite it — respect the project's choice and surface any rule disagreements in your final message.
+If the project already has a `.dmnlintrc` with a different `extends`, do not overwrite it — respect the project's choice and surface any rule disagreements in your final message.
 
 ## Recommended rule set
 
-`dmnlint:recommended` enables these rules (both are errors by default):
+`dmnlint:recommended` enables these rules (both errors by default):
 
 | Rule | Catches | Fix |
 |---|---|---|
-| `label-required` | Any Decision, InputData, BusinessKnowledgeModel, KnowledgeSource, or DecisionService missing a human-readable `name` attribute. The `id` is internal; `name` is what shows in Modeler and in error messages. | Add a descriptive `name=` to the flagged element. Pick something a domain reader can interpret without the diagram. |
-| `no-duplicate-requirements` | A decision that references the same upstream decision (or BKM / authority source) twice via `informationRequirement`, `knowledgeRequirement`, or `authorityRequirement`. | Remove the duplicate edge. The DRG must reference each upstream artifact at most once per decision. |
-
-`dmnlint` operates on the DMN XML — it catches the structural defects above but does not understand FEEL semantics, hit-policy correctness, or runtime variable resolution. Those are stage-2 concerns covered by execution (CPT or deploy-and-run) in the main SKILL.md.
+| `label-required` | A Decision, InputData, BusinessKnowledgeModel, KnowledgeSource, or DecisionService missing a `name` attribute. The `id` is internal; `name` is what shows in Modeler and error messages. | Add a descriptive `name=` to the flagged element. |
+| `no-duplicate-requirements` | A decision that references the same upstream decision (or BKM / authority source) twice via `informationRequirement`, `knowledgeRequirement`, or `authorityRequirement`. | Remove the duplicate edge. |
 
 ## Output format
 
 ```
 decision.dmn
   Decision_12    error  Element is missing label/name       label-required
-  Decision_15    error  Element is missing label/name       label-required
 
-✖ 2 problems (2 errors, 0 warnings)
+✖ 1 problem (1 error, 0 warnings)
 ```
 
 Each report line is `<elementId>  <severity>  <message>  <ruleId>` — columns separated by two or more spaces. Lines starting with `✖` are summary only.
 
-## Targeting files
+## Common pitfalls beyond lint coverage
 
-**Single file:**
+`dmnlint` operates on the DMN XML — it catches the structural defects above but does not understand FEEL semantics or runtime resolution. Cover these by execution (CPT or deploy-and-run) instead:
 
-```bash
-npx --yes dmnlint path/to/decision.dmn
-```
-
-**Directory:** pass discovered files explicitly so build / cache directories are skipped:
-
-```bash
-find src -name '*.dmn' -not -path '*/target/*' -not -path '*/node_modules/*' \
-  | xargs npx --yes dmnlint
-```
-
-Skip these directories during discovery: `.git`, `node_modules`, `target`, `build`, `.gradle`, `.mvn`, `.idea`.
-
-**Stdin** is supported by some bpmn-io linters; for `dmnlint`, stick to file arguments.
-
-## CI integration
-
-Camunda's CI/CD guide recommends running `dmnlint` (and `bpmnlint`) as a pipeline step before deploy. Minimal GitHub Actions example:
-
-```yaml
-- name: Lint DMN
-  run: |
-    [ -f .dmnlintrc ] || echo '{ "extends": "dmnlint:recommended" }' > .dmnlintrc
-    find src -name '*.dmn' -print0 | xargs -0 npx --yes dmnlint
-```
-
-The same shape works in any CI that gives you Node + a shell.
-
-## Limitations and what to layer on top
-
-`dmnlint` is structural-only and its rule set is small. The rules it does NOT have:
-
-- It does not flag unquoted string output entries (`HIGH` instead of `"HIGH"`) — those evaluate to `null` at runtime and are caught only by behaviour validation.
-- It does not check hit-policy correctness — `UNIQUE` tables with overlapping rules pass lint cleanly and fail at evaluation time.
-- It does not validate `typeRef` matches between input expression and input entries.
-- It does not check that BPMN `<zeebe:calledDecision decisionId>` references resolve to a deployed decision — cross-file references are out of scope.
-
-Treat `dmnlint` as the structural floor. Layer the by-execution validation (CPT or deploy) on top — see the main SKILL.md § Validation — two-stage loop.
+- **Unquoted string output entries** (`HIGH` instead of `"HIGH"`) — evaluate to `null` at runtime; no parse error, no lint warning.
+- **Hit-policy violations** — `UNIQUE` tables with overlapping rules pass lint cleanly and raise an incident only when input data hits the overlap.
+- **`typeRef` mismatches** between input expression and input entries — surface at evaluation time.
+- **Broken BPMN ↔ DMN references** — `<zeebe:calledDecision decisionId="…">` that no deployed decision satisfies; cross-file references are out of `dmnlint`'s scope.

--- a/skills/camunda-dmn/references/feel-in-dmn.md
+++ b/skills/camunda-dmn/references/feel-in-dmn.md
@@ -51,7 +51,7 @@ Example — `seasonalMenu` depends on `season`:
 ```xml
 <decision id="season">
   <variable name="season" typeRef="string"/>
-  <literalExpression><text>if month(today()) in [12, 1, 2] then "Winter" else "Other"</text></literalExpression>
+  <literalExpression><text>if today().month in [12, 1, 2] then "Winter" else "Other"</text></literalExpression>
 </decision>
 
 <decision id="seasonalMenu">
@@ -76,5 +76,6 @@ Only the root decision is invoked from BPMN; required decisions are evaluated tr
 - **Context literals**: `{ status: "ok", details: { code: 200 } }` — produce a structured output entry without a separate decision.
 - **`get value(context, "key")`** / **`get entries(context)`**: navigate context maps without dot notation; handy when keys are dynamic.
 - **Date arithmetic**: `today() - person.birthDate` produces a `dayTimeDuration` you can compare in unary tests.
+- **Date components are properties, not functions.** `someDate.month`, `someDate.year`, `someDate.day`, `someDate.weekday`. There is no `month(date)` function — `month(today())` raises `NO_FUNCTION_FOUND` at runtime and the decision returns `null`.
 
 For full FEEL reference and gotchas (number/string coercion, `null` handling), see **camunda-feel**.

--- a/skills/camunda-dmn/references/feel-in-dmn.md
+++ b/skills/camunda-dmn/references/feel-in-dmn.md
@@ -1,0 +1,80 @@
+# FEEL in DMN
+
+DMN uses FEEL (Friendly Enough Expression Language) for every expression-bearing element. The full FEEL reference lives in **camunda-feel** — this file covers only the DMN-specific contexts and the unary-tests subset.
+
+## Where FEEL appears in DMN
+
+| Location | FEEL flavour | Implicit subject | Example |
+|---|---|---|---|
+| `inputExpression` / `text` | full FEEL | none | `customer.totalAmount * 1.19` |
+| `inputEntry` / `text` (decision-table cell, condition side) | **unary tests** | the input value | `>= 1000`, `"gold", "silver"`, `not(null)` |
+| `outputEntry` / `text` (decision-table cell, result side) | full FEEL | none | `{ status: "approved", limit: amount * 2 }` |
+| `literalExpression` / `text` | full FEEL | none | `if size(orders) > 0 then orders[1].id else null` |
+| `variable` declaration in literal expression decisions | n/a (name + typeRef) | n/a | `<variable name="result" typeRef="string"/>` |
+
+The expression context differs in two important ways from FEEL in BPMN:
+
+1. **No `=` prefix.** Unlike BPMN, where every FEEL expression starts with `=`, DMN FEEL is implicit — every `text` element is parsed as FEEL. Adding `=` is a syntax error.
+2. **The cell is the unit.** Each input entry / output entry is evaluated as a separate FEEL expression. You cannot share state across rules.
+
+## Unary tests — the narrower grammar
+
+`inputEntry` cells use **unary tests**, a subset of FEEL designed for "does this value match this condition?". Differences from full FEEL:
+
+- The input value is implicit. `< 5` is shorthand for `? < 5` where `?` is the input.
+- A bare literal means equality: `"Winter"` matches when the input equals `"Winter"`.
+- Comma-separated lists mean OR: `"Winter", "Spring"` matches either value.
+- Comma-separated comparisons mean AND across the same input: `> 0, < 100` matches values in `(0, 100)`.
+- Ranges: `[1..10]` (closed), `(1..10)` (open), `[1..10)` (half-open).
+- Negation: `not("Winter", "Spring")` matches anything other than those.
+- Wildcard: `-` matches anything.
+- Function calls are still legal: `starts with("PREFIX-")`, `contains(?, "smith")`, `even(?)`.
+- Variable references are legal: `< threshold` where `threshold` is in scope.
+
+### What you cannot do in a unary test
+
+- Arithmetic on the implicit input alone is not valid as a *condition* — write the comparison explicitly. `* 2 > 100` is wrong; `? * 2 > 100` works.
+- Local variable binding (`let ... in ...`) is not part of unary tests.
+- Multi-statement expressions are not supported — one expression per cell.
+
+If you need expressive logic beyond unary tests, move it to the upstream `inputExpression` (which is full FEEL) and keep the unary test simple.
+
+## Variable scope across linked decisions
+
+When `decision B` requires `decision A` via `informationRequirement`, the result of A is in scope for B under A's decision ID:
+
+- A has **one output** (no `name`): use `decisionAId` as the variable.
+- A has **multiple outputs** (each with `name`): use `decisionAId.outputName`.
+
+Example — `seasonalMenu` depends on `season`:
+
+```xml
+<decision id="season">
+  <variable name="season" typeRef="string"/>
+  <literalExpression><text>if month(today()) in [12, 1, 2] then "Winter" else "Other"</text></literalExpression>
+</decision>
+
+<decision id="seasonalMenu">
+  <informationRequirement><requiredDecision href="#season"/></informationRequirement>
+  <decisionTable>
+    <input>
+      <inputExpression typeRef="string"><text>season</text></inputExpression>
+    </input>
+    <!-- ... -->
+  </decisionTable>
+</decision>
+```
+
+Here the input expression `season` references the result of the `season` decision (which is a literal expression with a `<variable name="season"/>` declaration). For a decision table with `id="season"` and a single output, the reference would still be `season`. For a multi-output table with `id="seasons"` and outputs `name="hemisphere"` and `name="solstice"`, references would be `seasons.hemisphere` and `seasons.solstice`.
+
+Only the root decision is invoked from BPMN; required decisions are evaluated transparently and exist only within DMN scope.
+
+## FEEL features especially useful in DMN
+
+- **`list contains`**: `list contains(blocklist, customer.id)` — boolean check.
+- **`item in collection` filtering**: `customer.orders[totalAmount > 1000]` — returns the matching items as a list. Useful in `inputExpression`.
+- **Context literals**: `{ status: "ok", details: { code: 200 } }` — produce a structured output entry without a separate decision.
+- **`get value(context, "key")`** / **`get entries(context)`**: navigate context maps without dot notation; handy when keys are dynamic.
+- **Date arithmetic**: `today() - person.birthDate` produces a `dayTimeDuration` you can compare in unary tests.
+
+For full FEEL reference and gotchas (number/string coercion, `null` handling), see **camunda-feel**.

--- a/skills/camunda-dmn/references/testing-decisions.md
+++ b/skills/camunda-dmn/references/testing-decisions.md
@@ -1,0 +1,107 @@
+# Testing decision behaviour
+
+"Deploy and run the BPMN" verifies the decision doesn't *fail*; it does not verify the *right* rules fired or the outputs match expectations. A decision that returns the wrong dish for every season will pass any BPMN-completes test if the downstream gateway only checks "is the value non-null". This reference covers how to actually assert decision behaviour.
+
+The mechanics described here live in **camunda-process-test** — see its `authoring.md` for the JSON instructions and Java surface. This file teaches *what to assert per hit policy and DRG shape*; the test skill teaches *how* to wire it up.
+
+## Standalone evaluation — no BPMN
+
+Evaluate a decision directly, without a process instance. The leaf decision in a DRD auto-evaluates upstream decisions linked via `informationRequirement`, so one call exercises the whole DRD.
+
+Java (CPT or production code):
+
+```java
+var response = camundaClient.newEvaluateDecisionCommand()
+    .decisionId("dish")
+    .variables(Map.of("season", "Winter"))
+    .send().join();
+```
+
+JSON instruction *(CPT 8.9+)*:
+
+```json
+{
+  "type": "EVALUATE_DECISION",
+  "decisionDefinitionSelector": { "decisionDefinitionId": "dish" },
+  "variables": { "season": "Winter" }
+}
+```
+
+Pair with an assertion (`ASSERT_DECISION` in JSON, `CamundaAssert.assertThatDecision(...)` in Java).
+
+## Decision-instance assertions *(CPT 8.9+)*
+
+```java
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.assertions.DecisionSelectors;
+
+CamundaAssert.assertThatDecision(DecisionSelectors.byId("season"))
+    .isEvaluated()
+    .hasOutput("Winter")
+    .hasMatchedRules(1);
+```
+
+`DecisionSelectors`: `byId`, `byName`, `byProcessInstanceKey`, `byResponse` (for the standalone variant). Available since CPT 8.9.
+
+JSON equivalent *(CPT 8.9+)*:
+
+```json
+{
+  "type": "ASSERT_DECISION",
+  "decisionSelector": { "decisionDefinitionId": "season" },
+  "output": "Winter",
+  "matchedRules": [1]
+}
+```
+
+### Rule numbering
+
+`hasMatchedRules` takes **1-based ordinals** matching the order of rules in the decision table — not BPMN `id`s. The first `<rule>` in the XML is rule 1.
+
+- `UNIQUE` / `ANY` / `FIRST` → single ordinal (`hasMatchedRules(2)`).
+- `COLLECT` / `RULE ORDER` → all matched ordinals (`hasMatchedRules(1, 2, 4)`).
+
+The API does not surface this 1-based convention in its types; the assertion error tells you only "expected X, got Y", so plan rule order with this in mind.
+
+## Strategy by hit policy
+
+| Hit policy | What to write | Assertion shape |
+|---|---|---|
+| `UNIQUE` | One scenario per rule, plus one no-match scenario if the table doesn't partition the full input space. | `.hasOutput(value).hasMatchedRules(N)` |
+| `ANY` | One scenario per group of overlapping rules that produce the same output. | `.hasOutput(value).hasMatchedRules(a, b, ...)` |
+| `FIRST` | One scenario per priority layer that exercises the cascade — the first rule's input, the second rule's input *with the first rule's input absent*, and so on. | `.hasOutput(value).hasMatchedRules(N)` |
+| `RULE ORDER` / `COLLECT` (list) | One scenario per input partition that produces a distinct list. | `.hasOutput([list]).hasMatchedRules(a, b, c)` |
+| `COLLECT` with aggregator | One scenario per distinct aggregated value. | `.hasOutput(scalar).hasMatchedRules(a, b, c)` |
+
+A "no-match" scenario uses `.hasNoMatchedRules()` (Java) or `noMatchedRules: true` (JSON).
+
+## DRG coverage
+
+For a chained DRG — `B requires A` via `informationRequirement` — write one scenario per UNIQUE branch in `A`. Each scenario then exercises the downstream rules in `B` tied to that branch. Two `ASSERT_DECISION` blocks per scenario:
+
+```json
+{ "type": "EVALUATE_DECISION",
+  "decisionDefinitionSelector": { "decisionDefinitionId": "beverages" },
+  "variables": { "season": "Winter" } },
+{ "type": "ASSERT_DECISION",
+  "decisionSelector": { "decisionDefinitionId": "season" },
+  "output": "Winter", "matchedRules": [1] },
+{ "type": "ASSERT_DECISION",
+  "decisionSelector": { "decisionDefinitionId": "beverages" },
+  "output": "Mulled wine", "matchedRules": [2] }
+```
+
+The leaf evaluation pulls the upstream in transparently; both decision instances are assertable.
+
+## Mocking vs testing
+
+`processTestContext.mockDmnDecision(decisionId, output)` *(CPT 8.9+)* replaces a real DMN evaluation with a fixed output. Two distinct uses:
+
+- **Mock**: in a BPMN flow test where DMN logic is not the unit under test — keeps the BPMN scenario stable when a rule changes.
+- **Test**: with `assertThatDecision` against the real DMN — validates the rules themselves.
+
+Use both. Mock the DMN in BPMN-flow tests so they don't break when rules change; assert the DMN directly in decision-focused tests so wrong outputs surface as test failures, not silent process completion.
+
+## Format suggestion
+
+DMN scenarios fit naturally in the JSON instruction format — inputs and expected matched rules are tabular, the audience (analysts maintaining rules) is closer to JSON than Java. Java is still fine when parameterized fixtures or shared expected-value computation help. Both work — match the format to the team.

--- a/skills/camunda-dmn/references/testing-decisions.md
+++ b/skills/camunda-dmn/references/testing-decisions.md
@@ -17,7 +17,7 @@ var response = camundaClient.newEvaluateDecisionCommand()
     .send().join();
 ```
 
-JSON instruction *(CPT 8.9+)*:
+JSON instruction *(`.test.json` grammar, 8.9+)*:
 
 ```json
 {
@@ -29,7 +29,7 @@ JSON instruction *(CPT 8.9+)*:
 
 Pair with an assertion (`ASSERT_DECISION` in JSON, `CamundaAssert.assertThatDecision(...)` in Java).
 
-## Decision-instance assertions *(CPT 8.9+)*
+## Decision-instance assertions
 
 ```java
 import io.camunda.process.test.api.CamundaAssert;
@@ -41,9 +41,9 @@ CamundaAssert.assertThatDecision(DecisionSelectors.byId("season"))
     .hasMatchedRules(1);
 ```
 
-`DecisionSelectors`: `byId`, `byName`, `byProcessInstanceKey`, `byResponse` (for the standalone variant). Available since CPT 8.9.
+`DecisionSelectors`: `byId`, `byName`, `byProcessInstanceKey`, `byResponse` (for the standalone variant). The Java decision-assertion API shipped with CPT itself (8.8+).
 
-JSON equivalent *(CPT 8.9+)*:
+JSON equivalent *(`.test.json` grammar, 8.9+)*:
 
 ```json
 {
@@ -95,7 +95,7 @@ The leaf evaluation pulls the upstream in transparently; both decision instances
 
 ## Mocking vs testing
 
-`processTestContext.mockDmnDecision(decisionId, output)` *(CPT 8.9+)* replaces a real DMN evaluation with a fixed output. Two distinct uses:
+`processTestContext.mockDmnDecision(decisionId, output)` replaces a real DMN evaluation with a fixed output. Two distinct uses:
 
 - **Mock**: in a BPMN flow test where DMN logic is not the unit under test — keeps the BPMN scenario stable when a rule changes.
 - **Test**: with `assertThatDecision` against the real DMN — validates the rules themselves.

--- a/skills/camunda-feel/SKILL.md
+++ b/skills/camunda-feel/SKILL.md
@@ -22,6 +22,7 @@ Write, debug, and evaluate FEEL expressions used in Camunda 8 BPMN processes, DM
 ## Cross-References
 
 - **camunda-bpmn**: Use when FEEL expressions are part of BPMN conditions or I/O mappings
+- **camunda-dmn**: Use when FEEL appears inside DMN — input expressions, input entries (unary tests), output entries, literal expressions
 - **camunda-forms**: Use when FEEL expressions control form validation or conditional visibility
 - **camunda-ai-agent**: Use when FEEL expressions are prompts, `fromAi()` parameter declarations, or `toolCallResult` shaping in an AI Agent process
 

--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -23,6 +23,7 @@ Runtime operations for Camunda 8.8+ clusters via c8ctl: deploy resources, start 
 
 - **camunda-c8ctl**: Use for c8ctl install, profile management, local cluster operations, and cluster-safety rules
 - **camunda-bpmn**: Use for fixing BPMN process issues found during debugging
+- **camunda-dmn**: Use for fixing DMN decision issues — `EXTRACT_VALUE_ERROR` / `DECISION_EVALUATION_FAILED` incidents typically trace back to the decision file
 - **camunda-connectors**: Use for fixing connector configuration issues found during debugging
 - **camunda-job-workers**: Use when an incident traces back to handler code rather than the process model — the worker side of `zeebe:taskDefinition type`
 - **camunda-connectors-development**: Use when an incident traces back to a custom connector's runtime / registration / hosting rather than its template configuration

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -24,6 +24,7 @@ Author and run Camunda Process Test suites for Camunda 8.8+ that reach **100% BP
 
 - **camunda-bpmn**: Run `c8ctl bpmn lint` on the process under test before authoring scenarios — failing lints surface as deploy-time `@TestDeployment` failures.
 - **camunda-feel**: Use when a gateway condition or DMN entry is unclear; FEEL semantics drive which segment hits which branch.
+- **camunda-dmn**: Use when a DMN decision is the unit under test — CPT exercises it via the calling business rule task; pair with `npx dmnlint` for structural checks.
 - **camunda-job-workers**: Use when the handler code that backs a service task is itself under test — CPT drives BPMN reachability; worker unit tests drive handler behaviour.
 - **camunda-connectors-development**: Use when a custom connector is the unit under test — CPT exercises it from the BPMN side; SDK-side tests cover the connector class directly.
 - **camunda-process-mgmt**: CPT runs against an **embedded** Zeebe engine — it does **not** use the c8ctl-managed cluster or any profile. No `c8ctl` call deploys a process under test.

--- a/skills/camunda-process-test/references/authoring.md
+++ b/skills/camunda-process-test/references/authoring.md
@@ -115,6 +115,53 @@ Asserts overall process state. Use only when the segment runs to an end event.
 }
 ```
 
+### Instructions for DMN *(8.9+)*
+
+The instructions above test the *process*; these test the *decision*. A BPMN-completes test passes even if every DMN output is wrong — assert the decision directly when its rules matter. See **camunda-dmn** § testing-decisions for what to assert per hit policy.
+
+#### `EVALUATE_DECISION`
+
+Runs a DMN decision without a process instance. The leaf of a chained DRG (`B requires A`) auto-evaluates upstream decisions, so one call exercises the whole graph.
+
+```json
+{
+  "type": "EVALUATE_DECISION",
+  "decisionDefinitionSelector": { "decisionDefinitionId": "dish" },
+  "variables": { "season": "Winter" }
+}
+```
+
+#### `ASSERT_DECISION`
+
+Asserts which rules fired and what the decision output. Fields: `output`, `matchedRules: [int]` (1-based ordinals in rule order, **not** BPMN ids), `notMatchedRules: [int]`, `noMatchedRules: boolean`.
+
+```json
+{
+  "type": "ASSERT_DECISION",
+  "decisionSelector": { "decisionDefinitionId": "dish" },
+  "output": ["Tortellini", "Roastbeef"],
+  "matchedRules": [1, 2]
+}
+```
+
+For UNIQUE/ANY/FIRST: single ordinal. For RULE ORDER/COLLECT: all matched ordinals as a list. For "no rule should match": `"noMatchedRules": true`.
+
+Pair with `EVALUATE_DECISION` for standalone decision tests, or place after the process scenario completes to assert what fired in-process.
+
+#### `MOCK_DMN_DECISION`
+
+Replaces a real DMN evaluation with a fixed output. Use to isolate BPMN-flow tests from DMN logic — BPMN scenarios stay stable when a rule changes.
+
+```json
+{
+  "type": "MOCK_DMN_DECISION",
+  "decisionDefinitionId": "dish",
+  "output": ["Tortellini"]
+}
+```
+
+Mocking and asserting are complementary, not interchangeable: mock the DMN in BPMN-flow tests; assert the DMN directly in decision-focused tests.
+
 ## Segment pattern
 
 A scenario for a non-happy-path segment typically looks like:
@@ -191,6 +238,7 @@ public class ExpenseApprovalJavaTest {
 - `CamundaAssert.assertThat(processInstance).hasActiveElements("…")` — equivalent to `ASSERT_ELEMENT_INSTANCES … IS_ACTIVE`.
 - `CamundaAssert.assertThat(processInstance).isCompleted()` — equivalent to `ASSERT_PROCESS_INSTANCE … IS_COMPLETED`.
 - `CamundaAssert.setAssertionTimeout(Duration.ofMinutes(5))` — bump the polling timeout for slow external workers (LLMs, multi-second connectors). The CPT default is short (10s as of 8.9 (assumption); confirm via `CamundaAssert` source for the version on your classpath).
+- `CamundaAssert.assertThatDecision(DecisionSelectors.byId("dish"))` *(8.9+)* — DMN decision-instance assertion. Methods: `.isEvaluated()`, `.hasOutput(value)`, `.hasMatchedRules(int...)`, `.hasNotMatchedRules(int...)`, `.hasNoMatchedRules()`. `DecisionSelectors`: `byId`, `byName`, `byProcessInstanceKey`, `byResponse` (for standalone evaluations via `camundaClient.newEvaluateDecisionCommand()...`). See **camunda-dmn** § testing-decisions for what to assert per hit policy.
 
 ### Mocking workers
 

--- a/skills/camunda-process-test/references/authoring.md
+++ b/skills/camunda-process-test/references/authoring.md
@@ -115,9 +115,11 @@ Asserts overall process state. Use only when the segment runs to an end event.
 }
 ```
 
-### Instructions for DMN *(8.9+)*
+### Instructions for DMN
 
 The instructions above test the *process*; these test the *decision*. A BPMN-completes test passes even if every DMN output is wrong — assert the decision directly when its rules matter. See **camunda-dmn** § testing-decisions for what to assert per hit policy.
+
+The three DMN instructions below are part of the 8.9 `.test.json` grammar. The equivalent Java API (`assertThatDecision`, `DecisionSelectors`, `mockDmnDecision`) shipped with CPT itself and is available on 8.8+.
 
 #### `EVALUATE_DECISION`
 
@@ -238,7 +240,7 @@ public class ExpenseApprovalJavaTest {
 - `CamundaAssert.assertThat(processInstance).hasActiveElements("…")` — equivalent to `ASSERT_ELEMENT_INSTANCES … IS_ACTIVE`.
 - `CamundaAssert.assertThat(processInstance).isCompleted()` — equivalent to `ASSERT_PROCESS_INSTANCE … IS_COMPLETED`.
 - `CamundaAssert.setAssertionTimeout(Duration.ofMinutes(5))` — bump the polling timeout for slow external workers (LLMs, multi-second connectors). The CPT default is short (10s as of 8.9 (assumption); confirm via `CamundaAssert` source for the version on your classpath).
-- `CamundaAssert.assertThatDecision(DecisionSelectors.byId("dish"))` *(8.9+)* — DMN decision-instance assertion. Methods: `.isEvaluated()`, `.hasOutput(value)`, `.hasMatchedRules(int...)`, `.hasNotMatchedRules(int...)`, `.hasNoMatchedRules()`. `DecisionSelectors`: `byId`, `byName`, `byProcessInstanceKey`, `byResponse` (for standalone evaluations via `camundaClient.newEvaluateDecisionCommand()...`). See **camunda-dmn** § testing-decisions for what to assert per hit policy.
+- `CamundaAssert.assertThatDecision(DecisionSelectors.byId("dish"))` — DMN decision-instance assertion. Methods: `.isEvaluated()`, `.hasOutput(value)`, `.hasMatchedRules(int...)`, `.hasNotMatchedRules(int...)`, `.hasNoMatchedRules()`. `DecisionSelectors`: `byId`, `byName`, `byProcessInstanceKey`, `byResponse` (for standalone evaluations via `camundaClient.newEvaluateDecisionCommand()...`). See **camunda-dmn** § testing-decisions for what to assert per hit policy.
 
 ### Mocking workers
 

--- a/skills/camunda-process-test/references/coverage-strategy.md
+++ b/skills/camunda-process-test/references/coverage-strategy.md
@@ -25,7 +25,7 @@ Build a candidate list. Walk the model:
 | Candidate type | Root | End | Notes |
 |----------------|------|-----|-------|
 | Each gateway branch (incl. `default`) | The gateway | First rejoin or end event | One candidate per outgoing flow |
-| Each DMN rule (incl. `default`) | The business-rule task | First rejoin or end event | Variables chosen to match the rule's input entries |
+| Each DMN rule (incl. `default`) | The business-rule task **or** a standalone `EVALUATE_DECISION` | First rejoin or end event (process-driven) / decision response (standalone) | Process-driven for rules whose inputs map 1:1 to a BPMN gateway; standalone (`EVALUATE_DECISION` + `ASSERT_DECISION`) when the input partition doesn't — isolates the failure cause. See **camunda-dmn** § testing-decisions. |
 | Each error boundary event | The activity it attaches to (use `THROW_BPMN_ERROR_FROM_JOB` with matching `errorCode`) | The boundary's outgoing path end event | |
 | Each timer / escalation / message boundary | The activity it attaches to | The boundary's outgoing path end event | Timer uses `INCREASE_TIME` past the cycle |
 | Each alternate end event | A gateway / branch combination that reaches it | The end event | |

--- a/skills/camunda-process-test/references/troubleshooting.md
+++ b/skills/camunda-process-test/references/troubleshooting.md
@@ -23,6 +23,8 @@ Diagnose `mvn test` failures. Each row classifies the failure as a **test proble
 | `BPMN error code mismatch` | `THROW_BPMN_ERROR_FROM_JOB errorCode` does not match `<bpmn:error errorCode>` | Test | Match exactly. Case-sensitive. |
 | Assertion failed on variable value | Value mismatch | **Investigate** | If the variable feeds a downstream gateway or DMN, fix whichever side is wrong. If nothing reads the variable, the assertion itself is out of scope — remove it. |
 | `IllegalStateException: Report resources not found in classpath` | Known SNAPSHOT bug in CPT coverage report generator | Infra | Non-blocking. Tests pass. Ignore until a GA release fixes it. |
+| DMN behaves wrong but no incident; process completes normally with wrong outputs | BPMN-completes tests can't catch wrong DMN outputs unless a downstream gateway consumes them | Test | Add `ASSERT_DECISION` (JSON) or `CamundaAssert.assertThatDecision(...)` (Java) — see authoring.md § Instructions for DMN, and **camunda-dmn** § testing-decisions for what to assert per hit policy. |
+| `DECISION_EVALUATION_ERROR: expected '<typeRef>' but found '[...]'` | Decision-table `<variable typeRef="string"/>` declared but the hit policy returns a list (RULE ORDER / COLLECT without aggregator) | Process | Drop the decision-level `<variable>` element on the decision table, or remove its `typeRef`. See **camunda-dmn** § Decision-level `<variable>` declarations. |
 
 ## Repair discipline
 


### PR DESCRIPTION
## Summary

New **camunda-dmn** skill — DMN 1.3 authoring on Camunda 8.8+. Decision tables (UNIQUE / ANY / FIRST / RULE ORDER / COLLECT with aggregators), literal expressions, DRG linking via `informationRequirement`, business-rule task wiring (`<zeebe:calledDecision>`).

Two-stage validation gate:
1. **Structural** — `npx dmnlint` with `.dmnlintrc` extending `dmnlint:recommended`.
2. **Behavioural** — CPT preferred, deploy-and-run fallback. A green BPMN-completes test only proves the decision didn't fail; for *rule-firing* assertions see the new `testing-decisions.md` reference.

**Files added**
- `skills/camunda-dmn/SKILL.md` — orientation, naming rules, hit-policy table, BPMN wiring, validation gates (~2000 tokens)
- `references/decision-tables.md` — clause shapes, unary-test forms, worked examples per hit policy, decision-level `<variable>` typeRef matrix, worked BPMN-calls-COLLECT example, type table, pitfalls
- `references/feel-in-dmn.md` — FEEL contexts in DMN, unary-tests vs full FEEL, scope across linked decisions, date-component property accessors (`today().month` — no `month(date)` function)
- `references/dmnlint.md` — `dmnlint:recommended` rules, rule → fix mapping, common pitfalls beyond lint coverage
- `references/testing-decisions.md` — `assertThatDecision` (Java, CPT 8.8+) and JSON `EVALUATE_DECISION` / `ASSERT_DECISION` / `MOCK_DMN_DECISION` (8.9+), 1-based rule-ordinal matching, strategy per hit policy, DRG coverage, mock-vs-test

**Cross-cuts**
- README.md + AGENTS.md rows added
- Reverse cross-refs from `camunda-bpmn`, `camunda-feel`, `camunda-process-test`, `camunda-process-mgmt`
- `camunda-process-test` extended: DMN instruction reference in `authoring.md`, DMN-rule candidates note in `coverage-strategy.md`, two troubleshooting rows (silent wrong-output + typeRef-mismatch incident)

## Test plan

- [x] `make lint SKILL=camunda-dmn` — High compliance, ~2000/5000 tokens
- [x] `make lint SKILL=camunda-process-test` — still High after DMN additions
- [x] FEEL property accessor verified empirically: `c8ctl feel evaluate 'today().month'` → `5`; `month(today())` → `NO_FUNCTION_FOUND`
- [x] CPT API version split verified against the local m2 cache: Java decision-assertion surface present in `camunda-process-test-java-8.8.2`; JSON DMN instruction handlers (`*InstructionHandler`) only in 8.9.0+
- [ ] Smoke test on local c8run: deploy a 2-rule discount DMN + calling BPMN, start an instance, verify the result variable
- [ ] `npx --yes dmnlint` smoke test against a `label-required` fixture and a clean fixture