### PR TITLE
docs(camunda-connectors): document apply defaults and multi-line FEEL body

### DIFF
--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -119,6 +119,8 @@ Note the `string(userId)` wrapper — `userId` is a number and FEEL does not aut
 
 **FEEL value syntax.** `feel: required` values must start with `=`. Use `--set key='=value'` (outer quotes make `=` obvious) or `--set 'key==value'` (compact). Avoid `--set 'key== value'` — the space writes `source="= ..."` and Modeler shows the property as un-set. `c8ctl` writes verbatim; check `get-properties --detailed <name>` when unsure.
 
+**Defaults bake in.** `apply` materializes every active property with a default into the BPMN — `<zeebe:input>`, `<zeebe:output>`, `<zeebe:taskHeaders>`, and `<zeebe:property>` entries — not just the keys you `--set`. The defaults are captured at apply time — if the template later ships a new default, this BPMN keeps the old value.
+
 **Re-apply.** Omitted `--set` keys keep their current XML value, so single-property re-applies don't disturb the rest. Exception: dropdowns reset to the template default on every re-apply.
 
 ### Result Mapping — `resultVariable` and `resultExpression`

--- a/skills/camunda-connectors/references/element-template-schema.md
+++ b/skills/camunda-connectors/references/element-template-schema.md
@@ -84,6 +84,21 @@ Resulting BPMN (the `data:image/svg+xml;base64,...` icon blob is elided here for
 
 Validate with `c8ctl bpmn lint process.bpmn` after applying.
 
+## Multi-line FEEL context literal values
+
+For any `feel: required` property that takes a structured value (the REST connector's `body` is the typical case), pass a FEEL **context literal**, not a JSON object:
+
+```bash
+c8ctl element-template apply -i <id> <element> process.bpmn \
+  --set 'body=={
+    orderId: orderId,
+    amount: amount
+  }'
+```
+
+- Keys are unquoted (`{ orderId: ... }`); `{ "orderId": ... }` is rejected by the FEEL parser.
+- `--set 'key==<value>'` (compact `==`) is the multi-line-friendly form; `--set key='=<value>'` is the canonical single-line form. Either works.
+
 ## Where to look next
 
 - Full element-template authoring schema (property types, all binding types, inbound variants, FEEL features, the field-ordering rule): `camunda-connectors-development/references/element-template-json.md`


### PR DESCRIPTION
## Description

Add a `Defaults bake in` paragraph to the `Setting Property Values at Apply Time` section: `c8ctl element-template apply` materializes every active property with a default into the BPMN — `<zeebe:input>`, `<zeebe:output>`, `<zeebe:taskHeaders>`, `<zeebe:property>` entries — not just the keys passed via `--set`. Defaults are frozen at apply time, so a later template default-change does not propagate to BPMNs already on disk.

Add a `Multi-line FEEL context literal values` section to `references/element-template-schema.md` showing the `--set 'key=={ ... }'` shape for `feel: required` properties that take a structured value. The REST connector's `body` is the typical case but the syntax generalizes. Verified end-to-end: `apply` writes the value as `source="= & #10; ... & #10; "` on `<zeebe:input>`, and the cluster's FEEL engine evaluates the same expression to the expected context.

Closes #

## Checklist

- [x] `make lint` passes
- [x] Updated `SKILL.md` / `references/` if behaviour changed