### PR TITLE
docs(camunda-development): add local prerequisites reference

### DIFF
--- a/skills/camunda-c8ctl/SKILL.md
+++ b/skills/camunda-c8ctl/SKILL.md
@@ -16,7 +16,7 @@ Install and use [c8ctl](https://github.com/camunda/c8ctl) — the minimal-depend
 
 ## Prerequisites
 
-- **Node.js ≥ 22.18.0** (required for native TypeScript support)
+- **Node.js ≥ 22.18.0** (required for native TypeScript support) — see **camunda-development** for installing it locally
 
 ## Cross-References
 

--- a/skills/camunda-connectors-development/SKILL.md
+++ b/skills/camunda-connectors-development/SKILL.md
@@ -18,7 +18,7 @@ Build a custom Camunda 8 connector when the OOTB catalog doesn't cover the integ
 
 - Camunda 8.8+ cluster reachable for testing (local c8run, SaaS, or Self-Managed — see **camunda-c8ctl**)
 - Path A: Web Modeler access (Desktop or SaaS) to use *Save as Template* and edit the generated JSON
-- Path B: Java 17+, Maven 3.8+ (or Gradle equivalent), and a JVM hosting option for the resulting connector JAR
+- Path B: Java 17+, Maven 3.8+ (or Gradle equivalent), and a JVM hosting option for the resulting connector JAR — see **camunda-development** for installing the JDK / Maven toolchain locally
 
 ## Cross-References
 

--- a/skills/camunda-development/SKILL.md
+++ b/skills/camunda-development/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: camunda-development
 description: |
-  Use this skill to choose the right Camunda 8 development surface (OOTB connector, custom connector template, custom Java connector, or job worker) before writing any integration code.
+  Use this skill to choose the right Camunda 8 development surface (OOTB connector, custom connector template, custom Java connector, or job worker) and to see what local tooling (JDK, Maven, Node.js, Docker) each surface needs.
 
-  Use for: orienting between out-of-the-box connectors, JSON-only templates on protocol connectors, custom Java connectors via the Connectors SDK, and job workers (Java / Spring / TypeScript); understanding the trade-offs (language reach, secrets handling, intrinsic functions, Camunda Documents, inbound support, low-level Zeebe APIs); deciding whether a piece of integration logic belongs in a reusable connector or in your application as a worker.
+  Use for: orienting between out-of-the-box connectors, JSON-only templates on protocol connectors, custom Java connectors via the Connectors SDK, and job workers (Java / Spring / TypeScript); understanding the trade-offs (language reach, secrets, intrinsic functions, inbound support); getting a per-workflow overview of which tools each path needs locally and how to verify them.
 
-  Do not use for: actually building a worker (use camunda-job-workers), building a custom connector (use camunda-connectors-development), or configuring an already-published OOTB connector (use camunda-connectors).
+  Do not use for: actually building a worker (use camunda-job-workers), building a custom connector (use camunda-connectors-development), or configuring an OOTB connector (use camunda-connectors).
 
-  **Utility skill** — decision matrix only. Read this first, then jump into the focused build skill it points you to.
+  **Utility skill** — decision matrix plus a local-prereqs overview. Read this first, then jump into the focused build skill it points you to.
 ---
 
 # Camunda Development
@@ -94,3 +94,11 @@ The SDK supports three inbound flavours, and the choice drives which BPMN elemen
 - **Polling** — the runtime polls an external endpoint on a schedule.
 
 If the integration is inbound, paths A and B in the decision matrix are the only options; path C does not apply. See **camunda-connectors-development**.
+
+## Local prerequisites
+
+The decision matrix points at a path; that path needs a working local toolchain. See [`references/prerequisites.md`](references/prerequisites.md) for the per-workflow overview (which tools each path expects — Node.js, JRE, JDK + Maven, Docker), OS-agnostic verification one-liners, and the cross-cutting gotchas (`JAVA_HOME` vs `PATH`, Docker daemon vs CLI, why not to pre-pull `camunda/zeebe:latest`). Specific minimum versions live in the linked skill for each path — they move with each Camunda release.
+
+## References
+
+- [prerequisites.md](references/prerequisites.md) — Local dev environment matrix (JDK / Node.js / Maven / Docker per workflow), verification one-liners, and tooling gotchas.

--- a/skills/camunda-development/references/prerequisites.md
+++ b/skills/camunda-development/references/prerequisites.md
@@ -1,0 +1,65 @@
+# Local dev environment prerequisites
+
+What tools each Camunda 8 workflow expects on the host, how to verify they're working, and the cross-cutting gotchas. This file deliberately does **not** prescribe an installation path — package managers and version managers are OS- and stack-specific, and the right choice depends on what else lives on the machine.
+
+## Prerequisite matrix
+
+| Workflow | Tools | Where the current minimum lives |
+|----------|-------|---------------------------------|
+| Use c8ctl (BPMN lint, deploy, FEEL eval, connector templates, …) | Node.js | **camunda-c8ctl** |
+| Run a local cluster via `c8ctl cluster start` (c8run) | JRE | **camunda-c8ctl** |
+| Implement Java / Spring Boot job workers | JDK, Maven (or Gradle) | **camunda-job-workers** |
+| Build a custom Java connector (Connectors SDK) | JDK, Maven (or Gradle) | **camunda-connectors-development** |
+| Implement TypeScript job workers | Node.js | **camunda-job-workers** |
+| Run Camunda Process Test (CPT) | JDK, Maven, Docker runtime | **camunda-process-test** |
+
+A single machine usually needs the union of the rows for the workflows in scope — Java versions stack (install the highest required JDK and the lower-bound rows are satisfied), Node.js does not.
+
+## Verification one-liners
+
+Run these from any shell — they don't depend on the install path:
+
+```bash
+node -v                                  # c8ctl, TypeScript SDK
+java -version                            # workers, connectors, CPT, c8run
+mvn -v                                   # workers, connectors, CPT
+docker info --format '{{.ServerVersion}}'  # CPT (must print a version, not error)
+```
+
+The Docker check is more than `docker info` — see "Docker daemon vs. CLI" below.
+
+## How people install these
+
+Common paths, named so they're recognisable, not prescribed:
+
+- **Version managers** keep multiple JDKs / Node versions side by side and pin per-project via a checked-in file. [asdf](https://asdf-vm.com), [mise](https://mise.jdx.dev), and [SDKMAN!](https://sdkman.io) cover JDK + Maven; [nvm](https://github.com/nvm-sh/nvm) and [fnm](https://github.com/Schniz/fnm) cover Node.js. SDKMAN! is JVM-focused; the others span more runtimes.
+- **OS package managers** — Homebrew on macOS, `apt`/`dnf` on Linux, `choco`/`winget` on Windows. Fine for a one-off install; less convenient when the project needs a different version than the system.
+- **Vendor installers** — Temurin / Oracle JDK installers, Node.js installer from nodejs.org, Docker Desktop / OrbStack / Rancher Desktop for the container runtime.
+
+Pick whichever fits the existing setup. The skill's job is to know what's needed and how to verify it, not to dictate how it got there.
+
+When a verification one-liner reports a missing or wrong-version tool, **surface the gap to the user and discuss the install path** — don't install it autonomously. The right choice depends on what else lives on the machine (existing version manager, shared toolchain, project-pinned versions), which only the user can answer.
+
+## Cross-cutting gotchas
+
+### `JAVA_HOME` vs. `PATH`
+
+Maven, Gradle, and many JVM tools resolve the JDK via `JAVA_HOME`, not the `java` binary on `PATH`. If `java -version` reports JDK 21 but `mvn -v` reports JDK 17, the two are pointing at different installs — fix `JAVA_HOME` (or the version-manager shim) before debugging build errors. Version managers handle this automatically when activated; ad-hoc installs often don't.
+
+### Docker daemon vs. CLI
+
+`docker` is a client binary. `docker info` exits 0 as long as the client is installed — even when the daemon is stopped — because it still prints the Client section. The reliable daemon check is:
+
+```bash
+docker info --format '{{.ServerVersion}}'
+```
+
+This only prints a version when the daemon is reachable. CPT, which uses Testcontainers, needs the daemon, not just the CLI — see **camunda-process-test**.
+
+### Testcontainers expects the daemon already running
+
+Testcontainers connects to whichever runtime is currently up (Docker Desktop, OrbStack, Rancher Desktop, Colima, …) — it doesn't start one for you. Start the runtime first, then run the test.
+
+### Don't pre-pull `camunda/zeebe:latest`
+
+Testcontainers fetches the Zeebe image matching the CPT version on the test classpath on first run. Pre-pulling `camunda/zeebe:latest` wastes bandwidth and ships a tag that may not match the CPT version — see **camunda-process-test**.

--- a/skills/camunda-job-workers/SKILL.md
+++ b/skills/camunda-job-workers/SKILL.md
@@ -18,7 +18,7 @@ Implement job workers for Camunda 8.8+ in Java, Camunda Spring Boot, or TypeScri
 
 - Camunda 8.8+ cluster reachable from the worker process (local c8run, SaaS, or Self-Managed — see **camunda-c8ctl**)
 - A BPMN process with at least one element that has `<zeebe:taskDefinition type="..."/>` matching the worker's job type (see **camunda-bpmn**)
-- Toolchain for the chosen SDK — OpenJDK 17+ and Maven/Gradle for Java and Spring; Node.js 18+ for TypeScript. SDK-specific version constraints (e.g. Spring Boot 4 vs 3, browser support) are in each SDK's reference.
+- Toolchain for the chosen SDK — OpenJDK 17+ and Maven/Gradle for Java and Spring; Node.js 18+ for TypeScript. SDK-specific version constraints (e.g. Spring Boot 4 vs 3, browser support) are in each SDK's reference. See **camunda-development** for installing these locally.
 
 ## Cross-References
 


### PR DESCRIPTION
## Description

Adds a `references/prerequisites.md` to **camunda-development** so the existing decision matrix has a companion that covers what local toolchain each Camunda 8 workflow expects on the host, how to verify it with OS-agnostic one-liners, and the recurring tooling gotchas (`JAVA_HOME` vs `PATH`, Docker daemon vs CLI, `camunda/zeebe:latest` pre-pull pitfall).

The matrix's version column points at the skill that owns each minimum version, so versions are tracked once (in their owning skill) rather than re-stated and drifting here.

**camunda-c8ctl**, **camunda-job-workers**, and **camunda-connectors-development** each gain a one-line cross-ref from their existing tool-version prerequisites to this new reference.

Closes #

## Checklist

- [x] `make lint` passes
- [x] Updated `SKILL.md` / `references/` if behaviour changed