### PR TITLE
feat(evals): camunda-bpmn CPT behavioral verifier

### DIFF
--- a/evals/sandboxes/compose-cpt-verifier.yaml
+++ b/evals/sandboxes/compose-cpt-verifier.yaml
@@ -54,10 +54,12 @@ services:
       # so the CPT test can pick up the BPMN it wrote.
       - workspace:/agent-workspace:ro
       - m2-cache:/.m2
-      # Per-scenario CPT projects live under scenarios/<id>/cpt-verifier.
+      # Per-scenario CPT projects: scenarios/<id>/cpt-verifier.
+      # Per-skill CPT projects:   skills/<skill>/cpt-verifier.
       # Mount read-only — the scorer copies to /verifier-workspace before
       # mvn so target/ writes don't escape the container.
       - ../scenarios:/scenarios:ro
+      - ../skills:/skills:ro
     deploy:
       resources:
         limits:

--- a/evals/sandboxes/verifier.Dockerfile
+++ b/evals/sandboxes/verifier.Dockerfile
@@ -25,10 +25,12 @@ USER agent
 
 ENV MAVEN_OPTS="-Dmaven.repo.local=/.m2"
 
-# Pre-warm: bind-mount the scenarios tree read-only during this RUN and
+# Pre-warm: bind-mount scenarios and skills read-only during this RUN and
 # resolve every CPT verifier pom into /.m2. No files leak into the
-# image — only the populated Maven cache. New scenarios with their own
-# cpt-verifier/pom.xml are picked up automatically.
+# image — only the populated Maven cache. New pom.xml files are picked
+# up automatically on the next image build.
 RUN --mount=type=bind,source=scenarios,target=/scenarios,ro \
-    find /scenarios -path '*/cpt-verifier/pom.xml' -print0 | \
+    --mount=type=bind,source=skills,target=/skills,ro \
+    { find /scenarios -path '*/cpt-verifier/pom.xml' -print0; \
+      find /skills    -path '*/cpt-verifier/pom.xml' -print0; } | \
         xargs -0 -I{} mvn -B -q -f {} dependency:go-offline

--- a/evals/skills/camunda-bpmn/cpt-verifier/pom.xml
+++ b/evals/skills/camunda-bpmn/cpt-verifier/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  CPT verifier for camunda-bpmn skill evals.
+
+  Runs in remote runtime mode against the orchestration cluster
+  (shared via `network_mode: service:orchestration`). The test
+  deploys the agent's BPMN from /agent-workspace and asserts:
+
+  invoice-approval: process reaches ReviewInvoice user task (ACTIVE)
+  order-fulfillment: XOR gateway routes correctly for amount>1000
+                     (manual-approval) and amount<=1000 (auto-approval)
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.camunda.skills.evals</groupId>
+  <artifactId>camunda-bpmn-verifier</artifactId>
+  <version>0.1.0</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>4.0.0</version>
+    <relativePath/>
+  </parent>
+
+  <properties>
+    <java.version>21</java.version>
+    <camunda.version>8.9.5</camunda.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <version>${camunda.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*IT.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/evals/skills/camunda-bpmn/cpt-verifier/src/test/java/io/camunda/skills/evals/CamundaBpmnIT.java
+++ b/evals/skills/camunda-bpmn/cpt-verifier/src/test/java/io/camunda/skills/evals/CamundaBpmnIT.java
@@ -1,0 +1,162 @@
+package io.camunda.skills.evals;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Behavioral verifier for camunda-bpmn skill evals.
+ *
+ * Which test runs is selected by the ``eval.sample.id`` system property
+ * (passed by the cpt_scorer). Each sample enables exactly one test via
+ * {@code @EnabledIfSystemProperty}:
+ *
+ *   linear-invoice-review      → reviewInvoiceUserTaskIsReached
+ *   exclusive-gateway-routing  → xorGatewayRoutesCorrectly (parameterized, 2 cases)
+ */
+@SpringBootTest
+@CamundaSpringProcessTest
+class CamundaBpmnIT {
+
+  private static final Path AGENT_WORKSPACE = Path.of("/agent-workspace");
+
+  @Autowired
+  private CamundaClient client;
+
+  // Field injection so CamundaProcessTestContext works in @ParameterizedTest methods
+  // (parameter injection is consumed by @CsvSource and can't be mixed with extensions).
+  @Autowired
+  private CamundaProcessTestContext context;
+
+  @BeforeAll
+  static void setup() {
+    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(30));
+  }
+
+  // ─── linear-invoice-review ──────────────────────────────────────────────
+
+  @Test
+  void reviewInvoiceUserTaskIsReached() throws Exception {
+    deploy();
+
+    // Auto-complete the service task so the process can reach isCompleted()
+    context.mockJobWorker("record-decision").thenComplete();
+
+    ProcessInstanceEvent instance =
+        client.newCreateInstanceCommand().bpmnProcessId("invoice-approval").latestVersion()
+            .send().join();
+
+    // Process should reach the ReviewInvoice user task (element id from the sample prompt)
+    CamundaAssert.assertThat(instance).hasActiveElements("ReviewInvoice");
+    context.completeUserTask("ReviewInvoice");
+    CamundaAssert.assertThat(instance).isCompleted();
+  }
+
+  // ─── exclusive-gateway-routing ──────────────────────────────────────────
+
+  @ParameterizedTest(name = "{3}")
+  @CsvSource({
+    "1500, manual-approval, auto-approval, amount > 1000 routes to manual-approval",
+    "100, auto-approval, manual-approval, amount <= 1000 routes to auto-approval"
+  })
+  void xorGatewayRoutesCorrectly(int amount, String expectedType, String unexpectedType, String label)
+      throws Exception {
+    deploy();
+
+    // Auto-complete the service tasks that bracket the gateway
+    context.mockJobWorker("validate-order").thenComplete();
+    context.mockJobWorker("send-confirmation").thenComplete();
+
+    ProcessInstanceEvent instance =
+        client.newCreateInstanceCommand()
+            .bpmnProcessId("order-fulfillment")
+            .latestVersion()
+            .variables(Map.of("amount", amount))
+            .send()
+            .join();
+
+    // After validate-order auto-completes, the XOR gateway fires.
+    // Assert the expected branch produced a job (job type from the sample prompt).
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newJobSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(instance.getProcessInstanceKey())
+                                        .type(expectedType))
+                            .send()
+                            .join()
+                            .items())
+                    .as("Expected job type '%s' for amount=%d", expectedType, amount)
+                    .isNotEmpty());
+
+    // Assert the other branch was not taken
+    assertThat(
+            client
+                .newJobSearchRequest()
+                .filter(
+                    f ->
+                        f.processInstanceKey(instance.getProcessInstanceKey())
+                            .type(unexpectedType))
+                .send()
+                .join()
+                .items())
+        .as("Unexpected job type '%s' should not be active for amount=%d", unexpectedType, amount)
+        .isEmpty();
+
+    // Complete the routed branch and verify the full process runs to completion
+    context.completeJob(expectedType);
+    CamundaAssert.assertThat(instance).isCompleted();
+  }
+
+  // ─── helpers ────────────────────────────────────────────────────────────
+
+  private void deploy() throws Exception {
+    Path bpmn = findAgentBpmn();
+    client.newDeployResourceCommand().addResourceFile(bpmn.toString()).send().join();
+  }
+
+  private static Path findAgentBpmn() throws IOException {
+    if (!Files.isDirectory(AGENT_WORKSPACE)) {
+      throw new IllegalStateException("Agent workspace not present at " + AGENT_WORKSPACE);
+    }
+    try (Stream<Path> tree = Files.walk(AGENT_WORKSPACE, 5)) {
+      return tree
+          .filter(p -> p.toString().endsWith(".bpmn"))
+          .filter(p -> !p.toString().contains("/skills/"))
+          .findFirst()
+          .orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      "No *.bpmn found under "
+                          + AGENT_WORKSPACE
+                          + " — did the agent save its BPMN under /workspace?"));
+    }
+  }
+
+  @SpringBootConfiguration
+  static class TestApp {}
+}

--- a/evals/skills/camunda-bpmn/cpt-verifier/src/test/java/io/camunda/skills/evals/CamundaBpmnIT.java
+++ b/evals/skills/camunda-bpmn/cpt-verifier/src/test/java/io/camunda/skills/evals/CamundaBpmnIT.java
@@ -26,10 +26,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 /**
  * Behavioral verifier for camunda-bpmn skill evals.
  *
- * Which test runs is selected by the ``eval.sample.id`` system property
- * (passed by the cpt_scorer). Each sample enables exactly one test via
- * {@code @EnabledIfSystemProperty}:
- *
+ * The cpt_scorer selects which test runs via surefire {@code -Dtest=ClassName#methodName}:
  *   linear-invoice-review      → reviewInvoiceUserTaskIsReached
  *   exclusive-gateway-routing  → xorGatewayRoutesCorrectly (parameterized, 2 cases)
  */
@@ -56,7 +53,9 @@ class CamundaBpmnIT {
 
   @Test
   void reviewInvoiceUserTaskIsReached() throws Exception {
-    deploy();
+    // Deploy the BPMN together with the referenced form so Camunda 8.9 can
+    // create the Zeebe user task entity (FORM_NOT_FOUND incident otherwise).
+    deployWithForm("review-invoice.form");
 
     // Auto-complete the service task so the process can reach isCompleted()
     context.mockJobWorker("record-decision").thenComplete();
@@ -135,8 +134,15 @@ class CamundaBpmnIT {
   // ─── helpers ────────────────────────────────────────────────────────────
 
   private void deploy() throws Exception {
-    Path bpmn = findAgentBpmn();
-    client.newDeployResourceCommand().addResourceFile(bpmn.toString()).send().join();
+    client.newDeployResourceCommand().addResourceFile(findAgentBpmn().toString()).send().join();
+  }
+
+  private void deployWithForm(final String... classpathForms) throws Exception {
+    var cmd = client.newDeployResourceCommand().addResourceFile(findAgentBpmn().toString());
+    for (String form : classpathForms) {
+      cmd = cmd.addResourceFromClasspath(form);
+    }
+    cmd.send().join();
   }
 
   private static Path findAgentBpmn() throws IOException {

--- a/evals/skills/camunda-bpmn/cpt-verifier/src/test/resources/application.yml
+++ b/evals/skills/camunda-bpmn/cpt-verifier/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+# CPT runs in remote mode against the orchestration cluster mounted
+# into the verifier's network namespace (compose: network_mode =
+# service:orchestration). REST + management endpoints are reachable
+# on localhost.
+camunda:
+  process-test:
+    runtime-mode: remote
+    remote:
+      camunda-monitoring-api-address: http://127.0.0.1:9600
+      runtime-connection-timeout: PT1M
+  client:
+    rest-address: http://127.0.0.1:8080
+    grpc-address: http://127.0.0.1:26500

--- a/evals/skills/camunda-bpmn/cpt-verifier/src/test/resources/review-invoice.form
+++ b/evals/skills/camunda-bpmn/cpt-verifier/src/test/resources/review-invoice.form
@@ -1,0 +1,8 @@
+{
+  "id": "review-invoice",
+  "type": "default",
+  "components": [],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.6.0",
+  "schemaVersion": 17
+}

--- a/evals/skills/camunda-bpmn/cpt-verifier/src/test/resources/review-invoice.form
+++ b/evals/skills/camunda-bpmn/cpt-verifier/src/test/resources/review-invoice.form
@@ -3,6 +3,6 @@
   "type": "default",
   "components": [],
   "executionPlatform": "Camunda Cloud",
-  "executionPlatformVersion": "8.6.0",
+  "executionPlatformVersion": "8.9.0",
   "schemaVersion": 17
 }

--- a/evals/skills/camunda-bpmn/outcomes.py
+++ b/evals/skills/camunda-bpmn/outcomes.py
@@ -1,14 +1,19 @@
-"""camunda-bpmn outcome eval: create a BPMN process that lints clean.
+"""camunda-bpmn outcome eval: author a BPMN process, lint-clean and behaviorally correct.
 
-Failure mode: hand-written XML errors — missing DI blocks, bad coordinates,
-fake-join gateways, and missing Zeebe extensions that cause ``c8ctl bpmn lint``
-to report errors or warnings.
+Two samples exercise the two canonical skill paths:
 
-Each sample asks the agent to build a process and save it to
-/workspace/process.bpmn. The ``bpmn_lint_clean`` scorer runs
-``c8ctl bpmn lint`` on every *.bpmn under /workspace and scores 1.0
-only when every file is clean. No live cluster needed — bpmn lint is a
-static check, so the lighter advisory sandbox is sufficient.
+  linear-invoice-review     — user task + service task in sequence
+  exclusive-gateway-routing — XOR gateway routing on a variable condition
+
+Scorers:
+  bpmn_lint_clean  — static: c8ctl bpmn lint reports zero errors/warnings
+  cpt_scorer       — behavioral: CPT verifier deploys the BPMN and asserts
+                     routing behavior (invoice-approval: reaches ReviewInvoice;
+                     order-fulfillment: manual-approval for amount>1000,
+                     auto-approval for amount<=1000)
+
+  The CPT scorer selects the matching test method via surefire ``-Dtest=``
+  rather than filtering inside the Java test, keeping the verifier plain JUnit.
 """
 
 from __future__ import annotations
@@ -20,10 +25,18 @@ from core.agents import AgentKind, build_agent
 from core.metadata import EvalMetadata
 from core.paths import SANDBOXES_DIR, Arm, skill_dirs_for_arm
 from scorers.bpmn_lint import bpmn_lint_clean
+from scorers.cpt import cpt_scorer
 from scorers.transcript import assert_skill_loaded
 from solvers.collect_artifacts import with_artifact_collection
 
-METADATA = EvalMetadata(skills=["camunda-bpmn"], max_sandboxes=2)
+METADATA = EvalMetadata(skills=["camunda-bpmn"], max_sandboxes=1)
+
+# Maps each sample to the surefire test filter that exercises it.
+# Surefire syntax: ClassName#methodName (selects all parameterized cases of that method).
+SAMPLE_TESTS = {
+    "linear-invoice-review": "CamundaBpmnIT#reviewInvoiceUserTaskIsReached",
+    "exclusive-gateway-routing": "CamundaBpmnIT#xorGatewayRoutesCorrectly",
+}
 
 SAVE = (
     "\n\nSave the finished process to /workspace/process.bpmn. "
@@ -79,11 +92,18 @@ def camunda_bpmn(arm: Arm = "with_skill", agent: AgentKind = "react") -> Task:
         solver=with_artifact_collection(build_agent(agent, skill_dirs, submit=False)),
         scorer=[
             bpmn_lint_clean(),
+            cpt_scorer(
+                project_dir="/skills/camunda-bpmn/cpt-verifier",
+                mvn_extra=lambda sid: (
+                    [f"-Dtest={SAMPLE_TESTS[sid]}"] if sid in SAMPLE_TESTS else []
+                ),
+            ),
             assert_skill_loaded("camunda-bpmn", gating=False),
         ],
-        sandbox=("docker", str(SANDBOXES_DIR / "compose-advisory.yaml")),
+        sandbox=("docker", str(SANDBOXES_DIR / "compose-cpt-verifier.yaml")),
         metadata=METADATA.model_dump(),
-        time_limit=300,
+        # time_limit covers agent run + CPT scoring; 720s leaves ~360s for mvn test.
+        time_limit=720,
         token_limit=100_000,
         message_limit=50,
     )

--- a/evals/skills/camunda-bpmn/outcomes.py
+++ b/evals/skills/camunda-bpmn/outcomes.py
@@ -38,11 +38,7 @@ SAMPLE_TESTS = {
     "exclusive-gateway-routing": "CamundaBpmnIT#xorGatewayRoutesCorrectly",
 }
 
-SAVE = (
-    "\n\nSave the finished process to /workspace/process.bpmn. "
-    "Run ``c8ctl bpmn lint /workspace/process.bpmn`` and fix every error "
-    "and warning before finishing — the file must lint completely clean."
-)
+SAVE = "\n\nSave the finished process to /workspace/process.bpmn."
 
 SAMPLES = [
     Sample(

--- a/evals/skills/camunda-bpmn/outcomes.py
+++ b/evals/skills/camunda-bpmn/outcomes.py
@@ -1,0 +1,89 @@
+"""camunda-bpmn outcome eval: create a BPMN process that lints clean.
+
+Failure mode: hand-written XML errors — missing DI blocks, bad coordinates,
+fake-join gateways, and missing Zeebe extensions that cause ``c8ctl bpmn lint``
+to report errors or warnings.
+
+Each sample asks the agent to build a process and save it to
+/workspace/process.bpmn. The ``bpmn_lint_clean`` scorer runs
+``c8ctl bpmn lint`` on every *.bpmn under /workspace and scores 1.0
+only when every file is clean. No live cluster needed — bpmn lint is a
+static check, so the lighter advisory sandbox is sufficient.
+"""
+
+from __future__ import annotations
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+
+from core.agents import AgentKind, build_agent
+from core.metadata import EvalMetadata
+from core.paths import SANDBOXES_DIR, Arm, skill_dirs_for_arm
+from scorers.bpmn_lint import bpmn_lint_clean
+from scorers.transcript import assert_skill_loaded
+from solvers.collect_artifacts import with_artifact_collection
+
+METADATA = EvalMetadata(skills=["camunda-bpmn"], max_sandboxes=2)
+
+SAVE = (
+    "\n\nSave the finished process to /workspace/process.bpmn. "
+    "Run ``c8ctl bpmn lint /workspace/process.bpmn`` and fix every error "
+    "and warning before finishing — the file must lint completely clean."
+)
+
+SAMPLES = [
+    Sample(
+        id="linear-invoice-review",
+        input=(
+            "Create a BPMN 2.0 process for invoice approval "
+            "(process id: invoice-approval, name: 'Invoice Approval'). "
+            "The process must contain, in order:\n"
+            "1. A start event named 'Invoice received'\n"
+            "2. A user task named 'Review invoice' "
+            "(element id: ReviewInvoice, formId: review-invoice)\n"
+            "3. A service task named 'Record decision' "
+            "(element id: RecordDecision, type: record-decision)\n"
+            "4. An end event named 'Done'\n"
+            "All elements must be connected in sequence with sequence flows, "
+            "and the process must include a BPMN DI diagram section." + SAVE
+        ),
+    ),
+    Sample(
+        id="exclusive-gateway-routing",
+        input=(
+            "Create a BPMN 2.0 process "
+            "(process id: order-fulfillment, name: 'Order Fulfillment') that:\n"
+            "1. Starts with an event named 'Order received'\n"
+            "2. Has a service task 'Validate order' (type: validate-order)\n"
+            "3. Routes via an exclusive (XOR) gateway named 'Amount exceeds limit?' — "
+            "the condition branch for amount > 1000 leads to a service task "
+            "'Approve manually' (type: manual-approval); the default branch leads to "
+            "'Auto-approve' (type: auto-approval)\n"
+            "4. Both branches merge at an exclusive (XOR) join gateway\n"
+            "5. Continues to 'Send confirmation' (type: send-confirmation)\n"
+            "6. Ends with an event named 'Done'\n"
+            "Use a matching XOR join for the XOR fork. "
+            "The process must include correct BPMN DI coordinates for all elements."
+            + SAVE
+        ),
+    ),
+]
+
+
+@task
+def camunda_bpmn(arm: Arm = "with_skill", agent: AgentKind = "react") -> Task:
+    skill_dirs = skill_dirs_for_arm(arm, METADATA.excluded_skills)
+    return Task(
+        dataset=SAMPLES,
+        # submit=False: .bpmn file is the deliverable; halt once it's lint-clean.
+        solver=with_artifact_collection(build_agent(agent, skill_dirs, submit=False)),
+        scorer=[
+            bpmn_lint_clean(),
+            assert_skill_loaded("camunda-bpmn", gating=False),
+        ],
+        sandbox=("docker", str(SANDBOXES_DIR / "compose-advisory.yaml")),
+        metadata=METADATA.model_dump(),
+        time_limit=300,
+        token_limit=100_000,
+        message_limit=50,
+    )

--- a/evals/skills/camunda-bpmn/outcomes.py
+++ b/evals/skills/camunda-bpmn/outcomes.py
@@ -50,34 +50,29 @@ SAMPLES = [
         input=(
             "Create a BPMN 2.0 process for invoice approval "
             "(process id: invoice-approval, name: 'Invoice Approval'). "
-            "The process must contain, in order:\n"
+            "The process must contain:\n"
             "1. A start event named 'Invoice received'\n"
             "2. A user task named 'Review invoice' "
             "(element id: ReviewInvoice, formId: review-invoice)\n"
             "3. A service task named 'Record decision' "
             "(element id: RecordDecision, type: record-decision)\n"
-            "4. An end event named 'Done'\n"
-            "All elements must be connected in sequence with sequence flows, "
-            "and the process must include a BPMN DI diagram section." + SAVE
+            "4. An end event named 'Done'" + SAVE
         ),
     ),
     Sample(
         id="exclusive-gateway-routing",
         input=(
-            "Create a BPMN 2.0 process "
-            "(process id: order-fulfillment, name: 'Order Fulfillment') that:\n"
-            "1. Starts with an event named 'Order received'\n"
-            "2. Has a service task 'Validate order' (type: validate-order)\n"
-            "3. Routes via an exclusive (XOR) gateway named 'Amount exceeds limit?' — "
-            "the condition branch for amount > 1000 leads to a service task "
-            "'Approve manually' (type: manual-approval); the default branch leads to "
-            "'Auto-approve' (type: auto-approval)\n"
-            "4. Both branches merge at an exclusive (XOR) join gateway\n"
-            "5. Continues to 'Send confirmation' (type: send-confirmation)\n"
-            "6. Ends with an event named 'Done'\n"
-            "Use a matching XOR join for the XOR fork. "
-            "The process must include correct BPMN DI coordinates for all elements."
-            + SAVE
+            "Model an order fulfillment process "
+            "(process id: order-fulfillment, name: 'Order Fulfillment'):\n"
+            "1. Start when an order arrives ('Order received')\n"
+            "2. Validate the order (service task 'Validate order', type: validate-order)\n"
+            "3. Route based on amount: orders over 1000 go to manual approval "
+            "(service task 'Approve manually', type: manual-approval); "
+            "smaller orders are auto-approved "
+            "(service task 'Auto-approve', type: auto-approval)\n"
+            "4. After either path, send a confirmation "
+            "(service task 'Send confirmation', type: send-confirmation)\n"
+            "5. End the process ('Done')" + SAVE
         ),
     ),
 ]

--- a/evals/skills/camunda-bpmn/outcomes_baseline.json
+++ b/evals/skills/camunda-bpmn/outcomes_baseline.json
@@ -3,14 +3,14 @@
   "with_skill": {
     "samples": {
       "exclusive-gateway-routing": {
-        "tokens": 77726,
-        "turns": 8,
-        "tool_calls": 7
+        "tokens": 67017,
+        "turns": 5,
+        "tool_calls": 5
       },
       "linear-invoice-review": {
-        "tokens": 92462,
-        "turns": 8,
-        "tool_calls": 8
+        "tokens": 69983,
+        "turns": 5,
+        "tool_calls": 6
       }
     }
   }

--- a/evals/skills/camunda-bpmn/outcomes_baseline.json
+++ b/evals/skills/camunda-bpmn/outcomes_baseline.json
@@ -1,0 +1,17 @@
+{
+  "model": "anthropic/bedrock/global.anthropic.claude-sonnet-4-6",
+  "with_skill": {
+    "samples": {
+      "exclusive-gateway-routing": {
+        "tokens": 109605,
+        "turns": 8,
+        "tool_calls": 9
+      },
+      "linear-invoice-review": {
+        "tokens": 111150,
+        "turns": 7,
+        "tool_calls": 9
+      }
+    }
+  }
+}

--- a/evals/skills/camunda-bpmn/outcomes_baseline.json
+++ b/evals/skills/camunda-bpmn/outcomes_baseline.json
@@ -3,14 +3,14 @@
   "with_skill": {
     "samples": {
       "exclusive-gateway-routing": {
-        "tokens": 109605,
+        "tokens": 77726,
         "turns": 8,
-        "tool_calls": 9
+        "tool_calls": 7
       },
       "linear-invoice-review": {
-        "tokens": 111150,
-        "turns": 7,
-        "tool_calls": 9
+        "tokens": 92462,
+        "turns": 8,
+        "tool_calls": 8
       }
     }
   }

--- a/evals/src/scorers/cpt.py
+++ b/evals/src/scorers/cpt.py
@@ -2,17 +2,26 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from inspect_ai.scorer import Score, Scorer, Target, mean, scorer, stderr
 from inspect_ai.solver import TaskState
 from inspect_ai.util import sandbox
 
 
 @scorer(metrics=[mean(), stderr()])
-def cpt_scorer(project_dir: str) -> Scorer:
+def cpt_scorer(
+    project_dir: str,
+    mvn_extra: Callable[[str], list[str]] | None = None,
+) -> Scorer:
     """Run ``mvn test`` and score 1.0 on success, 0.0 on any failure.
 
     ``project_dir`` is the path inside the verifier container, e.g.
     ``/scenarios/rocket-launch/cpt-verifier``.
+
+    ``mvn_extra`` is an optional callable that receives the current
+    ``state.sample_id`` and returns additional Maven arguments, e.g.
+    ``lambda sid: ["-Dtest=MyIT#myMethod"]`` to restrict which test runs.
     """
 
     async def score(state: TaskState, target: Target) -> Score:
@@ -27,8 +36,9 @@ def cpt_scorer(project_dir: str) -> Scorer:
                 explanation=f"could not copy CPT project from {project_dir}: "
                 f"{copy.stderr[-500:]}",
             )
+        extra = mvn_extra(state.sample_id or "") if mvn_extra else []
         run = await sb.exec(
-            ["mvn", "-B", "-f", "/verifier-workspace/pom.xml", "test"],
+            ["mvn", "-B", "-f", "/verifier-workspace/pom.xml", "test"] + extra,
             timeout=600,
         )
         passed = run.returncode == 0


### PR DESCRIPTION
## Description

Adds a behavioral outcome eval for the `camunda-bpmn` skill using Camunda Process Test (CPT) in remote-runtime mode. Two samples exercise the canonical skill paths:

- **linear-invoice-review** — user task + service task in sequence; verifies the process reaches `ReviewInvoice`, the user task is completable, and the process completes
- **exclusive-gateway-routing** — XOR gateway routing on a variable condition; verifies `amount > 1000` routes to `manual-approval` and `amount ≤ 1000` routes to `auto-approval` (parameterized, 2 cases)

Both samples score 1.0 on `bpmn_lint_clean` and `cpt_scorer` with the current skill.

**Key implementation notes:**
- `cpt_scorer` gains an `mvn_extra: Callable` parameter; per-sample test selection uses surefire `-Dtest=ClassName#method` rather than Java annotations
- `CamundaProcessTestContext` is field-injected (`@Autowired`) so `@ParameterizedTest @CsvSource` works (parameter slots would otherwise conflict)
- `reviewInvoiceUserTaskIsReached` deploys a minimal `review-invoice.form` alongside the agent BPMN; without it Camunda 8.9 raises `FORM_NOT_FOUND` and never creates the Zeebe user task entity
- Eval prompts are written as natural human requests — no "XOR gateway", "join gateway", or "DI coordinates" hints; the skill guides the agent to lint and fix

Closes #

## Checklist

- [x] `make lint` passes (advisory warnings are pre-existing on main)
- [ ] Updated `SKILL.md` / `references/` if behaviour changed