### PR TITLE
feat(camunda-docs): add Algolia DocSearch path alongside MCP

### DIFF
--- a/skills/camunda-docs/SKILL.md
+++ b/skills/camunda-docs/SKILL.md
@@ -113,9 +113,9 @@ Don't loop more than 2-3 refinements. If still nothing, switch to the MCP path (
 
 The Algolia search-only API key is public — Algolia ships it in the browser JS bundle of docs.camunda.io, so every visitor already has it. It's hardcoded at the top of `scripts/docs-search.sh` with a comment explaining why it's safe to commit. No env vars, no auth, safe in CI.
 
-### If curl/jq aren't available
+### Without the wrapper script
 
-The script needs `curl` and `jq`. If either is missing in your environment (e.g. Windows without WSL, sandbox without `jq`), replicate the request directly:
+If you can't or don't want to run `scripts/docs-search.sh` (e.g. `jq` missing, restricted sandbox, or you just need the raw API), call the Algolia endpoint directly:
 
 ```bash
 curl -sf -X POST \
@@ -126,7 +126,7 @@ curl -sf -X POST \
   -d '{"query":"YOUR QUERY","hitsPerPage":10,"facetFilters":[["version:8.9"]]}'
 ```
 
-Substitute the `version:` facet for the version you want (`current` for `next`, omit `facetFilters` entirely for `all`). The response shape is Algolia's raw hits — useful fields per hit are `url`, `hierarchy.lvl0..lvl5`, and `content`. If `curl` is also unavailable, use any HTTP client that can POST JSON (Python `urllib`, Node `fetch`, PowerShell `Invoke-RestMethod`); the endpoint, headers, and body are the same. The credentials in the snippet are public by design (see "No credentials needed" above).
+Substitute the `version:` facet for the version you want (`current` for `next`, omit `facetFilters` entirely for `all`). The response shape is Algolia's raw hits — useful fields per hit are `url`, `hierarchy.lvl0..lvl5`, and `content`. If `curl` itself isn't available either, use any HTTP client that can POST JSON (Python `urllib`, Node `fetch`, PowerShell `Invoke-RestMethod`); the endpoint, headers, and body are the same. The credentials in the snippet are public by design (see "No credentials needed" above).
 
 ## Fallback: llms.txt (docs index)
 

--- a/skills/camunda-docs/SKILL.md
+++ b/skills/camunda-docs/SKILL.md
@@ -60,7 +60,7 @@ Default `--version stable` resolves to the highest numeric version in the index 
 1. **Pick a version** (see table below). Default `stable`.
 2. Run the script.
 3. Inspect the hits — each has `url`, `hierarchy`, `title`, `snippet`.
-4. **Open the most relevant page(s) with WebFetch** to read full context. Snippets are short; don't answer from them alone if the question needs detail.
+4. **Fetch the most relevant page(s)** directly by URL to read full context. Snippets are short; don't answer from them alone if the question needs detail.
 5. **Refine if insufficient** — see refinement strategy below.
 
 ### Version handling

--- a/skills/camunda-docs/SKILL.md
+++ b/skills/camunda-docs/SKILL.md
@@ -118,7 +118,7 @@ The Algolia search-only API key is public — Algolia ships it in the browser JS
 If you can't or don't want to run `scripts/docs-search.sh` (e.g. `jq` missing, restricted sandbox, or you just need the raw API), call the Algolia endpoint directly:
 
 ```bash
-curl -sf -X POST \
+curl -sS -f -X POST \
   "https://6KYF3VMCXZ-dsn.algolia.net/1/indexes/camunda-v2/query" \
   -H "X-Algolia-API-Key: 68db7725a8410eace68419c29385ad1e" \
   -H "X-Algolia-Application-Id: 6KYF3VMCXZ" \

--- a/skills/camunda-docs/SKILL.md
+++ b/skills/camunda-docs/SKILL.md
@@ -6,11 +6,21 @@ description: |
 
 # Camunda Docs Lookup
 
-## Preferred: camunda-docs MCP server
+Two retrieval paths into `docs.camunda.io`, each with a different strength. Pick by question shape; fall back to `llms.txt` only if both are unavailable.
 
-If the `camunda-docs` MCP server (`https://camunda-docs.mcp.kapa.ai`, HTTP transport) is connected, call its knowledge search tool with a focused query.
+| Path | Mechanism | Best for | Returns |
+|---|---|---|---|
+| **camunda-docs MCP** | Semantic retrieval (vector search) over docs + other Camunda knowledge sources | Conceptual or fuzzy questions; you don't know the exact term; want chunks ready to read | Top-k markdown chunks with source URLs |
+| **Algolia DocSearch** | Classical lexical search (the same index docs.camunda.io's own search box uses) | You know the term; want **version-scoped** results (8.7 vs 8.9 vs next); want to triage a ranked page list | Ranked pages with title, hierarchy, snippet — fetch the page for full content |
+| **llms.txt / llms-full.txt** | Static text index/corpus | Offline fallback when neither service is reachable | Plain text; grep locally |
 
-If it isn't connected, suggest installing it before falling back, so the user can set it up once for future questions. Skip if you've already suggested it earlier in this conversation. For Claude Code:
+Use both primary paths in parallel when in doubt — they're cheap and frequently surface different relevant pages.
+
+## camunda-docs MCP server
+
+If the `camunda-docs` MCP server (`https://camunda-docs.mcp.kapa.ai`, HTTP transport) is connected, call its knowledge search tool with a single, well-formed natural-language sentence (the tool requires a complete sentence, not keywords).
+
+If it isn't connected, suggest installing it once so the user has it set up for future questions. Skip the suggestion if you've already made it earlier in this conversation. For Claude Code:
 
 ```bash
 claude mcp add --transport http camunda-docs https://camunda-docs.mcp.kapa.ai
@@ -18,9 +28,109 @@ claude mcp add --transport http camunda-docs https://camunda-docs.mcp.kapa.ai
 
 For VS Code Copilot, Cursor, or generic MCP clients, see [the reference](https://docs.camunda.io/docs/reference/mcp-docs/). Google sign-in on first use; 40 requests/hour and 200/day per user; not for CI.
 
+## Algolia DocSearch
+
+A bash wrapper around the public Algolia DocSearch endpoint lives at `scripts/docs-search.sh`. Run it as:
+
+```bash
+scripts/docs-search.sh "<query>" [--version stable|next|<major>.<minor>|all] [--limit N]
+```
+
+Default `--version stable` resolves to the highest numeric version in the index (so it keeps working when 9.0 ships). Default `--limit 10`. Returns JSON:
+
+```json
+{
+  "query": "...",
+  "version": "stable",
+  "algolia_version": "8.9",
+  "total": 5,
+  "total_matching": 25,
+  "hits": [
+    { "url": "...", "hierarchy": "...", "title": "...", "snippet": "..." }
+  ]
+}
+```
+
+- `total` — hits in this response.
+- `total_matching` — raw count of pages matching the query in the index, before pagination/dedupe. Useful for "how broadly does my term appear?"
+- `algolia_version` — the `version` facet value sent to the index (e.g. `"8.9"`, `"current"`). `null` in `--version all` mode (no facet filter applied).
+
+### Search flow
+
+1. **Pick a version** (see table below). Default `stable`.
+2. Run the script.
+3. Inspect the hits — each has `url`, `hierarchy`, `title`, `snippet`.
+4. **Open the most relevant page(s) with WebFetch** to read full context. Snippets are short; don't answer from them alone if the question needs detail.
+5. **Refine if insufficient** — see refinement strategy below.
+
+### Version handling
+
+The Camunda docs are versioned in the URL path. The Algolia `version` facet exposes those versions — without filtering, the same page returns 3-4 times across versions, which is noisy.
+
+| Flag value | Algolia facet | URL prefix | Use when |
+|---|---|---|---|
+| `stable` (default) | highest numeric (e.g. `8.9`) | `/docs/` | General questions, no version context |
+| `next` | `current` | `/docs/next/` | Upcoming/unreleased behavior, alpha features |
+| `8.8` / `8.7` / etc. | matching numeric | `/docs/8.8/` etc. | Customer/cluster on a specific generation |
+| `all` | (none) | any | Comparing versions; results deduped by URL stem so best-relevance version per page wins |
+
+**Pick explicitly when:**
+
+- Question is about a specific customer/cluster on a known generation → use that version.
+- Question is about an upcoming feature, an alpha, or "will this change in 8.10?" → run `stable` and `next` in parallel and compare.
+- Question is version-neutral (concepts, BPMN semantics, generic API shape) → `stable` is fine.
+
+In `--version all` mode the script over-fetches (4× `--limit`, capped at 100) so that after dedupe by URL stem the response contains close to `--limit` unique pages. Dedupe preserves Algolia's relevance order — first hit per unique URL stem wins, then trimmed to `--limit`.
+
+### Examples
+
+```bash
+# Default — latest stable
+scripts/docs-search.sh "zeebe gateway long polling timeout"
+
+# Specific version (customer on 8.7)
+scripts/docs-search.sh "task assignment" --version 8.7
+
+# Upcoming behavior
+scripts/docs-search.sh "agentic connectors" --version next
+
+# Compare across versions (deduped by URL stem)
+scripts/docs-search.sh "decision evaluation API" --version all --limit 15
+```
+
+### Refinement strategy
+
+If the first query is unhelpful:
+
+- **Too broad → too many off-topic hits**: add specifics (component, error code, config key).
+- **Too narrow → no hits**: drop adjectives, try the canonical product term (e.g. `"Tasklist"` not `"task UI"`, `"Zeebe"` not `"workflow engine"`).
+- **Wrong version**: try `--version all` to see if the term exists elsewhere, then narrow to the right release.
+- **Synonyms**: try alternative names — e.g. `"Operate"` ↔ `"process monitoring"`, `"Optimize"` ↔ `"analytics"`.
+
+Don't loop more than 2-3 refinements. If still nothing, switch to the MCP path (or note the gap to the user).
+
+### No credentials needed
+
+The Algolia search-only API key is public — Algolia ships it in the browser JS bundle of docs.camunda.io, so every visitor already has it. It's hardcoded at the top of `scripts/docs-search.sh` with a comment explaining why it's safe to commit. No env vars, no auth, safe in CI.
+
+### If curl/jq aren't available
+
+The script needs `curl` and `jq`. If either is missing in your environment (e.g. Windows without WSL, sandbox without `jq`), replicate the request directly:
+
+```bash
+curl -sf -X POST \
+  "https://6KYF3VMCXZ-dsn.algolia.net/1/indexes/camunda-v2/query" \
+  -H "X-Algolia-API-Key: 68db7725a8410eace68419c29385ad1e" \
+  -H "X-Algolia-Application-Id: 6KYF3VMCXZ" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"YOUR QUERY","hitsPerPage":10,"facetFilters":[["version:8.9"]]}'
+```
+
+Substitute the `version:` facet for the version you want (`current` for `next`, omit `facetFilters` entirely for `all`). The response shape is Algolia's raw hits — useful fields per hit are `url`, `hierarchy.lvl0..lvl5`, and `content`. If `curl` is also unavailable, use any HTTP client that can POST JSON (Python `urllib`, Node `fetch`, PowerShell `Invoke-RestMethod`); the endpoint, headers, and body are the same. The credentials in the snippet are public by design (see "No credentials needed" above).
+
 ## Fallback: llms.txt (docs index)
 
-Without the MCP, fetch [`https://docs.camunda.io/llms.txt`](https://docs.camunda.io/llms.txt) (~540 KB) — an index of `- [Title](url): description.` lines for every Camunda 8 docs page. **Do not read the whole file into context.** Cache it locally, search for the term to find the matching URL, then fetch that page directly.
+If neither MCP nor Algolia is usable, fetch [`https://docs.camunda.io/llms.txt`](https://docs.camunda.io/llms.txt) (~540 KB) — an index of `- [Title](url): description.` lines for every Camunda 8 docs page. **Do not read the whole file into context.** Cache it locally, search for the term to find the matching URL, then fetch that page directly.
 
 ## Last resort: llms-full.txt (full docs corpus)
 

--- a/skills/camunda-docs/scripts/docs-search.sh
+++ b/skills/camunda-docs/scripts/docs-search.sh
@@ -69,14 +69,21 @@ require_cmd jq
 
 # Resolve "stable" to the highest numeric version reported by the index.
 # This keeps the script working when 9.0 ships without a code change.
+# Max-version selection runs entirely in jq so the script's runtime deps
+# stay limited to curl + jq (no coreutils sort/tail needed).
 resolve_stable() {
   curl -sf -X POST "$URL" \
     -H "X-Algolia-API-Key: $API_KEY" \
     -H "X-Algolia-Application-Id: $APP_ID" \
     -H "Content-Type: application/json" \
     -d '{"query":"","hitsPerPage":0,"facets":["version"]}' \
-    | jq -r '.facets.version | keys[] | select(test("^[0-9]+\\.[0-9]+$"))' \
-    | sort -t. -k1,1n -k2,2n | tail -1
+    | jq -r '
+        .facets.version
+        | keys
+        | map(select(test("^[0-9]+\\.[0-9]+$")))
+        | sort_by(split(".") | map(tonumber))
+        | last // empty
+      '
 }
 
 if [ "$VERSION" = "stable" ]; then

--- a/skills/camunda-docs/scripts/docs-search.sh
+++ b/skills/camunda-docs/scripts/docs-search.sh
@@ -144,7 +144,7 @@ RAW=$(curl -sf -X POST "$URL" \
 # Algolia's relevance ranking. The reduce-based form below keeps the first
 # occurrence of each stem in the original order.
 if [ "$VERSION" = "all" ]; then
-  echo "$RAW" | jq --arg q "$QUERY" --argjson lim "$LIMIT" '
+  printf '%s' "$RAW" | jq --arg q "$QUERY" --argjson lim "$LIMIT" '
     . as $raw
     | [ .hits[] | {
           url,
@@ -166,7 +166,7 @@ if [ "$VERSION" = "all" ]; then
         hits: .
       }'
 else
-  echo "$RAW" | jq --arg q "$QUERY" --arg v "$VERSION" --arg av "$ALGOLIA_VERSION" '
+  printf '%s' "$RAW" | jq --arg q "$QUERY" --arg v "$VERSION" --arg av "$ALGOLIA_VERSION" '
     {
       query: $q,
       version: $v,

--- a/skills/camunda-docs/scripts/docs-search.sh
+++ b/skills/camunda-docs/scripts/docs-search.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Search docs.camunda.io via the public Algolia DocSearch index.
+# Usage: docs-search.sh <query> [--version stable|next|<major>.<minor>|all] [--limit N]
+#
+# Version mapping (Algolia 'version' facet → URL prefix):
+#   current → /docs/next/        (unreleased dev branch)
+#   <highest numeric> → /docs/   (no prefix; latest stable)
+#   8.8     → /docs/8.8/
+#   8.7     → /docs/8.7/         (etc., for any released <major>.<minor>)
+#
+# This script accepts user-friendly version names:
+#   stable          → highest numeric version present in the index (auto-resolved each call)
+#   next            → mapped to Algolia 'current'
+#   <major>.<minor> → passed through (e.g. 8.7, 9.0)
+#   all             → no filter; results deduped by URL path stripped of version segment
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# PUBLIC credentials — safe to commit.
+#
+# These are Algolia DocSearch search-only credentials. They are public by
+# design: Algolia ships them in the browser JS bundle of docs.camunda.io
+# (extracted from /assets/js/main.*.js), so every visitor to the docs site
+# already has them. Search-only keys are read-only and scoped to one index;
+# they cannot write, delete, list other indexes, or read account data.
+# If Camunda ever rotates the key on the docs site, re-extract from the JS
+# bundle.
+# ---------------------------------------------------------------------------
+APP_ID="6KYF3VMCXZ"
+API_KEY="68db7725a8410eace68419c29385ad1e"
+INDEX="camunda-v2"
+URL="https://${APP_ID}-dsn.algolia.net/1/indexes/${INDEX}/query"
+
+usage() {
+  echo "Usage: $0 <query> [--version stable|next|<major>.<minor>|all] [--limit N]" >&2
+  exit 1
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' is required but not installed." >&2
+    exit 1
+  fi
+}
+
+if [ $# -lt 1 ]; then
+  usage
+fi
+
+QUERY="$1"; shift
+VERSION="stable"
+LIMIT=10
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ $# -ge 2 ] || { echo "Error: --version requires a value" >&2; usage; }
+      VERSION="$2"; shift 2 ;;
+    --limit)
+      [ $# -ge 2 ] || { echo "Error: --limit requires a value" >&2; usage; }
+      [[ "$2" =~ ^[1-9][0-9]*$ ]] || { echo "Error: --limit must be a positive integer (got: $2)" >&2; usage; }
+      LIMIT="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+require_cmd curl
+require_cmd jq
+
+# Resolve "stable" to the highest numeric version reported by the index.
+# This keeps the script working when 9.0 ships without a code change.
+resolve_stable() {
+  curl -sf -X POST "$URL" \
+    -H "X-Algolia-API-Key: $API_KEY" \
+    -H "X-Algolia-Application-Id: $APP_ID" \
+    -H "Content-Type: application/json" \
+    -d '{"query":"","hitsPerPage":0,"facets":["version"]}' \
+    | jq -r '.facets.version | keys[] | select(test("^[0-9]+\\.[0-9]+$"))' \
+    | sort -t. -k1,1n -k2,2n | tail -1
+}
+
+if [ "$VERSION" = "stable" ]; then
+  ALGOLIA_VERSION="$(resolve_stable)"
+  if [ -z "$ALGOLIA_VERSION" ]; then
+    echo "Error: could not resolve 'stable' version from index" >&2
+    exit 1
+  fi
+elif [ "$VERSION" = "next" ]; then
+  ALGOLIA_VERSION="current"
+elif [ "$VERSION" = "all" ]; then
+  ALGOLIA_VERSION=""
+elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  ALGOLIA_VERSION="$VERSION"
+else
+  echo "Invalid --version: $VERSION (use stable|next|<major>.<minor>|all)" >&2
+  exit 1
+fi
+
+# In `all` mode, over-fetch from Algolia: the same content is indexed across
+# 3-4 versions, so dedupe by URL stem typically collapses N raw hits down to
+# ~N/3. Request 4× the requested limit (capped at 100) to land close to LIMIT
+# unique results after dedupe.
+if [ "$VERSION" = "all" ]; then
+  REQUEST_LIMIT=$(( LIMIT * 4 ))
+  [ "$REQUEST_LIMIT" -gt 100 ] && REQUEST_LIMIT=100
+else
+  REQUEST_LIMIT="$LIMIT"
+fi
+
+if [ -n "$ALGOLIA_VERSION" ]; then
+  BODY=$(jq -n \
+    --arg q "$QUERY" \
+    --argjson n "$REQUEST_LIMIT" \
+    --arg v "$ALGOLIA_VERSION" \
+    '{query: $q, hitsPerPage: $n, facetFilters: [["version:" + $v]]}')
+else
+  BODY=$(jq -n \
+    --arg q "$QUERY" \
+    --argjson n "$REQUEST_LIMIT" \
+    '{query: $q, hitsPerPage: $n}')
+fi
+
+RAW=$(curl -sf -X POST "$URL" \
+  -H "X-Algolia-API-Key: $API_KEY" \
+  -H "X-Algolia-Application-Id: $APP_ID" \
+  -H "Content-Type: application/json" \
+  -d "$BODY")
+
+# Project to a stable shape; in 'all' mode dedupe by URL with version segment
+# stripped, preserving Algolia's relevance order, then trim to LIMIT.
+#   total           = number of hits in this response (== hits | length)
+#   total_matching  = raw Algolia nbHits (total pages matching the query in
+#                     the index, before pagination/dedupe)
+#   algolia_version = the Algolia 'version' facet value sent to the index;
+#                     null in `all` mode (no facet filter applied)
+# Order-preserving dedupe: jq's `unique_by` sorts by the key and would lose
+# Algolia's relevance ranking. The reduce-based form below keeps the first
+# occurrence of each stem in the original order.
+if [ "$VERSION" = "all" ]; then
+  echo "$RAW" | jq --arg q "$QUERY" --argjson lim "$LIMIT" '
+    . as $raw
+    | [ .hits[] | {
+          url,
+          stem: (.url | sub("/docs/(next|[0-9]+\\.[0-9]+)/"; "/docs/")),
+          hierarchy: (.hierarchy.lvl0 // ""),
+          title: ((.hierarchy.lvl1 // .hierarchy.lvl0) // ""),
+          snippet: (.content // (.hierarchy.lvl5 // .hierarchy.lvl4 // .hierarchy.lvl3 // .hierarchy.lvl2 // ""))
+        }
+      ]
+    | reduce .[] as $h ([]; if any(.[]; .stem == $h.stem) then . else . + [$h] end)
+    | .[0:$lim]
+    | map(del(.stem))
+    | {
+        query: $q,
+        version: "all",
+        algolia_version: null,
+        total: length,
+        total_matching: $raw.nbHits,
+        hits: .
+      }'
+else
+  echo "$RAW" | jq --arg q "$QUERY" --arg v "$VERSION" --arg av "$ALGOLIA_VERSION" '
+    {
+      query: $q,
+      version: $v,
+      algolia_version: $av,
+      total: (.hits | length),
+      total_matching: .nbHits,
+      hits: [ .hits[] | {
+        url,
+        hierarchy: (.hierarchy.lvl0 // ""),
+        title: ((.hierarchy.lvl1 // .hierarchy.lvl0) // ""),
+        snippet: (.content // (.hierarchy.lvl5 // .hierarchy.lvl4 // .hierarchy.lvl3 // .hierarchy.lvl2 // ""))
+      } ]
+    }'
+fi

--- a/skills/camunda-docs/scripts/docs-search.sh
+++ b/skills/camunda-docs/scripts/docs-search.sh
@@ -72,7 +72,7 @@ require_cmd jq
 # Max-version selection runs entirely in jq so the script's runtime deps
 # stay limited to curl + jq (no coreutils sort/tail needed).
 resolve_stable() {
-  curl -sf -X POST "$URL" \
+  curl -sS -f -X POST "$URL" \
     -H "X-Algolia-API-Key: $API_KEY" \
     -H "X-Algolia-Application-Id: $APP_ID" \
     -H "Content-Type: application/json" \
@@ -127,7 +127,7 @@ else
     '{query: $q, hitsPerPage: $n}')
 fi
 
-RAW=$(curl -sf -X POST "$URL" \
+RAW=$(curl -sS -f -X POST "$URL" \
   -H "X-Algolia-API-Key: $API_KEY" \
   -H "X-Algolia-Application-Id: $APP_ID" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## Description

Adds a second retrieval path to the **camunda-docs** skill: a bash wrapper around the public Algolia DocSearch endpoint that powers `docs.camunda.io`'s own search. The skill now treats two paths as co-equal, picked by question shape:

- **camunda-docs MCP** — semantic (vector) retrieval; best for fuzzy/conceptual queries.
- **Algolia DocSearch** (new) — classical lexical search with a `version` facet (`stable` / `next` / `8.x` / `all`); best for known terms and version-scoped lookups.
- **llms.txt / llms-full.txt** — offline fallback if neither service is reachable.

### Changes

- New `skills/camunda-docs/scripts/docs-search.sh` — version-aware wrapper around the Algolia query endpoint with order-preserving dedupe in `--version all` mode. Inlines the small `_require_cmd` helper from upstream so the script has no external library dependency.
- Algolia search-only credentials are committed inline at the top of the script with a comment explaining why that's safe: they're shipped in the docs.camunda.io browser bundle by design, scoped to one index, and cannot write.
- SKILL.md reframed around the two primary paths plus the fallback, with version-handling table, search flow, examples, refinement strategy, and a curl/jq-free fallback snippet for environments where those tools are missing (Windows, restricted sandboxes).

### Verification

- Live tested: `scripts/docs-search.sh "zeebe long polling" --limit 3` returns the expected gateway-config + Zeebe-API pages, with `stable` auto-resolving to `8.9`.
- `make lint SKILL=camunda-docs` — passes all hard gates: spec 9/9, links 3/3 valid, 2099/5000 tokens.

Closes #

## Checklist

- [x] `make lint` passes
- [x] Updated `SKILL.md` / `references/` if behaviour changed