### PR TITLE
docs(camunda-bpmn): cover ad-hoc subprocess, end-event ioMapping, expanded-subprocess centring

### DIFF
--- a/skills/camunda-bpmn/references/element-catalog.md
+++ b/skills/camunda-bpmn/references/element-catalog.md
@@ -212,6 +212,40 @@ Triggered by events within a parent scope. Must have a start event (message, tim
 </bpmn:subProcess>
 ```
 
+### Ad-hoc Subprocess
+
+An embedded subprocess marked with the **ad-hoc** flag (BPMN's `~` tilde). Inner activities are not connected to start/end events — they're activated dynamically (either by an `activeElementsCollection` FEEL list or by a job worker), can run in any order, and can be skipped or repeated. The primary consumer of this shape is the AI Agent Sub-process connector (see **camunda-ai-agents**).
+
+```xml
+<bpmn:adHocSubProcess id="AgentTools" name="Agent tools" cancelRemainingInstances="true">
+  <bpmn:extensionElements>
+    <zeebe:adHoc activeElementsCollection="=requestedTools" />
+  </bpmn:extensionElements>
+  <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">=allDone</bpmn:completionCondition>
+  <!-- inner activities (one per tool/action), with no start or end events -->
+  <bpmn:serviceTask id="LookupCustomer" name="Look up customer"> ... </bpmn:serviceTask>
+  <bpmn:serviceTask id="EscalateToHuman" name="Escalate to human"> ... </bpmn:serviceTask>
+</bpmn:adHocSubProcess>
+```
+
+Engine-enforced constraints (both modes):
+
+- **Must have at least one inner activity.**
+- **Must not contain start or end events** — inner activities are entered directly when activated. Sequence flows between inner activities are allowed (and turn them into sub-sequences), but they're not required.
+
+**Two implementation modes:**
+
+- **Internal Zeebe mode** (default — no `<zeebe:taskDefinition>` on the ad-hoc subprocess). Zeebe drives activation and completion from the declarative properties below.
+- **Job-worker mode** (add `<zeebe:taskDefinition type="...">` to the ad-hoc subprocess). Zeebe creates a job on entry; the worker reads the `adHocSubProcessElements` process variable (inner-element metadata: id, name, documentation, properties, `fromAi()` parameters) and returns a job result that activates elements and/or signals completion/cancellation. The declarative properties below are not used — the worker decides programmatically. The AI Agent Sub-process connector uses this mode (see **camunda-ai-agents**).
+
+Declarative properties (internal Zeebe mode only):
+
+- `<zeebe:adHoc activeElementsCollection="...">` — FEEL expression returning a list of inner-element IDs (strings). Evaluated on entry; every listed element is activated and runs concurrently. If the list is empty or the expression is missing, no element activates and the subprocess remains active.
+- `<bpmn:completionCondition>` — boolean FEEL expression evaluated each time an inner element completes; when `true`, the subprocess completes. If absent, the subprocess completes when all activated elements complete.
+- `cancelRemainingInstances` attribute on `<bpmn:adHocSubProcess>` (default `true`) — when the completion condition fires, terminate any still-running inner activities; set `false` to wait for them.
+
+Diagram-interchange: the `<bpmndi:BPMNShape>` for the ad-hoc subprocess must enclose every inner shape with ≥50px padding on all sides (same rule as embedded subprocesses — see [layout-rules.md](layout-rules.md)).
+
 ## Multi-Instance
 
 Apply to any task or subprocess for iteration:

--- a/skills/camunda-bpmn/references/layout-rules.md
+++ b/skills/camunda-bpmn/references/layout-rules.md
@@ -91,7 +91,7 @@ Edges connect shapes via waypoints. Simple horizontal connections need two waypo
 - **From gateway right**: `x = gatewayX + gatewayWidth`, `y = gatewayY + gatewayHeight/2`
 - **From gateway bottom**: `x = gatewayX + gatewayWidth/2`, `y = gatewayY + gatewayHeight`
 
-For flows that change direction (e.g., from gateway down to a branch), use intermediate waypoints:
+**Orthogonal segments only.** Every segment between two adjacent waypoints must be **purely horizontal or purely vertical** (∆x = 0 or ∆y = 0). When a flow needs to change direction (e.g., from a gateway down to a branch, or from outside an ad-hoc subprocess into an inner activity), add intermediate waypoints to turn the path 90°:
 
 ```xml
 <bpmndi:BPMNEdge id="Flow_Down_di" bpmnElement="Flow_Down">
@@ -125,6 +125,19 @@ Subprocess bounds must enclose all internal elements with padding:
 ```
 
 Internal elements use coordinates relative to the diagram (not the subprocess). Ensure all internal shapes fall within the subprocess bounds with ≥50px padding.
+
+### Centring expanded subprocesses inline with adjacent tasks
+
+When an expanded subprocess (taller than a task — e.g. 200px) sits in the same horizontal track as regular tasks (80px tall, typically at `y=80` → centre `y=120`), line up the **vertical centres**, not the top edges. The subprocess `y` is `taskCentreY − subprocessHeight/2` — for a 200-tall subprocess on a 120-centre track, that's `y=20`.
+
+```xml
+<!-- Regular task at y=80, centre y=120 -->
+<bpmndi:BPMNShape id="Task_di" bpmnElement="Task"><dc:Bounds x="240" y="80" width="100" height="80"/></bpmndi:BPMNShape>
+<!-- Expanded subprocess centred on the same y=120 line -->
+<bpmndi:BPMNShape id="Sub_di" bpmnElement="Sub_Process" isExpanded="true"><dc:Bounds x="390" y="20" width="400" height="200"/></bpmndi:BPMNShape>
+```
+
+Aligning the top edges instead leaves the subprocess visually hanging — the connecting sequence-flow waypoints end up at `y=120` (task centre) but enter the subprocess at its left edge mid-height, which is fine, but the diagram reads cleaner when shapes share a baseline at their centres.
 
 ## Incremental Layout
 

--- a/skills/camunda-bpmn/references/zeebe-extensions.md
+++ b/skills/camunda-bpmn/references/zeebe-extensions.md
@@ -65,6 +65,20 @@ Control which variables propagate to parent scope AFTER execution:
 
 When output mappings are defined, ONLY mapped variables propagate. Unmapped local variables are discarded.
 
+#### End events accept `<zeebe:ioMapping>` too
+
+Useful when the final structure of a process variable needs to be reshaped right before completion without adding a downstream script task. The output mapping fires when the end event completes and writes to the enclosing scope (process instance, or parent subprocess for nested end events).
+
+```xml
+<bpmn:endEvent id="End_OrderProcessed">
+  <bpmn:extensionElements>
+    <zeebe:ioMapping>
+      <zeebe:output source='={ status: orderStatus, total: orderTotal }' target="orderSummary" />
+    </zeebe:ioMapping>
+  </bpmn:extensionElements>
+</bpmn:endEvent>
+```
+
 ### Variable Context by Element Type
 
 | Context | Access |


### PR DESCRIPTION
## Description

Three additions to the `camunda-bpmn` references based on findings from the live-review session:

- **Ad-hoc Subprocess** (`element-catalog.md`) — new subsection documenting `<bpmn:adHocSubProcess>` with `<zeebe:adHoc activeElementsCollection>` and `<bpmn:completionCondition>`, the engine-enforced constraints (≥1 inner activity, no start/end events, sequence flows between inner activities allowed), `cancelRemainingInstances` default, and the DI ≥50px padding rule. Cross-refs `camunda-ai-agents` as the primary consumer.
- **End events accept `<zeebe:ioMapping>`** (`zeebe-extensions.md`) — new subsection under Output Mappings. Verified empirically on Camunda 8.8.24 and 8.9.5 by deploying a tiny BPMN that maps `="hello-from-end-event"` to a `finalLabel` variable via the end event; both versions accept the deployment and fire the output mapping at completion.
- **Centring expanded subprocesses inline with adjacent tasks** (`layout-rules.md`) — new subsection. Documents the centre-on-task-centre rule (subprocess `y = taskCentreY − subprocessHeight/2`) with a worked `y=20` example for a 200-tall subprocess on a 120-centre track.

## Checklist

- [x] `make lint` passes
- [x] Updated `SKILL.md` / `references/` if behaviour changed