### PR TITLE
refactor(evals): run at temperature=0 for deterministic comparisons

### DIFF
--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -146,7 +146,7 @@ jobs:
           dir="${spec%/outcomes.py}"   # skills/<name> or scenarios/<name>
           uv run inspect eval "$spec" --log-dir logs/ \
             --display ${{ matrix.display }} ${{ matrix.limit }} --epochs "$EPOCHS" \
-            --model "$MODEL" ${{ matrix.targs }} \
+            --model "$MODEL" --temperature 0 ${{ matrix.targs }} \
             || echo "::warning::run failed for $dir"
           # Regeneration refuses (non-zero) unless every sample passed. Stage the
           # file only on success — a refused target stages nothing, so the commit

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -174,6 +174,7 @@ jobs:
         run: |
           uv run inspect eval "${{ matrix.spec }}" --log-dir logs/ --display ${{ matrix.display }} ${{ matrix.limit }} \
             --model "${{ vars.EVAL_MODEL || 'anthropic/bedrock/global.anthropic.claude-sonnet-4-6' }}" \
+            --temperature 0 \
             ${{ matrix.targs }}
 
       - name: Gate (evals-pass-fail)

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ AGENT ?= react
 # Arbitrary extra flags forwarded to `inspect eval`.
 # Example: make run-outcome-evals TARGET=scenarios/rocket-launch ARGS="--epochs 3"
 ARGS ?=
+# Temperature for all eval runs. Default 0 for deterministic, reproducible runs
+# that compare cleanly against baselines. Override with TEMPERATURE=1 for
+# stochastic exploration.
+TEMPERATURE ?= 0
 # Trigger evals are sandbox-free model calls, so their samples run fully in
 # parallel. Caps concurrent samples per skill; raise it if a skill grows.
 TRIGGER_SAMPLES ?= 20
@@ -56,9 +60,10 @@ help:
 	@echo "  TARGET    Outcome eval dir path (skills/<name> or scenarios/<name>), for run-outcome-evals / regenerate-baseline."
 	@echo "  ARM       Comparison arm: with_skill (default) or without_skill."
 	@echo "  MODEL     Inspect model id (default anthropic/bedrock/global.anthropic.claude-sonnet-4-6; needs AWS creds)."
-	@echo "  AGENT     Agent loop: react (default) or claude_code."
-	@echo "  ARGS      Extra flags forwarded to 'inspect eval' (run-trigger-evals / run-outcome-evals)."
-	@echo "            Example: ARGS=\"--epochs 3\""
+	@echo "  AGENT       Agent loop: react (default) or claude_code."
+	@echo "  TEMPERATURE Temperature for inspect eval (default 0 — deterministic). Override with TEMPERATURE=1 for stochastic runs."
+	@echo "  ARGS        Extra flags forwarded to 'inspect eval' (run-trigger-evals / run-outcome-evals)."
+	@echo "              Example: ARGS=\"--epochs 3\""
 	@echo ""
 	@echo "Notes:"
 	@echo "  run-outcome-evals runs at each eval's METADATA.max_sandboxes (default 1, sequential)."
@@ -108,7 +113,7 @@ run-trigger-evals:
 	else \
 		t="skills/*/triggers.py"; \
 	fi; \
-	uv run inspect eval $$t --log-dir logs/ --max-samples $(TRIGGER_SAMPLES) --model $(MODEL) $(ARGS)
+	uv run inspect eval $$t --log-dir logs/ --max-samples $(TRIGGER_SAMPLES) --model $(MODEL) --temperature $(TEMPERATURE) $(ARGS)
 
 # Outcome evals run in a Docker sandbox. With TARGET=<dir> runs that one;
 # without, runs the whole suite (slow + costly). TARGET is the eval dir path,
@@ -130,7 +135,7 @@ run-outcome-evals:
 	for s in "$$@"; do \
 		ms=$$(printf '%s' "$$targets" | uv run python -c "import sys,json; print(next((t['max_sandboxes'] for t in json.load(sys.stdin) if t['path']==sys.argv[1]), 1))" "$$s"); \
 		echo "=== $$s (max-sandboxes $$ms) ==="; \
-		uv run inspect eval "$$s" --log-dir logs/ --max-sandboxes $$ms --model $(MODEL) -T arm=$(ARM) -T agent=$(AGENT) $(ARGS) || exit $$?; \
+		uv run inspect eval "$$s" --log-dir logs/ --max-sandboxes $$ms --model $(MODEL) --temperature $(TEMPERATURE) -T arm=$(ARM) -T agent=$(AGENT) $(ARGS) || exit $$?; \
 		uv run evals-extract-artifacts || exit $$?; \
 	done
 

--- a/evals/scenarios/rocket-launch/outcomes_baseline.json
+++ b/evals/scenarios/rocket-launch/outcomes_baseline.json
@@ -3,9 +3,9 @@
   "with_skill": {
     "samples": {
       "timer-countdown": {
-        "tokens": 496008,
-        "turns": 22,
-        "tool_calls": 23
+        "tokens": 465076,
+        "turns": 21,
+        "tool_calls": 22
       }
     }
   }

--- a/evals/skills/camunda-bpmn/outcomes_baseline.json
+++ b/evals/skills/camunda-bpmn/outcomes_baseline.json
@@ -3,13 +3,13 @@
   "with_skill": {
     "samples": {
       "exclusive-gateway-routing": {
-        "tokens": 67017,
+        "tokens": 67246,
         "turns": 5,
         "tool_calls": 5
       },
       "linear-invoice-review": {
-        "tokens": 69983,
-        "turns": 5,
+        "tokens": 77856,
+        "turns": 6,
         "tool_calls": 6
       }
     }

--- a/evals/skills/camunda-c8ctl/outcomes_baseline.json
+++ b/evals/skills/camunda-c8ctl/outcomes_baseline.json
@@ -3,17 +3,17 @@
   "with_skill": {
     "samples": {
       "get-topology": {
-        "tokens": 47099,
-        "turns": 5,
-        "tool_calls": 4
+        "tokens": 57155,
+        "turns": 6,
+        "tool_calls": 5
       },
       "install-cli": {
-        "tokens": 89675,
+        "tokens": 90110,
         "turns": 9,
         "tool_calls": 8
       },
       "list-users": {
-        "tokens": 56627,
+        "tokens": 56652,
         "turns": 6,
         "tool_calls": 5
       }

--- a/evals/skills/camunda-development/outcomes_baseline.json
+++ b/evals/skills/camunda-development/outcomes_baseline.json
@@ -3,37 +3,37 @@
   "with_skill": {
     "samples": {
       "ai-agent-ticket-triage": {
-        "tokens": 32659,
+        "tokens": 31777,
         "turns": 3,
         "tool_calls": 2
       },
       "custom-inbound-webhook": {
-        "tokens": 29978,
+        "tokens": 29634,
         "turns": 3,
         "tool_calls": 2
       },
       "public-rest-api": {
-        "tokens": 17046,
+        "tokens": 16749,
         "turns": 2,
         "tool_calls": 1
       },
       "reusable-internal-api": {
-        "tokens": 30510,
+        "tokens": 30295,
         "turns": 3,
         "tool_calls": 2
       },
       "slack-notification": {
-        "tokens": 29443,
+        "tokens": 29735,
         "turns": 3,
         "tool_calls": 2
       },
       "spring-embedded-throughput": {
-        "tokens": 46649,
+        "tokens": 46092,
         "turns": 4,
         "tool_calls": 4
       },
       "ts-node-stack": {
-        "tokens": 43170,
+        "tokens": 42977,
         "turns": 4,
         "tool_calls": 3
       }

--- a/evals/skills/camunda-feel/outcomes_baseline.json
+++ b/evals/skills/camunda-feel/outcomes_baseline.json
@@ -3,17 +3,17 @@
   "with_skill": {
     "samples": {
       "bool-guard": {
-        "tokens": 23568,
+        "tokens": 23536,
         "turns": 3,
         "tool_calls": 2
       },
       "list-sum": {
-        "tokens": 32637,
+        "tokens": 32585,
         "turns": 4,
         "tool_calls": 3
       },
       "string-greeting": {
-        "tokens": 32531,
+        "tokens": 32422,
         "turns": 4,
         "tool_calls": 3
       }


### PR DESCRIPTION
## Description

Sampling randomness at default temperature produces ±10-15% token variance between runs, which swamps the signal from skill optimizations and makes baseline comparisons unreliable without inspecting transcripts.

Setting `temperature=0` makes individual CI runs directly comparable to the baseline without needing multi-epoch averaging to cancel noise.

Changes:
- `eval.yml`: `--temperature 0` on every `inspect eval` run
- `eval-baseline.yml`: `--temperature 0` on baseline regeneration runs
- `Makefile`: `TEMPERATURE ?= 0` variable wired into `run-trigger-evals` and `run-outcome-evals`; overridable with `TEMPERATURE=1` for stochastic exploration

Closes #

## Checklist

- [ ] `make lint` passes
- [ ] Updated `SKILL.md` / `references/` if behaviour changed