### PR TITLE
Path A: Replace Web Modeler Save-as-Template with c8ctl fetch workflow

### DIFF
--- a/skills/camunda-ai-agents/SKILL.md
+++ b/skills/camunda-ai-agents/SKILL.md
@@ -81,7 +81,7 @@ bpmn:adHocSubProcess  (template applied here)
     bpmn:subProcess    — multi-step or async tool
 ```
 
-Hard rules that the lint loop does NOT catch — verify by hand:
+Hard rules that the lint loop does NOT catch — verify by reading the BPMN:
 
 - The element type must be `bpmn:adHocSubProcess`. A regular `bpmn:subProcess` or a service task will not host the connector.
 - A tool's **root node** is the entry activity that the LLM picks. A root node has **no incoming sequence flow** and is **not a boundary event**. An incoming flow turns the node into a regular flow step and the agent never sees it.
@@ -207,10 +207,10 @@ Run the BPMN lint loop (see **camunda-bpmn**) before declaring the agent process
 c8ctl bpmn lint process.bpmn
 ```
 
-Lint catches structural BPMN problems but does not validate connector-template inputs. After lint is clean, verify by hand:
+Lint catches structural BPMN problems but does not validate connector-template inputs. After lint is clean, verify by reading the BPMN:
 
 - Host element is `bpmn:adHocSubProcess` with the AI Agent template applied.
-- Every tool's root node has no incoming sequence flow and has a `<bpmn:documentation>` element (`apply` doesn't write it — set it by hand).
+- Every tool's root node has no incoming sequence flow and has a `<bpmn:documentation>` element (`apply` doesn't write it — set it via a direct edit).
 - Every tool's flow ends with `toolCallResult` set in scope.
 - Both prompts start with `=`.
 - `data.limits.maxModelCalls` is set.

--- a/skills/camunda-c8ctl/references/local-cluster.md
+++ b/skills/camunda-c8ctl/references/local-cluster.md
@@ -67,7 +67,7 @@ After `c8ctl cluster start`, the local cluster exposes:
 
 c8ctl's default localhost fallback (`http://localhost:8080/v2`) means commands work without a profile against a freshly-started local cluster.
 
-Open the web apps via:
+For interactive local sessions where the user can see a browser, `c8ctl open` launches the web apps:
 
 ```bash
 c8ctl open operate
@@ -75,6 +75,8 @@ c8ctl open tasklist
 c8ctl open modeler   # opens Camunda Modeler in the browser if available
 c8ctl open optimize
 ```
+
+An agent should *offer* these to the user rather than run them unprompted — in sandboxed or remote sessions `open` has no effect. A typical pattern: after starting a process instance, surface the Operate URL and ask the user whether to open it.
 
 ## Common Workflows
 

--- a/skills/camunda-connectors-development/SKILL.md
+++ b/skills/camunda-connectors-development/SKILL.md
@@ -17,7 +17,7 @@ Build a custom Camunda 8 connector when the OOTB catalog doesn't cover the integ
 ## Prerequisites
 
 - Camunda 8.8+ cluster reachable for testing (local c8run, SaaS, or Self-Managed — see **camunda-c8ctl**)
-- Path A: Web Modeler access (Desktop or SaaS) to use *Save as Template* and edit the generated JSON
+- Path A: none beyond the cluster — the JSON template is hand-authored, using `c8ctl element-template get <id>` to fetch the base OOTB template as a starting point
 - Path B: Java 17+, Maven 3.8+ (or Gradle equivalent), and a JVM hosting option for the resulting connector JAR — see **camunda-development** for installing the JDK / Maven toolchain locally
 
 ## Cross-References
@@ -66,8 +66,21 @@ A JSON template is also the natural way to give a job worker a polished Modeler 
 
 Both paths produce an element template JSON file. The schema is the same; what differs is how the file gets written:
 
-- **Path A**: start from the protocol connector's published template (`*Save as Template*` in Web Modeler is the canonical entry point), then customise — hide infrastructure properties (URL, method, auth) with `"type": "Hidden"`, pre-fill them with FEEL, and expose only the domain-specific inputs.
+- **Path A**: fetch the protocol connector's published template with `c8ctl element-template get <id>` as the starting point, then customise — hide infrastructure properties (URL, method, auth) with `"type": "Hidden"`, pre-fill them with FEEL, and expose only the domain-specific inputs.
 - **Path B**: annotate the connector class with `@ElementTemplate` and let the Maven plugin generate the JSON during build (`references/element-template-generator.md`), or hand-author it.
+
+### Specialising any OOTB template, not just protocol connectors
+
+The "hide infrastructure, expose only domain inputs" pattern works for *any* OOTB template, not just the generic protocol ones. As long as the customised template still writes the input mappings the underlying job worker expects (the `zeebe:taskDefinition type` and `zeebe:input` shape are the data contract), the worker sees the same payload — only the Modeler UI differs.
+
+Concrete examples in `camunda/connectors`:
+
+- `connectors/openai/element-templates/openai-connector.json` — full OpenAI template; a specialised version could hide the system prompt or model picker and expose only domain inputs.
+- `connectors/github/element-templates/github-connector.json` — specialised UI over the underlying job worker.
+- `connectors/github/element-templates/github-webhook-connector-receive.json` — the *generic webhook inbound* connector exposed as a GitHub-specific webhook UI.
+- `connectors/hugging-face/element-templates/hugging-face-connector.json` — Hugging Face-shaped UI over an underlying REST call.
+
+Use `c8ctl element-template get <id>` to pull the base template, then hide / hardcode / rename properties while preserving the bindings the worker reads.
 
 `references/element-template-json.md` is the schema reference for both — property types, binding types, FEEL/constraints/condition/generatedValue features, and the template variants for each BPMN attachment.
 
@@ -108,7 +121,7 @@ When Path B will run via the standalone runtime against a SaaS cluster (Hybrid h
 
 For detail, read from `references/`:
 
-- [protocol-connector-templates.md](references/protocol-connector-templates.md) — Path A walkthrough: *Save as Template*, hiding URL/method/auth, FEEL pre-fill, custom groups, a REST Countries worked example, and a brief link to template-generator tools
+- [protocol-connector-templates.md](references/protocol-connector-templates.md) — Path A walkthrough: fetching the base template via c8ctl, hiding URL/method/auth, FEEL pre-fill, custom groups, a REST Countries worked example, and a brief link to template-generator tools
 - [connector-sdk-outbound.md](references/connector-sdk-outbound.md) — `OutboundConnectorProvider` + `@Operation` (modern), `OutboundConnectorFunction` (legacy), `@Variable` / `@Header`, `ConnectorException`, Jakarta Validation
 - [connector-sdk-inbound.md](references/connector-sdk-inbound.md) — `InboundConnectorExecutable`, three flavours, lifecycle, `correlateWithResult` / `CorrelationResult`
 - [element-template-json.md](references/element-template-json.md) — schema reference: top-level fields, property types, binding types, property features, template variants per BPMN attachment

--- a/skills/camunda-connectors-development/references/element-template-json.md
+++ b/skills/camunda-connectors-development/references/element-template-json.md
@@ -184,7 +184,7 @@ Modeler offers the template only on matching elements; one connector class can b
 
 > Properties referenced by another property's FEEL `value` or `condition.property` must be declared *earlier* in the `properties` array.
 
-Out-of-order references silently evaluate to `null` at runtime (FEEL) or always-false (condition). Modeler does not flag this. When customising a Path A template, double-check ordering after edits — `Save as Template` preserves it, but manual reorders can break it.
+Out-of-order references silently evaluate to `null` at runtime (FEEL) or always-false (condition). Modeler does not flag this. When customising a Path A template, double-check ordering after edits — the OOTB template fetched via `c8ctl element-template get` is ordered correctly, but manual reorders can break it.
 
 The Maven plugin orders by annotation source order; if hand-authored templates need to mix generated and manual sections, put computed `Hidden` properties last.
 

--- a/skills/camunda-connectors-development/references/protocol-connector-templates.md
+++ b/skills/camunda-connectors-development/references/protocol-connector-templates.md
@@ -11,7 +11,7 @@ The same pattern works for specialising any OOTB connector (not just protocol on
 ## Canonical workflow
 
 1. **Discover the base template.** `c8ctl element-template search "<keyword>"` to find the protocol connector (e.g. *REST Outbound*), then `c8ctl element-template get <id>` to fetch its JSON. This is the starting point — every property, binding, and default is already shaped correctly for the underlying job worker.
-2. **Author the customised template.** Copy the fetched JSON into a new file under `resources/element-templates/` (or wherever your project stores templates). Give it a new `id` and `name`. Hide infrastructure properties (`"type": "Hidden"`), pre-fill them with FEEL, expose only the domain inputs, group them into custom groups.
+2. **Author the customised template.** Copy the fetched JSON into a new file under `resources/element-templates/` (or wherever your project stores templates). Give it a new `id` and `name`. Hide infrastructure properties (`"type": "Hidden"`), pre-fill them with FEEL, and group what remains into custom groups. You can also *add* new domain-specific inputs that map — via FEEL on the existing properties — to the data contract the underlying job worker expects (e.g. a `country` input that feeds into a hidden URL `=concat("https://.../", country)`).
 3. **Validate.** Run `c8ctl element-template apply -i <template> <element-id> <bpmn>` against a test BPMN to confirm the bindings produce the expected XML, and run `c8ctl bpmn lint` on the result.
 4. **Hand off.** The `.json` file is the deliverable. The user uploads it to their Modeler project (SaaS) or drops it under `resources/element-templates/` (Desktop) to apply it to elements.
 
@@ -206,7 +206,7 @@ The hidden `zeebe:taskDefinition` `type` is what binds the element to the underl
 
 ## Tools that generate templates from API specs
 
-When the OpenAPI / Postman spec for the target system is the starting point, **`congen-cli`** (Postman collection → REST connector template; CLI in the `camunda/connectors` repository, not currently distributed as a standalone binary — verify availability before recommending) can produce a draft template that you then refine using the same JSON edits described above.
+When the OpenAPI / Postman spec for the target system is the starting point, [**`congen-cli`**](https://github.com/camunda/connectors/tree/main/element-template-generator/congen-cli) (Postman collection → REST connector template; lives in the `camunda/connectors` repository, not currently distributed as a standalone binary) can produce a draft template that you then refine using the same JSON edits described above.
 
 ## Validating the template
 

--- a/skills/camunda-connectors-development/references/protocol-connector-templates.md
+++ b/skills/camunda-connectors-development/references/protocol-connector-templates.md
@@ -1,17 +1,19 @@
 # Path A — JSON-only template on a protocol connector
 
-Customise an existing protocol connector (REST, SOAP, GraphQL, Kafka, RabbitMQ, AWS SQS/SNS/EventBridge) into a domain-specific template by editing JSON only. No Java, no extra runtime, no separate deployment — the customised template lives in your repo as a single `.json` file and is uploaded to Web Modeler.
+Customise an existing protocol connector (REST, SOAP, GraphQL, Kafka, RabbitMQ, AWS SQS/SNS/EventBridge) into a domain-specific template by editing JSON only. No Java, no extra runtime, no separate deployment — the customised template lives in your repo as a single `.json` file.
 
 ## When this path applies
 
 The integration is a single call over one of the protocols above, AND you want a polished domain-specific UI in Modeler (named fields, hidden infrastructure, sensible defaults). Multi-step orchestration, proprietary protocols, or non-HTTP/non-messaging I/O require Path B.
 
+The same pattern works for specialising any OOTB connector (not just protocol ones) — see SKILL.md § *Specialising any OOTB template*.
+
 ## Canonical workflow
 
-1. **Model the call once in Web Modeler.** Drop the OOTB protocol connector (e.g. *REST Outbound*) onto a service task and fill in URL, method, headers, body, auth — everything the call needs.
-2. **Save as Template.** Right-click the configured element → *Save as Template* (Web Modeler Desktop and SaaS). Modeler emits a JSON file mirroring the configured connector with the same property structure.
-3. **Edit the JSON.** Hide infrastructure properties, pre-fill them with FEEL, expose only the domain inputs, group them into custom groups.
-4. **Upload as a template** to the Modeler project (SaaS) or place under `resources/element-templates/` (Desktop), then attach it to elements in a process.
+1. **Discover the base template.** `c8ctl element-template search "<keyword>"` to find the protocol connector (e.g. *REST Outbound*), then `c8ctl element-template get <id>` to fetch its JSON. This is the starting point — every property, binding, and default is already shaped correctly for the underlying job worker.
+2. **Author the customised template.** Copy the fetched JSON into a new file under `resources/element-templates/` (or wherever your project stores templates). Give it a new `id` and `name`. Hide infrastructure properties (`"type": "Hidden"`), pre-fill them with FEEL, expose only the domain inputs, group them into custom groups.
+3. **Validate.** Run `c8ctl element-template apply -i <template> <element-id> <bpmn>` against a test BPMN to confirm the bindings produce the expected XML, and run `c8ctl bpmn lint` on the result.
+4. **Hand off.** The `.json` file is the deliverable. The user uploads it to their Modeler project (SaaS) or drops it under `resources/element-templates/` (Desktop) to apply it to elements.
 
 ## Hiding infrastructure properties
 
@@ -204,24 +206,17 @@ The hidden `zeebe:taskDefinition` `type` is what binds the element to the underl
 
 ## Tools that generate templates from API specs
 
-Sometimes the OpenAPI / Postman spec for the target system is the starting point, not Web Modeler. Two tools in the connectors ecosystem produce REST templates from specs:
-
-- **`congen-cli`** — Postman collection → REST connector template. CLI tool in the `camunda/connectors` repository, not currently distributed as a standalone binary. Verify availability before recommending.
-- **Web Modeler's OpenAPI/Swagger/Postman generator** — the SaaS / Desktop UI has a *Create from REST API* flow that ingests a spec and produces an initial template.
-
-Both produce a template you then refine using the same JSON edits described above. Treat their output as the *Save as Template* starting point, not a finished artefact.
+When the OpenAPI / Postman spec for the target system is the starting point, **`congen-cli`** (Postman collection → REST connector template; CLI in the `camunda/connectors` repository, not currently distributed as a standalone binary — verify availability before recommending) can produce a draft template that you then refine using the same JSON edits described above.
 
 ## Validating the template
 
-Upload to Modeler and apply it to a service task; the Modeler validates the schema and surfaces errors inline. For repo-side validation, the JSON schema linked via `$schema` is the same one Modeler uses — most JSON-schema-aware editors will flag malformed properties without needing to round-trip through Modeler.
-
-To round-trip a template against `c8ctl`:
+The JSON schema linked via `$schema` lets any JSON-schema-aware editor flag malformed properties. To verify the bindings actually produce the expected BPMN XML, round-trip through `c8ctl`:
 
 ```bash
 c8ctl element-template apply -i my-template.json <element-id> <bpmn-file>
 ```
 
-prints the resulting BPMN (omit `-i` to print, include `-i` to write back). Confirms the binding writes the expected `zeebe:taskDefinition` + `zeebe:input` + `zeebe:taskHeaders` XML.
+Omit `-i` to print the result to stdout, include `-i` to write back. Confirms the binding writes the expected `zeebe:taskDefinition` + `zeebe:input` + `zeebe:taskHeaders` XML. Follow with `c8ctl bpmn lint` on the resulting BPMN.
 
 ## Where to look next
 

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -123,14 +123,7 @@ PY
 
 Diff against the BPMN element + sequenceFlow id list (`grep -oE 'id="[A-Za-z0-9_]+"' <bpmn>`, exclude `_di`, `BPMNDiagram`, `BPMNPlane`, `Definitions_`, `ErrorDef_`, `TimerDef_`, `Signal_`, `Message_`).
 
-**Open the HTML report in the user's browser as soon as `mvn test` exits — pass or fail.** Default command (macOS):
-
-```bash
-REPORT="target/coverage-report/report.html"
-[ -f "$REPORT" ] && open "$REPORT"
-```
-
-On Linux substitute `xdg-open`; on Windows substitute `start`. Default behavior, not opt-in — every run ends with the report visible.
+**Surface the HTML report path to the user as soon as `mvn test` exits — pass or fail.** The agent already verifies coverage from the JSON data above; the HTML report is for the user to inspect. Print the absolute path (`target/coverage-report/report.html`) in the final reply so they can open it themselves. In an interactive local session you may additionally offer to open it on their behalf (`open` on macOS, `xdg-open` on Linux, `start` on Windows) — do not run that unprompted in a sandboxed / remote environment where it has no effect.
 
 **Patch-loop on prediction misses — default behavior.** Set-cover planning in step 3 should reach 100% on the first authoring pass. When it does not, the gap is a *prediction miss*: the static walk for some candidate did not match runtime behavior. For each uncovered id:
 

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -141,7 +141,7 @@ Hard blockers that terminate the loop:
 
 Do not declare the suite done while ids remain uncovered and no hard blocker applies.
 
-> **Note**: in early 8.9 SNAPSHOT releases the report generator may throw `IllegalStateException: Report resources not found` and skip the HTML output. Tests still pass. Walk the BPMN against scenarios manually to confirm coverage in that case.
+> **Note**: in early 8.9 SNAPSHOT releases the report generator may throw `IllegalStateException: Report resources not found` and skip the HTML output. Tests still pass. Walk the BPMN against scenarios from source to confirm coverage in that case.
 
 ### 7. Verify no redundancy slipped through
 


### PR DESCRIPTION
## Description

Updates Path A (JSON-only template on protocol connector) documentation to reflect a modernized workflow that uses `c8ctl element-template get <id>` to fetch base OOTB templates as the starting point, rather than relying on Web Modeler's *Save as Template* feature.

### Key Changes

- **Canonical workflow**: Replaced the Web Modeler-centric "model once, save as template" approach with a CLI-first pattern:
  - Discover templates via `c8ctl element-template search`
  - Fetch the base template JSON via `c8ctl element-template get <id>`
  - Hand-author customizations (hide infrastructure, expose domain inputs)
  - Validate bindings with `c8ctl element-template apply` and `c8ctl bpmn lint`

- **Prerequisites**: Removed Web Modeler as a hard requirement for Path A; now only requires cluster access and c8ctl

- **Template-generator tools**: Simplified guidance on `congen-cli` and removed mention of Web Modeler's OpenAPI generator (both are optional draft-generation aids, not the primary workflow)

- **Validation**: Clarified that `c8ctl element-template apply` is the primary validation mechanism (round-trip against BPMN XML), with JSON schema validation as a secondary editor-side check

- **Specialising any OOTB template**: Added new section documenting that the "hide infrastructure, expose domain inputs" pattern works for *any* OOTB template (OpenAI, GitHub, Hugging Face, etc.), not just protocol connectors — with concrete examples and the `c8ctl element-template get` fetch pattern

- **Local cluster docs**: Updated guidance on `c8ctl open` to clarify it should be offered to users in interactive sessions rather than run unprompted in sandboxed/remote environments

- **Process test coverage reporting**: Changed from auto-opening HTML reports to surfacing the path to the user, with optional browser launch only in interactive local sessions

### Rationale

This aligns Path A with the c8ctl-first design goal (c8ctl as the single programmatic API surface) and removes friction from the workflow by eliminating the need to round-trip through Web Modeler's UI. The fetch-and-customize pattern is more reproducible, scriptable, and suitable for both interactive and automated contexts.

Closes #

## Checklist

- [ ] `make lint` passes
- [ ] Updated `SKILL.md` / `references/` if behaviour changed

https://claude.ai/code/session_01J6QYzpGCmnpMQNadpN8dbX