### PR TITLE
docs(camunda-c8ctl): track c8ctl 3.0.0 stable release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,10 @@ Why: c8ctl is versioned, tested, and shared across skills. Ad-hoc scripts drift,
 
 c8ctl is a **hard prerequisite** for every skill below. The dedicated **camunda-c8ctl** skill walks through installation, picking a cluster (incl. starting a local one via `c8ctl cluster start`), profile setup, and plugin management.
 
-Quick start. The `bpmn`, `element-template`, and `feel` plugins the skills below depend on require **c8ctl ≥ 3.0.0-alpha.1** — pin the alpha explicitly, since npm's `latest` still points at 2.x:
+Quick start. The `bpmn`, `element-template`, and `feel` plugins the skills below depend on require **c8ctl ≥ 3.0.0**. Install the latest version:
 
 ```bash
-npm install -g @camunda8/cli@3.0.0-alpha.1
+npm install -g @camunda8/cli
 c8ctl cluster start         # spin up a local cluster (downloads c8run on first run)
 c8ctl get topology --json   # confirm it's alive (use --json per command for scripting/AI use)
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ make try
 
 1. Install c8ctl and start a local cluster:
    ```bash
-   npm install -g @camunda8/cli@3.0.0-alpha.1
+   npm install -g @camunda8/cli
    c8ctl cluster start          # downloads c8run on first run
    ```
 

--- a/skills/camunda-c8ctl/SKILL.md
+++ b/skills/camunda-c8ctl/SKILL.md
@@ -30,10 +30,10 @@ Install and use [c8ctl](https://github.com/camunda/c8ctl) — the minimal-depend
 
 ### Install
 
-Install c8ctl globally from npm. The other camunda-* skills depend on the `bpmn`, `element-template`, and `feel` plugins, which require **c8ctl ≥ 3.0.0-alpha.1**. Pin the alpha explicitly — npm's `latest` tag still points at the 2.x line, which ships without these plugins:
+Install c8ctl globally from npm. The other camunda-* skills depend on the `bpmn`, `element-template`, and `feel` plugins, which require **c8ctl ≥ 3.0.0**:
 
 ```bash
-npm install -g @camunda8/cli@3.0.0-alpha.1
+npm install -g @camunda8/cli
 ```
 
 After installation, both `c8ctl` and the shorter alias `c8` are available. The other camunda-* skills use the `c8ctl` form for clarity.
@@ -47,7 +47,7 @@ c8ctl help
 
 ### Verify default plugins
 
-The other camunda-* skills depend on three plugins that ship with c8ctl ≥ 3.0.0-alpha.1: `bpmn`, `element-template`, and `feel`. Verify each is available:
+The other camunda-* skills depend on three plugins that ship with c8ctl ≥ 3.0.0: `bpmn`, `element-template`, and `feel`. Verify each is available:
 
 ```bash
 c8ctl bpmn --help              # camunda-bpmn
@@ -55,10 +55,10 @@ c8ctl element-template --help  # camunda-connectors, camunda-ai-agent
 c8ctl feel --help              # camunda-feel
 ```
 
-If any command exits non-zero, the installed c8ctl is older than 3.0.0-alpha.1 and lacks these plugins. **Ask the user to confirm before installing** — don't run the install unprompted — then run:
+If any command exits non-zero, the installed c8ctl is older than 3.0.0 and lacks these plugins. **Ask the user to confirm before installing** — don't run the install unprompted — then run:
 
 ```bash
-npm install -g @camunda8/cli@3.0.0-alpha.1
+npm install -g @camunda8/cli
 ```
 
 ### Pick a Cluster


### PR DESCRIPTION
## Summary

- c8ctl 3.0.0 is out on npm's `latest` tag, so users no longer need to pin the alpha
- Drop `@3.0.0-alpha.1` pins and the "npm latest still points at 2.x" rationale across `AGENTS.md` / `CLAUDE.md` (symlink), `README.md`, and `skills/camunda-c8ctl/SKILL.md`
- Bump the stated minimum from `≥ 3.0.0-alpha.1` to `≥ 3.0.0`

## Test plan

- [x] `grep -rn "3.0.0-alpha" --include="*.md"` returns no matches
- [x] `make lint SKILL=camunda-c8ctl` passes