### PR TITLE
docs(camunda-process-mgmt,camunda-c8ctl): prefer --json per call over persistent output toggle

### DIFF
--- a/skills/camunda-c8ctl/SKILL.md
+++ b/skills/camunda-c8ctl/SKILL.md
@@ -3,7 +3,7 @@ name: camunda-c8ctl
 description: |
   Use this skill to install, configure, and operate c8ctl (the Camunda 8 CLI), the foundation the other camunda-* skills build on.
 
-  Use for: starting a local cluster via c8run, connecting to Camunda 8 SaaS or Self-Managed via already-configured profiles, switching between connection profiles, managing connector secrets for the local cluster, switching output to JSON for scripting, also when another camunda-* skill needs c8ctl and it isn't installed yet.
+  Use for: starting a local cluster via c8run, connecting to Camunda 8 SaaS or Self-Managed via already-configured profiles, switching between connection profiles, managing connector secrets for the local cluster, switching c8ctl output modes for AI and scripting use, and any time another camunda-* skill calls c8ctl — load this first for the conventions (flags, profiles, output modes) shared across commands.
 
   Do not use for: writing BPMN (use camunda-bpmn), writing FEEL (use camunda-feel), or deploying and operating running processes (use camunda-process-mgmt — that skill builds on c8ctl).
 

--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -21,7 +21,7 @@ Runtime operations for Camunda 8.8+ clusters via c8ctl: deploy resources, start 
 
 ## Cross-References
 
-- **camunda-c8ctl**: Use for c8ctl install, profile management, local cluster operations, and cluster-safety rules
+- **camunda-c8ctl**: Use for c8ctl setup, cluster safety, and shared conventions (flags, profiles, output modes)
 - **camunda-bpmn**: Use for fixing BPMN process issues found during debugging
 - **camunda-dmn**: Use for fixing DMN decision issues — `EXTRACT_VALUE_ERROR` / `DECISION_EVALUATION_FAILED` incidents typically trace back to the decision file
 - **camunda-connectors**: Use for fixing connector configuration issues found during debugging
@@ -240,17 +240,12 @@ c8ctl cancel pi <instanceKey>
 
 ### JSON Output for Scripting
 
-Switch to structured output globally:
+Pass `--json` per call, optionally narrowed with `--fields`. Don't toggle session-wide output mode — see **camunda-c8ctl** for the why.
 
 ```bash
-c8ctl output json
-```
-
-Reduce noise by limiting fields:
-
-```bash
-c8ctl list pi --fields Key,State,ProcessDefinitionId
-c8ctl list pd --fields Key,Name,Version
+c8ctl list pi --json --fields=key,state,bpmnProcessId
+c8ctl list pd --json --fields=key,bpmnProcessId,version
+c8ctl get inc <key> --json
 ```
 
 ### Troubleshooting


### PR DESCRIPTION
## Description

`camunda-process-mgmt` previously recommended `c8ctl output json` for scripted use, which mutates `session.json` and leaks across tools and sessions. That contradicted `camunda-c8ctl`'s own guidance and primed agents to set the persistent toggle from inside an unrelated workflow.

Replaced the section with per-call `--json` examples and pointed at `camunda-c8ctl` for the rationale. Reframed `camunda-c8ctl`'s description to surface "shared conventions (flags, profiles, output modes)" — making it the natural skill an agent loads when reaching for any cross-cutting c8ctl behavior, not just one-time install. The cross-ref bullet in `camunda-process-mgmt` mirrors the new framing.

Closes #

## Checklist

- [x] \`make lint\` passes
- [x] Updated \`SKILL.md\` / \`references/\` if behaviour changed