### PR TITLE
docs(contributing,repo): clarify docs() is not for skill content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,12 @@ the target skill's rules. Keep cross-ref bullets to a one-line topical pointer
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) — `<type>(<scope>): <subject>`,
 with the skill name as the scope (e.g. `feat(camunda-dmn): …`, `fix(camunda-bpmn): …`).
+
+**`SKILL.md` and `references/` files are the product, not docs.** Changes that ship new
+guidance, tighten wording, fix an example, or restructure a reference all change what the
+skill does — use `feat` / `fix` / `refactor`, not `docs`. `docs` is reserved for repo-level
+files (README.md, AGENTS.md, CONTRIBUTING.md, issue/PR templates).
+
 See [CONTRIBUTING.md § Commit Messages](CONTRIBUTING.md#commit-messages) for the full list of types and examples.
 
 ### Pull Requests and Issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,14 +96,16 @@ When a script is genuinely warranted, it must be:
 
 ## Commit Messages
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/). Format: `<type>(<scope>): <subject>`. Scope is the skill name (`camunda-bpmn`, `camunda-feel`, …) or a repo-wide area (`ci`, `contributing`, `lint`). Common types:
+Follow [Conventional Commits](https://www.conventionalcommits.org/). Format: `<type>(<scope>): <subject>`. Scope is the skill name (`camunda-bpmn`, `camunda-feel`, …) or a repo-wide area (`ci`, `contributing`, `lint`, `repo`). Common types:
 
 - `feat` — new skill or new capability within a skill
 - `fix` — correction to existing skill content or tooling
-- `docs` — README / CONTRIBUTING / AGENTS.md changes
+- `docs` — **repo-level docs only**: README.md, AGENTS.md, CONTRIBUTING.md, issue/PR templates. *Not* for SKILL.md or `references/` edits
 - `refactor` — restructuring without behavioural change (e.g., moving content into `references/`)
 - `chore` — versioning, lint config, dependency bumps
 - `test` — eval suites or test infrastructure
+
+**`SKILL.md` and `references/` files are the product, not documentation.** Adding guidance, tightening wording, fixing an example, or restructuring a reference all change what the skill does — pick `feat` / `fix` / `refactor` based on the nature of the change. Reserve `docs` for the repo-level files listed above. When in doubt: if the change ships to skill consumers, it isn't `docs`.
 
 Examples:
 
@@ -112,6 +114,14 @@ feat(camunda-dmn): add decision-table hit-policy reference
 fix(camunda-connectors): correct sync caveat duplication
 refactor(camunda-connectors): move post-apply concerns into references/
 docs(contributing): document conventional commit format
+docs(repo): require PR and issue templates in AGENTS.md
+```
+
+Wrong vs. right for skill content:
+
+```
+docs(camunda-bpmn): cover ad-hoc subprocess and end-event ioMapping   # ❌ ships new skill guidance
+feat(camunda-bpmn): cover ad-hoc subprocess and end-event ioMapping   # ✅
 ```
 
 Keep the subject under ~70 characters. Use the body for the *why*, not the *what*.


### PR DESCRIPTION
## Description

`SKILL.md` and `references/` files are the product of this repo, so changes to them are `feat` / `fix` / `refactor` — not `docs`. Reserve `docs()` for repo-level files: `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, and the GitHub issue/PR templates.

Recent history landed several `docs(camunda-X): …` commits that actually shipped new skill guidance. Strengthening the rule in both `CONTRIBUTING.md` and `AGENTS.md` (with a wrong-vs-right example) makes the intended boundary loud enough for humans and agents writing future commits.

Closes #

## Checklist

- [x] `make lint` passes
- [x] Updated `SKILL.md` / `references/` if behaviour changed (n/a — repo-level docs only)