### PR TITLE
feat(camunda-process-test): add Web Modeler scenario file support

### DIFF
--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -33,7 +33,8 @@ Author and run Camunda Process Test suites for Camunda 8.8+ that reach **100% BP
 ## Scope boundaries
 
 - **In scope**: BPMN reachability (every element visited at least once), gateway-branch selection, DMN rule selection, error-boundary firing, timer / escalation boundary firing, end-event selection.
-- **Out of scope**: asserting data values produced by service tasks, external system payloads, UI behavior, agent / LLM output. Do not write `ASSERT_VARIABLE` instructions on service-task output unless the variable is the FEEL input to a downstream gateway you also test.
+- **Out of scope**: asserting exact data values produced by service tasks, external system payloads, UI behavior. Do not write `ASSERT_VARIABLE` instructions on service-task output unless the variable is the FEEL input to a downstream gateway you also test.
+- **Agentic exception**: behavioral quality of AI agent output (LLM-as-Judge, semantic similarity) is **in scope** for agentic process segments when the agent's response text drives downstream routing or is itself the test subject (e.g. regression detection on model swap). These assertions are Java-only — they are not renderable in Web Modeler. See [references/judge-configuration.md](references/judge-configuration.md).
 
 ## Workflow
 
@@ -46,6 +47,8 @@ Find the BPMN under test in priority order:
 3. `../resources/` (Node.js layouts where the test harness lives in `test/`)
 
 Skip `target/`, `node_modules/`, `.git/`, `build/`. If multiple files match, list them and ask which to target.
+
+**Web Modeler scenario files.** After finding the BPMN, also scan the same resources directory for `* test scenarios.json` files (spaces in the name, no `.test.json` suffix). If found, do **not** author new CPT unit-test scenarios for those processes — go to [references/web-modeler-scenarios.md](references/web-modeler-scenarios.md) instead and follow the one-shot setup guide there. WM scenario files and hand-authored CPT scenarios serve different purposes and must live in separate test classes.
 
 Check `pom.xml` (or `test/pom.xml`) for `camunda-process-test-spring`. If missing, go to step 2.
 
@@ -67,7 +70,7 @@ Plan the minimum number of segments **before** authoring anything. Apply [refere
 
 For each segment, write one entry inside `src/test/resources/scenarios/<processId>.test.json` using [references/authoring.md](references/authoring.md). Naming: `"<who/what> — <outcome>"`. Assertions: `ASSERT_ELEMENT_INSTANCES` on the elements the segment must visit, `ASSERT_PROCESS_INSTANCE` only when the segment runs to an end event.
 
-Use the Java fallback only when the segment needs Spring bean mocking, parameterized data tables, non-deterministic runtime races (`context.when().then()` *(8.9+)*), or assertions richer than the JSON instruction set offers — see [references/test-context.md](references/test-context.md). Accept that Java tests are invisible to Web Modeler.
+Use the Java fallback only when the segment needs Spring bean mocking, parameterized data tables, non-deterministic runtime races (`context.when().then()` *(8.9+)*), LLM behavioral quality assertions on agent output (8.9+), or assertions richer than the JSON instruction set offers — see [references/test-context.md](references/test-context.md) and [references/judge-configuration.md](references/judge-configuration.md). Accept that Java tests are invisible to Web Modeler.
 
 ### 5. Run
 
@@ -167,8 +170,10 @@ Duplicates flagged: 0
 ## References
 
 - [setup.md](references/setup.md) — Java, Maven, Docker prereqs; CPT dependency; test scaffold layout; Spring Boot 4.x pin
+- [web-modeler-scenarios.md](references/web-modeler-scenarios.md) — running Web Modeler-exported scenario files in CI/CD; cluster mode decision; ephemeral and remote templates; one-shot checklist
 - [coverage-strategy.md](references/coverage-strategy.md) — segment selection rules per BPMN element type, including ad-hoc subprocess tool activation
-- [authoring.md](references/authoring.md) — `.test.json` schema, full 8.9 instruction reference, Java fallback
-- [test-context.md](references/test-context.md) — `CamundaProcessTestContext` Java API surface (job/decision/child-process mocking, time control, conditional behavior)
+- [authoring.md](references/authoring.md) — `.test.json` schema, full 8.9 instruction reference, Java fallback, agentic evaluation assertions
+- [test-context.md](references/test-context.md) — `CamundaProcessTestContext` Java API surface (job/decision/child-process mocking, time control, conditional behavior, evaluation assertions)
+- [judge-configuration.md](references/judge-configuration.md) — LLM-as-Judge and semantic similarity configuration; provider setup; threshold tuning; use cases
 - [connectors-runtime.md](references/connectors-runtime.md) — enabling the Connectors runtime alongside Zeebe; WireMock pattern; inbound webhooks
 - [troubleshooting.md](references/troubleshooting.md) — failure diagnosis table (test problem vs. process problem)

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -33,8 +33,7 @@ Author and run Camunda Process Test suites for Camunda 8.8+ that reach **100% BP
 ## Scope boundaries
 
 - **In scope**: BPMN reachability (every element visited at least once), gateway-branch selection, DMN rule selection, error-boundary firing, timer / escalation boundary firing, end-event selection.
-- **Out of scope**: asserting exact data values produced by service tasks, external system payloads, UI behavior. Do not write `ASSERT_VARIABLE` instructions on service-task output unless the variable is the FEEL input to a downstream gateway you also test.
-- **Agentic exception**: behavioral quality of AI agent output (LLM-as-Judge, semantic similarity) is **in scope** for agentic process segments when the agent's response text drives downstream routing or is itself the test subject (e.g. regression detection on model swap). These assertions are Java-only — they are not renderable in Web Modeler. See [references/judge-configuration.md](references/judge-configuration.md).
+- **Out of scope**: asserting data values produced by service tasks, external system payloads, UI behavior, agent / LLM output. Do not write `ASSERT_VARIABLE` instructions on service-task output unless the variable is the FEEL input to a downstream gateway you also test.
 
 ## Workflow
 
@@ -86,7 +85,7 @@ Plan the minimum number of segments **before** authoring anything. Apply [refere
 
 For each segment, write one entry inside `src/test/resources/scenarios/<processId>.test.json` using [references/authoring.md](references/authoring.md). Naming: `"<who/what> — <outcome>"`. Assertions: `ASSERT_ELEMENT_INSTANCES` on the elements the segment must visit, `ASSERT_PROCESS_INSTANCE` only when the segment runs to an end event.
 
-Use the Java fallback only when the segment needs Spring bean mocking, parameterized data tables, non-deterministic runtime races (`context.when().then()` *(8.9+)*), LLM behavioral quality assertions on agent output (8.9+), or assertions richer than the JSON instruction set offers — see [references/test-context.md](references/test-context.md) and [references/judge-configuration.md](references/judge-configuration.md). Accept that Java tests are invisible to Web Modeler.
+Use the Java fallback only when the segment needs Spring bean mocking, parameterized data tables, non-deterministic runtime races (`context.when().then()` *(8.9+)*), or assertions richer than the JSON instruction set offers — see [references/test-context.md](references/test-context.md). Accept that Java tests are invisible to Web Modeler.
 
 ### 5. Run
 
@@ -196,11 +195,10 @@ These workflows are complementary: evaluate gaps first, implement new scenarios,
 ## References
 
 - [setup.md](references/setup.md) — Java, Maven, Docker prereqs; CPT dependency; test scaffold layout; Spring Boot 4.x pin
-- [web-modeler-scenarios.md](references/web-modeler-scenarios.md) — running Web Modeler-exported scenario files in CI/CD; cluster mode decision; ephemeral and remote templates; one-shot checklist
+- [web-modeler-scenarios.md](references/web-modeler-scenarios.md) — running Web Modeler-exported scenario files; cluster mode decision; ephemeral and remote templates; one-shot checklist
 - [coverage-strategy.md](references/coverage-strategy.md) — segment selection rules per BPMN element type, including ad-hoc subprocess tool activation
 - [authoring.md](references/authoring.md) — `.test.json` schema, full 8.9 instruction reference, Java fallback, agentic evaluation assertions
 - [test-context.md](references/test-context.md) — `CamundaProcessTestContext` Java API surface (job/decision/child-process mocking, time control, conditional behavior, evaluation assertions)
-- [judge-configuration.md](references/judge-configuration.md) — LLM-as-Judge and semantic similarity configuration; provider setup; threshold tuning; use cases
 - [connectors-runtime.md](references/connectors-runtime.md) — enabling the Connectors runtime alongside Zeebe; WireMock pattern; inbound webhooks
 - [troubleshooting.md](references/troubleshooting.md) — failure diagnosis table (test problem vs. process problem)
 - [run-and-diagnose.md](references/run-and-diagnose.md) — test-run execution loop and failure-batch repair strategy

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -195,7 +195,7 @@ These workflows are complementary: evaluate gaps first, implement new scenarios,
 ## References
 
 - [setup.md](references/setup.md) — Java, Maven, Docker prereqs; CPT dependency; test scaffold layout; Spring Boot 4.x pin
-- [web-modeler-scenarios.md](references/web-modeler-scenarios.md) — running Web Modeler-exported scenario files; cluster mode decision; ephemeral and remote templates; one-shot checklist
+- [web-modeler-scenarios.md](references/web-modeler-scenarios.md) — running Web Modeler-exported scenario files; cluster mode decision; ephemeral and remote templates; failsafe wiring and connectors bundle image version for any `*IT.java`
 - [coverage-strategy.md](references/coverage-strategy.md) — segment selection rules per BPMN element type, including ad-hoc subprocess tool activation
 - [authoring.md](references/authoring.md) — `.test.json` schema, full 8.9 instruction reference, Java fallback
 - [test-context.md](references/test-context.md) — `CamundaProcessTestContext` Java API surface (job/decision/child-process mocking, time control, conditional behavior)

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -197,8 +197,8 @@ These workflows are complementary: evaluate gaps first, implement new scenarios,
 - [setup.md](references/setup.md) — Java, Maven, Docker prereqs; CPT dependency; test scaffold layout; Spring Boot 4.x pin
 - [web-modeler-scenarios.md](references/web-modeler-scenarios.md) — running Web Modeler-exported scenario files; cluster mode decision; ephemeral and remote templates; one-shot checklist
 - [coverage-strategy.md](references/coverage-strategy.md) — segment selection rules per BPMN element type, including ad-hoc subprocess tool activation
-- [authoring.md](references/authoring.md) — `.test.json` schema, full 8.9 instruction reference, Java fallback, agentic evaluation assertions
-- [test-context.md](references/test-context.md) — `CamundaProcessTestContext` Java API surface (job/decision/child-process mocking, time control, conditional behavior, evaluation assertions)
+- [authoring.md](references/authoring.md) — `.test.json` schema, full 8.9 instruction reference, Java fallback
+- [test-context.md](references/test-context.md) — `CamundaProcessTestContext` Java API surface (job/decision/child-process mocking, time control, conditional behavior)
 - [connectors-runtime.md](references/connectors-runtime.md) — enabling the Connectors runtime alongside Zeebe; WireMock pattern; inbound webhooks
 - [troubleshooting.md](references/troubleshooting.md) — failure diagnosis table (test problem vs. process problem)
 - [run-and-diagnose.md](references/run-and-diagnose.md) — test-run execution loop and failure-batch repair strategy

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -39,6 +39,8 @@ Required entry in the project (or test harness) `pom.xml`:
 
 Use 8.9+ — the instruction-based `.test.json` format (`CREATE_PROCESS_INSTANCE`, `COMPLETE_JOB`, …) requires it.
 
+**Always use the latest stable (GA) release.** Never use RC, alpha, or SNAPSHOT versions in project pom files. RC and SNAPSHOT tags are not published for `camunda/connectors-bundle` on Docker Hub, so enabling the Connectors runtime with a non-GA version causes a `ContainerFetchException` at test startup. If an existing project uses an RC version, update it to the GA release before running tests with connectors enabled.
+
 ### Spring Boot 4.x pin (CPT 8.9.x only)
 
 CPT 8.9.x ships against Spring Boot 4.x. If the project already imports `spring-boot-dependencies` (e.g. via a parent BOM), pin the version explicitly or omit the BOM:
@@ -147,6 +149,36 @@ If the project root has `package.json` but no `pom.xml`, scaffold a sibling `tes
 ```
 
 Confirm the scaffold by running `mvn test-compile` from `test/`.
+
+## Failsafe plugin (integration tests)
+
+When adding an `*IT.java` class alongside `ProcessTest.java` (e.g. a Web Modeler integration test), add `maven-failsafe-plugin` to `pom.xml`. Surefire runs `*Test.java` on `mvn test`; failsafe runs `*IT.java` on `mvn verify`.
+
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-failsafe-plugin</artifactId>
+  <version>3.2.5</version>
+  <executions>
+    <execution>
+      <goals>
+        <goal>integration-test</goal>
+        <goal>verify</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+```
+
+See [web-modeler-scenarios.md](web-modeler-scenarios.md) for the full classpath and test-class setup for WM scenario files.
+
+## Connectors bundle image version
+
+If `connectors-enabled=true` is set, CPT pulls `camunda/connectors-bundle:<camunda.version>`. RC and SNAPSHOT tags are not published for this image on Docker Hub — always use a GA stable release as `camunda.version`. If you must use a different tag, override it:
+
+```
+io.camunda.process.test.connectors-docker-image-version=8.9.0
+```
 
 ## Filename hygiene
 

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -58,7 +58,7 @@ Required entry in the project (or test harness) `pom.xml`:
 
 Use 8.9+ — the instruction-based `.test.json` format (`CREATE_PROCESS_INSTANCE`, `COMPLETE_JOB`, …) requires it.
 
-**Always use the latest stable (GA) release.** Never use RC, alpha, or SNAPSHOT versions in project pom files. RC and SNAPSHOT tags are not published for `camunda/connectors-bundle` on Docker Hub, so enabling the Connectors runtime with a non-GA version causes a `ContainerFetchException` at test startup. If an existing project uses an RC version, update it to the GA release before running tests with connectors enabled.
+**Use a GA release, aligned with the version the target production cluster runs.** If connectors are enabled, the version also has to be one the connectors bundle image was published for — see [Connectors bundle image version](#connectors-bundle-image-version) below.
 
 ### Spring Boot 4.x pin (CPT 8.9.x only)
 
@@ -193,7 +193,11 @@ See [web-modeler-scenarios.md](web-modeler-scenarios.md) for the full classpath 
 
 ## Connectors bundle image version
 
-If `connectors-enabled=true` is set, CPT pulls `camunda/connectors-bundle:<camunda.version>`. RC and SNAPSHOT tags are not published for this image on Docker Hub — always use a GA stable release as `camunda.version`. If you must use a different tag, override it:
+If `connectors-enabled=true` is set, CPT pulls `camunda/connectors-bundle:<camunda.version>`. Prefer a GA release for `camunda.version`.
+
+The reason is tag coverage, not tag absence: `camunda/connectors-bundle` does publish `-rc*`, `-alpha*`, and `SNAPSHOT` tags, but not for every version `camunda/camunda` has. `8.7.0-alpha3-rc2`, `8.8.0-alpha3-rc3`, and `8.6.12-rc1` all exist for `camunda/camunda` with no connectors-bundle counterpart. When the derived tag doesn't exist, the test fails at startup with `ContainerFetchException` for `camunda/connectors-bundle:<version>`.
+
+So: pin a GA version, or check the exact tag exists on Docker Hub first. To use a tag that differs from `camunda.version`, override it:
 
 ```
 io.camunda.process.test.connectors-docker-image-version=8.9.0

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -56,7 +56,7 @@ Required entry in the project (or test harness) `pom.xml`:
 </dependencies>
 ```
 
-Use 8.9+ — the instruction-based `.test.json` format (`CREATE_PROCESS_INSTANCE`, `COMPLETE_JOB`, …) requires it.
+Use 8.9+ — the instruction-based `.test.json` format (`CREATE_PROCESS_INSTANCE`, `COMPLETE_JOB`, …) requires it. `camunda-process-test.version` above is the property this guide means wherever it refers to the CPT dependency version; the upstream docs call the same thing `camunda.version`.
 
 **Use a GA release, aligned with the version the target production cluster runs.** If connectors are enabled, the version also has to be one the connectors bundle image was published for — see [Connectors bundle image version](#connectors-bundle-image-version) below.
 
@@ -193,7 +193,7 @@ See [web-modeler-scenarios.md](web-modeler-scenarios.md) for the full classpath 
 
 ## Connectors bundle image version
 
-If `io.camunda.process.test.connectors-enabled=true` is set, CPT pulls `camunda/connectors-bundle:<camunda.version>`. Prefer a GA release for `camunda.version`.
+If `camunda.process-test.connectors-enabled=true` is set, CPT pulls `camunda/connectors-bundle:<version>`, where `<version>` defaults to the CPT dependency version on the classpath — the one pinned by `camunda-process-test.version` in the snippet above (the upstream docs pin the same dependency with a `camunda.version` property). Prefer a GA release for it.
 
 The reason is tag coverage, not tag absence: `camunda/connectors-bundle` does publish `-rc*`, `-alpha*`, and `SNAPSHOT` tags, but not for every version `camunda/camunda` has. Pre-release tags in particular are published per image and pruned independently, so a version that resolves for `camunda/camunda` can have no connectors-bundle counterpart (`8.6.12-rc1` was one such tag). When the derived tag doesn't exist, the test fails at startup with `ContainerFetchException` for `camunda/connectors-bundle:<version>`.
 
@@ -204,10 +204,10 @@ curl -sf "https://hub.docker.com/v2/repositories/camunda/connectors-bundle/tags/
   && echo "exists" || echo "missing — pin a GA version or override the tag"
 ```
 
-So: pin a GA version, or confirm the exact tag exists first. To use a tag that differs from `camunda.version`, override it:
+So: pin a GA version, or confirm the exact tag exists first. To use a tag that differs from the CPT dependency version, override it:
 
 ```
-io.camunda.process.test.connectors-docker-image-version=8.9.0
+camunda.process-test.connectors-docker-image-version=8.9.0
 ```
 
 ## Filename hygiene

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -200,9 +200,12 @@ The reason is tag coverage, not tag absence: `camunda/connectors-bundle` does pu
 Rather than trusting a list of known-missing tags, check the one you intend to use — pre-release tag coverage changes on both images:
 
 ```bash
+TAG=8.9.0   # the version you intend to pin
 curl -sf "https://hub.docker.com/v2/repositories/camunda/connectors-bundle/tags/${TAG}" >/dev/null \
   && echo "exists" || echo "missing — pin a GA version or override the tag"
 ```
+
+Set `TAG` before running it. With `TAG` empty the URL collapses to the tag-listing endpoint, which answers `200` for every image and reports "exists" regardless.
 
 So: pin a GA version, or confirm the exact tag exists first. To use a tag that differs from the CPT dependency version, override it:
 

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -171,9 +171,10 @@ Confirm the scaffold by running `mvn test-compile` from `test/`.
 
 ## Failsafe plugin (integration tests)
 
-When adding an `*IT.java` class alongside `ProcessTest.java` (e.g. a Web Modeler integration test), add `maven-failsafe-plugin` to `pom.xml`. Surefire runs `*Test.java` on `mvn test`; failsafe runs `*IT.java` on `mvn verify`.
+When adding an `*IT.java` class alongside `ProcessTest.java` (e.g. a Web Modeler integration test), add `maven-failsafe-plugin` under `<build><plugins>` in `pom.xml` — declared anywhere else it is silently ignored. Surefire runs `*Test.java` on `mvn test`; failsafe runs `*IT.java` on `mvn verify`.
 
 ```xml
+<!-- inside <build><plugins> -->
 <plugin>
   <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-failsafe-plugin</artifactId>

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -193,7 +193,7 @@ See [web-modeler-scenarios.md](web-modeler-scenarios.md) for the full classpath 
 
 ## Connectors bundle image version
 
-If `connectors-enabled=true` is set, CPT pulls `camunda/connectors-bundle:<camunda.version>`. Prefer a GA release for `camunda.version`.
+If `io.camunda.process.test.connectors-enabled=true` is set, CPT pulls `camunda/connectors-bundle:<camunda.version>`. Prefer a GA release for `camunda.version`.
 
 The reason is tag coverage, not tag absence: `camunda/connectors-bundle` does publish `-rc*`, `-alpha*`, and `SNAPSHOT` tags, but not for every version `camunda/camunda` has. Pre-release tags in particular are published per image and pruned independently, so a version that resolves for `camunda/camunda` can have no connectors-bundle counterpart (`8.6.12-rc1` was one such tag). When the derived tag doesn't exist, the test fails at startup with `ContainerFetchException` for `camunda/connectors-bundle:<version>`.
 

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -58,7 +58,7 @@ Required entry in the project (or test harness) `pom.xml`:
 
 Use 8.9+ — the instruction-based `.test.json` format (`CREATE_PROCESS_INSTANCE`, `COMPLETE_JOB`, …) requires it. `camunda-process-test.version` above is the property this guide means wherever it refers to the CPT dependency version; the upstream docs call the same thing `camunda.version`.
 
-**Use a GA release, aligned with the version the target production cluster runs.** If connectors are enabled, the version also has to be one the connectors bundle image was published for — see [Connectors bundle image version](#connectors-bundle-image-version) below.
+**Use a GA release, aligned with the version the target production cluster runs.** If connectors are enabled, the version also has to be one the connectors bundle image was published for — see [Connectors bundle image version](web-modeler-scenarios.md#connectors-bundle-image-version).
 
 ### Spring Boot 4.x pin (CPT 8.9.x only)
 
@@ -169,50 +169,9 @@ If the project root has `package.json` but no `pom.xml`, scaffold a sibling `tes
 
 Confirm the scaffold by running `mvn test-compile` from `test/`.
 
-## Failsafe plugin (integration tests)
+## Integration tests (`*IT.java`)
 
-When adding an `*IT.java` class alongside `ProcessTest.java` (e.g. a Web Modeler integration test), add `maven-failsafe-plugin` under `<build><plugins>` in `pom.xml` — declared anywhere else it is silently ignored. Surefire runs `*Test.java` on `mvn test`; failsafe runs `*IT.java` on `mvn verify`.
-
-```xml
-<!-- inside <build><plugins> -->
-<plugin>
-  <groupId>org.apache.maven.plugins</groupId>
-  <artifactId>maven-failsafe-plugin</artifactId>
-  <version>3.2.5</version>
-  <executions>
-    <execution>
-      <goals>
-        <goal>integration-test</goal>
-        <goal>verify</goal>
-      </goals>
-    </execution>
-  </executions>
-</plugin>
-```
-
-See [web-modeler-scenarios.md](web-modeler-scenarios.md) for the full classpath and test-class setup for WM scenario files.
-
-## Connectors bundle image version
-
-If `camunda.process-test.connectors-enabled=true` is set, CPT pulls `camunda/connectors-bundle:<version>`, where `<version>` defaults to the CPT dependency version on the classpath — the one pinned by `camunda-process-test.version` in the snippet above (the upstream docs pin the same dependency with a `camunda.version` property). Prefer a GA release for it.
-
-The reason is tag coverage, not tag absence: `camunda/connectors-bundle` does publish `-rc*`, `-alpha*`, and `SNAPSHOT` tags, but not for every version `camunda/camunda` has. Pre-release tags in particular are published per image and pruned independently, so a version that resolves for `camunda/camunda` can have no connectors-bundle counterpart (`8.6.12-rc1` was one such tag). When the derived tag doesn't exist, the test fails at startup with `ContainerFetchException` for `camunda/connectors-bundle:<version>`.
-
-Rather than trusting a list of known-missing tags, check the one you intend to use — pre-release tag coverage changes on both images:
-
-```bash
-TAG=8.9.0   # the version you intend to pin
-curl -sf "https://hub.docker.com/v2/repositories/camunda/connectors-bundle/tags/${TAG}" >/dev/null \
-  && echo "exists" || echo "missing — pin a GA version or override the tag"
-```
-
-Set `TAG` before running it. With `TAG` empty the URL collapses to the tag-listing endpoint, which answers `200` for every image and reports "exists" regardless.
-
-So: pin a GA version, or confirm the exact tag exists first. To use a tag that differs from the CPT dependency version, override it:
-
-```
-camunda.process-test.connectors-docker-image-version=8.9.0
-```
+Failsafe wiring, the connectors bundle image version constraint, and the classpath setup for integration tests live in [web-modeler-scenarios.md](web-modeler-scenarios.md). They apply only when you add an `*IT.java` class, so they are kept off this page — surefire runs `*Test.java` on `mvn test`, failsafe runs `*IT.java` on `mvn verify`.
 
 ## Filename hygiene
 

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -195,9 +195,16 @@ See [web-modeler-scenarios.md](web-modeler-scenarios.md) for the full classpath 
 
 If `connectors-enabled=true` is set, CPT pulls `camunda/connectors-bundle:<camunda.version>`. Prefer a GA release for `camunda.version`.
 
-The reason is tag coverage, not tag absence: `camunda/connectors-bundle` does publish `-rc*`, `-alpha*`, and `SNAPSHOT` tags, but not for every version `camunda/camunda` has. `8.7.0-alpha3-rc2`, `8.8.0-alpha3-rc3`, and `8.6.12-rc1` all exist for `camunda/camunda` with no connectors-bundle counterpart. When the derived tag doesn't exist, the test fails at startup with `ContainerFetchException` for `camunda/connectors-bundle:<version>`.
+The reason is tag coverage, not tag absence: `camunda/connectors-bundle` does publish `-rc*`, `-alpha*`, and `SNAPSHOT` tags, but not for every version `camunda/camunda` has. Pre-release tags in particular are published per image and pruned independently, so a version that resolves for `camunda/camunda` can have no connectors-bundle counterpart (`8.6.12-rc1` was one such tag). When the derived tag doesn't exist, the test fails at startup with `ContainerFetchException` for `camunda/connectors-bundle:<version>`.
 
-So: pin a GA version, or check the exact tag exists on Docker Hub first. To use a tag that differs from `camunda.version`, override it:
+Rather than trusting a list of known-missing tags, check the one you intend to use — pre-release tag coverage changes on both images:
+
+```bash
+curl -sf "https://hub.docker.com/v2/repositories/camunda/connectors-bundle/tags/${TAG}" >/dev/null \
+  && echo "exists" || echo "missing — pin a GA version or override the tag"
+```
+
+So: pin a GA version, or confirm the exact tag exists first. To use a tag that differs from `camunda.version`, override it:
 
 ```
 io.camunda.process.test.connectors-docker-image-version=8.9.0

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -1,0 +1,239 @@
+# Running Web Modeler scenario files in CI/CD
+
+Web Modeler exports test scenarios alongside BPMN/DMN files as part of its Git sync. These files use the same CPT 8.9 instruction grammar as hand-authored `.test.json` scenarios but have a different file envelope. This reference covers how to detect them, how to choose a test cluster, and how to get them running in one pass.
+
+## Detection fingerprint
+
+A Web Modeler scenario file is present when:
+
+- **Location**: alongside BPMN/DMN in the project's resources directory (`src/main/resources/`, not `src/test/`)
+- **Filename**: `<Process Name> test scenarios.json` — spaces in the name, no `.test.json` suffix
+- **Format**: `processId` and `testCases` at root; no `$schema` field; each test case carries a `metadata` block with `processInstanceId` and `coveredFlowNodes` (the execution trace from a prior Web Modeler run)
+
+```json
+{
+  "processId": "my-process",
+  "testCases": [
+    {
+      "name": "Happy path",
+      "instructions": [ /* standard CPT 8.9 instructions */ ],
+      "metadata": {
+        "processInstanceId": 1234567890,
+        "coveredFlowNodes": [
+          { "flowNodeId": "StartEvent_1", "elementType": "bpmn:StartEvent" }
+        ]
+      }
+    }
+  ]
+}
+```
+
+The `metadata` block is informational — it records which elements the scenario covered when it last ran in Web Modeler. CPT ignores it at runtime; it is not an assertion.
+
+**Do not author new CPT unit-test scenarios for a process that already has a WM scenario file.** The two formats serve different purposes: WM scenarios validate real connector and cluster behavior; hand-authored CPT scenarios validate process routing in fast isolation. Run them in separate test classes.
+
+## Step-by-step: get WM scenarios running
+
+### Step 1 — Identify the cluster mode
+
+Before writing any code, decide which cluster will execute the tests. This decision is **persisted in the repo** (see step 2) so that everyone on the team — and CI — uses the same target without relying on undocumented environment variables.
+
+| Mode | When to use | `runtime-mode` value |
+|------|-------------|----------------------|
+| **Ephemeral** (CPT Testcontainers) | Full isolation; process + connectors under test; no shared infrastructure needed | `MANAGED` |
+| **Remote — shared cluster** | Dedicated test/staging environment already exists; team runs against it | `REMOTE` |
+| **Remote — same cluster as Web Modeler** | Developer wants to run scenarios against the exact cluster where they were authored | `REMOTE` |
+
+Ask the user which mode to use if it is not already clear from context.
+
+### Step 2 — Create `application-integration.yml`
+
+Create `test/src/test/resources/application-integration.yml` (Spring profile `integration`). This file is committed to the repo and records the cluster choice. Credentials are always supplied via environment variables — never committed.
+
+```yaml
+# Cluster mode for Web Modeler integration tests.
+# Change runtime-mode to switch modes; do not commit credentials.
+#
+# cluster-mode: ephemeral          → runtime-mode: MANAGED
+# cluster-mode: remote-shared      → runtime-mode: REMOTE
+# cluster-mode: remote-wm-cluster  → runtime-mode: REMOTE
+camunda:
+  process-test:
+    runtime-mode: MANAGED   # change to REMOTE for shared/WM cluster
+  client:
+    zeebe:
+      grpc-address: ${ZEEBE_GRPC_ADDRESS:}
+    auth:
+      client-id: ${CAMUNDA_CLIENT_ID:}
+      client-secret: ${CAMUNDA_CLIENT_SECRET:}
+      issuer: ${CAMUNDA_OAUTH_URL:}
+```
+
+For ephemeral mode the `client` block is unused; it can be left as-is for future flexibility.
+
+### Step 3 — Update `pom.xml`
+
+Two additions are needed: a `<testResource>` block to put the WM scenario file on the classpath, and the `maven-failsafe-plugin` so the integration test class runs on `mvn verify` but not `mvn test`.
+
+```xml
+<testResources>
+  <!-- existing testResource entries … -->
+  <testResource>
+    <directory>../src/main/resources</directory>   <!-- adjust to project layout -->
+    <targetPath>integration-scenarios</targetPath>
+    <includes>
+      <include>*test scenarios.json</include>       <!-- glob picks up all WM files -->
+    </includes>
+  </testResource>
+</testResources>
+
+<plugins>
+  <!-- existing plugins … -->
+  <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-failsafe-plugin</artifactId>
+    <version>3.2.5</version>
+    <executions>
+      <execution>
+        <goals>
+          <goal>integration-test</goal>
+          <goal>verify</goal>
+        </goals>
+      </execution>
+    </executions>
+  </plugin>
+</plugins>
+```
+
+### Step 4 — Write the integration test class
+
+Name the class `<Process>IntegrationIT.java` (the `IT` suffix is what makes failsafe pick it up). Choose the template that matches the cluster mode from step 1.
+
+#### Ephemeral cluster (Testcontainers + Connectors runtime)
+
+Use this when `runtime-mode: MANAGED`. Include `@TestDeployment` so CPT deploys the BPMN/DMN into the embedded engine.
+
+```java
+package io.camunda.tests;
+
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
+import io.camunda.process.test.api.TestDeployment;
+import io.camunda.process.test.api.testCases.TestCase;
+import io.camunda.process.test.api.testCases.TestCaseRunner;
+import io.camunda.process.test.api.testCases.TestCaseSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import java.time.Duration;
+
+@SpringBootTest(properties = {
+    "spring.profiles.active=integration",
+    "io.camunda.process.test.connectors-enabled=true"
+})
+@CamundaSpringProcessTest
+@TestDeployment(resources = {"MyProcess.bpmn", "my-decision.dmn"})
+public class MyProcessIntegrationIT {
+
+    @Autowired
+    private TestCaseRunner testCaseRunner;
+
+    @BeforeAll
+    static void configureTimeout() {
+        // Real HTTP calls are slower than embedded engine — bump the assertion timeout.
+        CamundaAssert.setAssertionTimeout(Duration.ofSeconds(60));
+    }
+
+    @ParameterizedTest
+    @TestCaseSource(directory = "/integration-scenarios")
+    void shouldRunWebModelerScenario(final TestCase testCase, final String fileName) {
+        testCaseRunner.run(testCase);
+    }
+}
+```
+
+Notes:
+- `connectors-enabled=true` starts the `camunda/connectors-bundle` container so the HTTP JSON connector and other outbound connectors execute for real.
+- The connectors bundle image tag is derived from `camunda.version` in `pom.xml`. Use a GA stable release — RC and SNAPSHOT tags are not published for this image. Set `io.camunda.process.test.connectors-docker-image-version` to override if needed.
+- 60 seconds is a safe default timeout for a single external HTTP call. Increase it if the process has multiple sequential connector calls.
+
+#### Remote cluster (shared or WM cluster)
+
+Use this when `runtime-mode: REMOTE`. Drop `@TestDeployment` — the BPMN/DMN is already deployed on the target cluster, and the scenario runs against the live deployment.
+
+```java
+package io.camunda.tests;
+
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
+import io.camunda.process.test.api.testCases.TestCase;
+import io.camunda.process.test.api.testCases.TestCaseRunner;
+import io.camunda.process.test.api.testCases.TestCaseSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import java.time.Duration;
+
+@SpringBootTest(properties = {
+    "spring.profiles.active=integration"
+})
+@CamundaSpringProcessTest
+// No @TestDeployment — process is already deployed on the target cluster.
+public class MyProcessIntegrationIT {
+
+    @Autowired
+    private TestCaseRunner testCaseRunner;
+
+    @BeforeAll
+    static void configureTimeout() {
+        // Remote clusters include network round-trips — use a longer timeout.
+        CamundaAssert.setAssertionTimeout(Duration.ofSeconds(120));
+    }
+
+    @ParameterizedTest
+    @TestCaseSource(directory = "/integration-scenarios")
+    void shouldRunWebModelerScenario(final TestCase testCase, final String fileName) {
+        testCaseRunner.run(testCase);
+    }
+}
+```
+
+Required environment variables for remote mode (supply in CI secrets or local `.env`):
+
+| Variable | Description |
+|----------|-------------|
+| `ZEEBE_GRPC_ADDRESS` | gRPC endpoint, e.g. `https://abc.zeebe.camunda.io:443` |
+| `CAMUNDA_CLIENT_ID` | OAuth client ID |
+| `CAMUNDA_CLIENT_SECRET` | OAuth client secret |
+| `CAMUNDA_OAUTH_URL` | Token issuer URL |
+
+### Step 5 — Run
+
+```bash
+# Integration tests only (faster feedback loop):
+mvn failsafe:integration-test failsafe:verify
+
+# Full suite (unit + integration):
+mvn verify
+```
+
+`mvn test` alone runs surefire (`*Test.java`) only — it does not run the integration tests.
+
+## Troubleshooting WM scenarios
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Element ID in `metadata.coveredFlowNodes` not found in BPMN | BPMN was modified after the scenario was exported from Web Modeler | Re-export the scenario from Web Modeler, or update element IDs manually |
+| `ASSERT_PROCESS_INSTANCE IS_COMPLETED` fails but process is running | Assertion timeout too short for real connector calls | Increase `CamundaAssert.setAssertionTimeout` |
+| `ContainerFetchException` for `camunda/connectors-bundle:<version>` | RC or SNAPSHOT tag not published on Docker Hub | Pin `camunda.version` to a GA stable release; or set `io.camunda.process.test.connectors-docker-image-version` explicitly |
+| Remote mode: `NullPointerException` on `ZEEBE_GRPC_ADDRESS` | Environment variable not set | Set the required env vars (see table above) |
+| Remote mode: process not found | BPMN not deployed to target cluster, or wrong cluster credentials | Deploy via Web Modeler or `c8ctl deploy`; verify `ZEEBE_GRPC_ADDRESS` points to the right cluster |
+| WM scenario file not discovered by `@TestCaseSource` | File not on classpath, or `<targetPath>` missing from pom.xml | Confirm the `<testResource>` block in pom.xml uses `<targetPath>integration-scenarios</targetPath>` and the glob matches the filename |
+
+## What WM scenarios do and do not assert
+
+Web Modeler generates scenarios that assert `ASSERT_PROCESS_INSTANCE IS_COMPLETED`. They do not assert specific end events or intermediate element reachability. This is intentional — WM prioritizes end-to-end completion over path specificity.
+
+The `metadata.coveredFlowNodes` array records what the scenario covered in its last WM run. It is informational only; CPT does not read or enforce it. If you want path-specific assertions, add `ASSERT_ELEMENT_INSTANCES` instructions to the scenario file, or write a separate hand-authored CPT unit-test scenario in `src/test/resources/scenarios/`.

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -82,7 +82,7 @@ Two additions are needed: a `<testResource>` block to put the WM scenario file o
     <directory>../src/main/resources</directory>   <!-- adjust to project layout -->
     <targetPath>integration-scenarios</targetPath>
     <includes>
-      <include>*test scenarios.json</include>       <!-- glob picks up all WM files -->
+      <include>* test scenarios.json</include>       <!-- space before "test" is literal; matches WM pattern, not .test.json -->
     </includes>
   </testResource>
 </testResources>

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -169,7 +169,7 @@ public class MyProcessIntegrationIT {
 
 Notes:
 - `camunda.process-test.connectors-enabled=true` starts the `camunda/connectors-bundle` container so the HTTP JSON connector and other outbound connectors execute for real.
-- The connectors bundle image tag defaults to the CPT dependency version on the classpath — whichever property the project pins it with (`camunda-process-test.version` in the setup.md snippet, `camunda.version` in the upstream docs). That version must be one the connectors image was published for; see the version guidance in [setup.md](setup.md).
+- The connectors bundle image tag defaults to the CPT dependency version on the classpath — whichever property the project pins it with (`camunda-process-test.version` in the setup.md snippet, `camunda.version` in the upstream docs). That version must be one the connectors image was published for; see [Connectors bundle image version](#connectors-bundle-image-version) below.
 - 60 seconds is a safe default timeout for a single external HTTP call. Increase it if the process has multiple sequential connector calls.
 
 #### Remote cluster (shared or WM cluster)
@@ -236,13 +236,35 @@ mvn verify
 
 `mvn test` alone runs surefire (`*Test.java`) only — it does not run the integration tests.
 
+## Connectors bundle image version
+
+If `camunda.process-test.connectors-enabled=true` is set, CPT pulls `camunda/connectors-bundle:<version>`, where `<version>` defaults to the CPT dependency version on the classpath — the one pinned by `camunda-process-test.version` in the `pom.xml` snippet in [setup.md](setup.md#cpt-dependency) (the upstream docs pin the same dependency with a `camunda.version` property). Prefer a GA release for it.
+
+The reason is tag coverage, not tag absence: `camunda/connectors-bundle` does publish `-rc*`, `-alpha*`, and `SNAPSHOT` tags, but not for every version `camunda/camunda` has. Pre-release tags in particular are published per image and pruned independently, so a version that resolves for `camunda/camunda` can have no connectors-bundle counterpart (`8.6.12-rc1` was one such tag). When the derived tag doesn't exist, the test fails at startup with `ContainerFetchException` for `camunda/connectors-bundle:<version>`.
+
+Rather than trusting a list of known-missing tags, check the one you intend to use — pre-release tag coverage changes on both images:
+
+```bash
+TAG=8.9.0   # the version you intend to pin
+curl -sf "https://hub.docker.com/v2/repositories/camunda/connectors-bundle/tags/${TAG}" >/dev/null \
+  && echo "exists" || echo "missing — pin a GA version or override the tag"
+```
+
+Set `TAG` before running it. With `TAG` empty the URL collapses to the tag-listing endpoint, which answers `200` for every image and reports "exists" regardless.
+
+So: pin a GA version, or confirm the exact tag exists first. To use a tag that differs from the CPT dependency version, override it:
+
+```
+camunda.process-test.connectors-docker-image-version=8.9.0
+```
+
 ## Troubleshooting WM scenarios
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | An instruction targets an element ID that no longer exists in the BPMN | BPMN was modified after the scenario was exported from Web Modeler | Re-export the scenario from Web Modeler, or update the element IDs in the scenario file. Stale IDs under `metadata` are not the cause — CPT does not read `metadata` |
 | `ASSERT_PROCESS_INSTANCE IS_COMPLETED` fails but process is running | Assertion timeout too short for real connector calls | Increase `CamundaAssert.setAssertionTimeout` |
-| `ContainerFetchException` for `camunda/connectors-bundle:<version>` | No connectors-bundle tag for the version CPT derived from the CPT dependency version — common with non-GA versions | Pin that version (`camunda-process-test.version` in the setup.md snippet) to a GA release; or set `camunda.process-test.connectors-docker-image-version` explicitly |
+| `ContainerFetchException` for `camunda/connectors-bundle:<version>` | No connectors-bundle tag for the version CPT derived from the CPT dependency version — common with non-GA versions | Pin that version (`camunda-process-test.version`, see [below](#connectors-bundle-image-version)) to a GA release; or set `camunda.process-test.connectors-docker-image-version` explicitly |
 | Remote mode: startup fails resolving the cluster address | A required environment variable is unset, so the client has no address to connect to | Set the required env vars (see table above) |
 | Remote mode: process not found | BPMN not deployed to target cluster, or wrong cluster credentials | Deploy via Web Modeler or `c8ctl deploy`; verify `CAMUNDA_GRPC_ADDRESS` / `CAMUNDA_REST_ADDRESS` point at the right cluster |
 | WM scenario file not discovered by `@TestCaseSource` | File not on classpath, or `<targetPath>` missing from pom.xml | Confirm the `<testResource>` block in pom.xml uses `<targetPath>integration-scenarios</targetPath>` and the glob matches the filename |

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -10,7 +10,7 @@ A Web Modeler scenario file is present when:
 - **Filename**: `<Process Name> test scenarios.json` — spaces in the name, no `.test.json` suffix
 - **Format**: `processId` and `testCases` at root; no `$schema` field; each test case carries a `metadata` block with `processInstanceId` and `coveredFlowNodes` (the execution trace from a prior Web Modeler run)
 
-```json
+```jsonc
 {
   "processId": "my-process",
   "testCases": [
@@ -81,33 +81,42 @@ For ephemeral mode the `client` block is unused; it can be left as-is for future
 Two additions are needed: a `<testResource>` block to put the WM scenario file on the classpath, and the `maven-failsafe-plugin` so the integration test class runs on `mvn verify` but not `mvn test`.
 
 ```xml
-<testResources>
-  <!-- existing testResource entries … -->
-  <testResource>
-    <directory>src/main/resources</directory>       <!-- standard Maven module: where WM exported the file. Sibling test/ harness: ../resources (setup.md#nodejs-project-layout) -->
-    <targetPath>integration-scenarios</targetPath>
-    <includes>
-      <include>**/* test scenarios.json</include>    <!-- ** so scenarios in subfolders are copied too; space before "test" is literal, matches the WM pattern not .test.json -->
-    </includes>
-  </testResource>
-</testResources>
+<!-- Both blocks belong inside <build>. Maven silently ignores testResources
+     and plugins declared anywhere else, so the scenarios never reach the
+     test classpath and failsafe never runs. -->
+<build>
+  <testResources>
+    <!-- existing testResource entries … -->
+    <testResource>
+      <!-- standard Maven module: where WM exported the file.
+           Sibling test/ harness: ../resources (setup.md#nodejs-project-layout) -->
+      <directory>src/main/resources</directory>
+      <targetPath>integration-scenarios</targetPath>
+      <includes>
+        <!-- ** so scenarios exported into a subfolder are copied too; the space
+             before "test" is literal, matching the WM pattern not .test.json -->
+        <include>**/* test scenarios.json</include>
+      </includes>
+    </testResource>
+  </testResources>
 
-<plugins>
-  <!-- existing plugins … -->
-  <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-failsafe-plugin</artifactId>
-    <version>3.2.5</version>
-    <executions>
-      <execution>
-        <goals>
-          <goal>integration-test</goal>
-          <goal>verify</goal>
-        </goals>
-      </execution>
-    </executions>
-  </plugin>
-</plugins>
+  <plugins>
+    <!-- existing plugins … -->
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-failsafe-plugin</artifactId>
+      <version>3.2.5</version>
+      <executions>
+        <execution>
+          <goals>
+            <goal>integration-test</goal>
+            <goal>verify</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
 ```
 
 ### Step 4 — Write the integration test class
@@ -138,7 +147,7 @@ import java.time.Duration;
     "camunda.process-test.connectors-enabled=true"
 })
 @CamundaSpringProcessTest
-@TestDeployment(resources = {"MyProcess.bpmn", "my-decision.dmn"})
+@TestDeployment(resources = {"processes/MyProcess.bpmn", "processes/my-decision.dmn"})
 public class MyProcessIntegrationIT {
 
     @Autowired

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -40,9 +40,9 @@ Before writing any code, decide which cluster will execute the tests. This decis
 
 | Mode | When to use | `runtime-mode` value |
 |------|-------------|----------------------|
-| **Ephemeral** (CPT Testcontainers) | Full isolation; process + connectors under test; no shared infrastructure needed | `MANAGED` |
-| **Remote — shared cluster** | Dedicated test/staging environment already exists; team runs against it | `REMOTE` |
-| **Remote — same cluster as Web Modeler** | Developer wants to run scenarios against the exact cluster where they were authored | `REMOTE` |
+| **Ephemeral** (CPT Testcontainers) | Full isolation; process + connectors under test; no shared infrastructure needed | `managed` |
+| **Remote — shared cluster** | Dedicated test/staging environment already exists; team runs against it | `remote` |
+| **Remote — same cluster as Web Modeler** | Developer wants to run scenarios against the exact cluster where they were authored | `remote` |
 
 Ask the user which mode to use if it is not already clear from context.
 
@@ -54,20 +54,24 @@ Create `application-integration.yml` (Spring profile `integration`) in the test 
 # Cluster mode for Web Modeler integration tests.
 # Change runtime-mode to switch modes; do not commit credentials.
 #
-# cluster-mode: ephemeral          → runtime-mode: MANAGED
-# cluster-mode: remote-shared      → runtime-mode: REMOTE
-# cluster-mode: remote-wm-cluster  → runtime-mode: REMOTE
+# cluster-mode: ephemeral          → runtime-mode: managed
+# cluster-mode: remote-shared      → runtime-mode: remote
+# cluster-mode: remote-wm-cluster  → runtime-mode: remote
 camunda:
   process-test:
-    runtime-mode: MANAGED   # change to REMOTE for shared/WM cluster
+    runtime-mode: managed   # change to remote for shared/WM cluster
   client:
-    zeebe:
-      grpc-address: ${ZEEBE_GRPC_ADDRESS:}
+    # Addresses sit directly under camunda.client. The camunda.client.zeebe.*
+    # nesting is the pre-8.8 Spring Zeebe SDK shape and is not the current one.
+    grpc-address: ${CAMUNDA_GRPC_ADDRESS:}
+    rest-address: ${CAMUNDA_REST_ADDRESS:}
     auth:
       client-id: ${CAMUNDA_CLIENT_ID:}
       client-secret: ${CAMUNDA_CLIENT_SECRET:}
-      issuer: ${CAMUNDA_OAUTH_URL:}
+      issuer-url: ${CAMUNDA_OAUTH_URL:}
 ```
+
+`rest-address` is not optional for remote mode: the client prefers REST over gRPC by default (`camunda.client.prefer-rest-over-grpc` defaults to `true`), so a remote runtime configured with only a gRPC address has no address for the calls it actually makes.
 
 For ephemeral mode the `client` block is unused; it can be left as-is for future flexibility.
 
@@ -82,7 +86,7 @@ Two additions are needed: a `<testResource>` block to put the WM scenario file o
     <directory>src/main/resources</directory>       <!-- standard Maven module: where WM exported the file. Sibling test/ harness: ../resources (setup.md#nodejs-project-layout) -->
     <targetPath>integration-scenarios</targetPath>
     <includes>
-      <include>* test scenarios.json</include>       <!-- space before "test" is literal; matches WM pattern, not .test.json -->
+      <include>**/* test scenarios.json</include>    <!-- ** so scenarios in subfolders are copied too; space before "test" is literal, matches the WM pattern not .test.json -->
     </includes>
   </testResource>
 </testResources>
@@ -111,7 +115,7 @@ Name the class `<Process>IntegrationIT.java` (the `IT` suffix is what makes fail
 
 #### Ephemeral cluster (Testcontainers + Connectors runtime)
 
-Use this when `runtime-mode: MANAGED`. Include `@TestDeployment` so CPT deploys the BPMN/DMN into the embedded engine.
+Use this when `runtime-mode: managed`. Include `@TestDeployment` so CPT deploys the BPMN/DMN into the embedded engine.
 
 ```java
 package io.camunda.tests;
@@ -130,7 +134,7 @@ import java.time.Duration;
 
 @SpringBootTest(properties = {
     "spring.profiles.active=integration",
-    "io.camunda.process.test.connectors-enabled=true"
+    "camunda.process-test.connectors-enabled=true"
 })
 @CamundaSpringProcessTest
 @TestDeployment(resources = {"MyProcess.bpmn", "my-decision.dmn"})
@@ -154,13 +158,13 @@ public class MyProcessIntegrationIT {
 ```
 
 Notes:
-- `io.camunda.process.test.connectors-enabled=true` starts the `camunda/connectors-bundle` container so the HTTP JSON connector and other outbound connectors execute for real.
-- The connectors bundle image tag is derived from `camunda.version` in `pom.xml`, so `camunda.version` must be a version that image was published for — see the version guidance in [setup.md](setup.md).
+- `camunda.process-test.connectors-enabled=true` starts the `camunda/connectors-bundle` container so the HTTP JSON connector and other outbound connectors execute for real.
+- The connectors bundle image tag defaults to the CPT dependency version on the classpath — whichever property the project pins it with (`camunda-process-test.version` in the setup.md snippet, `camunda.version` in the upstream docs). That version must be one the connectors image was published for; see the version guidance in [setup.md](setup.md).
 - 60 seconds is a safe default timeout for a single external HTTP call. Increase it if the process has multiple sequential connector calls.
 
 #### Remote cluster (shared or WM cluster)
 
-Use this when `runtime-mode: REMOTE`. Drop `@TestDeployment` — the BPMN/DMN is already deployed on the target cluster, and the scenario runs against the live deployment.
+Use this when `runtime-mode: remote`. Drop `@TestDeployment` — the BPMN/DMN is already deployed on the target cluster, and the scenario runs against the live deployment.
 
 ```java
 package io.camunda.tests;
@@ -204,7 +208,8 @@ Required environment variables for remote mode (supply in CI secrets or local `.
 
 | Variable | Description |
 |----------|-------------|
-| `ZEEBE_GRPC_ADDRESS` | gRPC endpoint, e.g. `https://abc.zeebe.camunda.io:443` |
+| `CAMUNDA_GRPC_ADDRESS` | gRPC endpoint, e.g. `https://abc.zeebe.camunda.io:443` |
+| `CAMUNDA_REST_ADDRESS` | REST endpoint, e.g. `https://bru-2.zeebe.camunda.io:443/<cluster-id>` |
 | `CAMUNDA_CLIENT_ID` | OAuth client ID |
 | `CAMUNDA_CLIENT_SECRET` | OAuth client secret |
 | `CAMUNDA_OAUTH_URL` | Token issuer URL |
@@ -227,9 +232,9 @@ mvn verify
 |---------|-------|-----|
 | An instruction targets an element ID that no longer exists in the BPMN | BPMN was modified after the scenario was exported from Web Modeler | Re-export the scenario from Web Modeler, or update the element IDs in the scenario file. Stale IDs under `metadata` are not the cause — CPT does not read `metadata` |
 | `ASSERT_PROCESS_INSTANCE IS_COMPLETED` fails but process is running | Assertion timeout too short for real connector calls | Increase `CamundaAssert.setAssertionTimeout` |
-| `ContainerFetchException` for `camunda/connectors-bundle:<version>` | No connectors-bundle tag for the version CPT derived from `camunda.version` — common with non-GA versions | Pin `camunda.version` to a GA release; or set `io.camunda.process.test.connectors-docker-image-version` explicitly |
+| `ContainerFetchException` for `camunda/connectors-bundle:<version>` | No connectors-bundle tag for the version CPT derived from the CPT dependency version — common with non-GA versions | Pin that version (`camunda-process-test.version` in the setup.md snippet) to a GA release; or set `camunda.process-test.connectors-docker-image-version` explicitly |
 | Remote mode: startup fails resolving the cluster address | A required environment variable is unset, so the client has no address to connect to | Set the required env vars (see table above) |
-| Remote mode: process not found | BPMN not deployed to target cluster, or wrong cluster credentials | Deploy via Web Modeler or `c8ctl deploy`; verify `ZEEBE_GRPC_ADDRESS` points to the right cluster |
+| Remote mode: process not found | BPMN not deployed to target cluster, or wrong cluster credentials | Deploy via Web Modeler or `c8ctl deploy`; verify `CAMUNDA_GRPC_ADDRESS` / `CAMUNDA_REST_ADDRESS` point at the right cluster |
 | WM scenario file not discovered by `@TestCaseSource` | File not on classpath, or `<targetPath>` missing from pom.xml | Confirm the `<testResource>` block in pom.xml uses `<targetPath>integration-scenarios</targetPath>` and the glob matches the filename |
 
 ## What WM scenarios do and do not assert

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -79,7 +79,7 @@ Two additions are needed: a `<testResource>` block to put the WM scenario file o
 <testResources>
   <!-- existing testResource entries … -->
   <testResource>
-    <directory>../src/main/resources</directory>   <!-- adjust to project layout -->
+    <directory>src/main/resources</directory>       <!-- standard Maven module: where WM exported the file. Sibling test/ harness: ../resources (setup.md#nodejs-project-layout) -->
     <targetPath>integration-scenarios</targetPath>
     <includes>
       <include>* test scenarios.json</include>       <!-- space before "test" is literal; matches WM pattern, not .test.json -->
@@ -225,10 +225,10 @@ mvn verify
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Element ID in `metadata.coveredFlowNodes` not found in BPMN | BPMN was modified after the scenario was exported from Web Modeler | Re-export the scenario from Web Modeler, or update element IDs manually |
+| An instruction targets an element ID that no longer exists in the BPMN | BPMN was modified after the scenario was exported from Web Modeler | Re-export the scenario from Web Modeler, or update the element IDs in the scenario file. Stale IDs under `metadata` are not the cause — CPT does not read `metadata` |
 | `ASSERT_PROCESS_INSTANCE IS_COMPLETED` fails but process is running | Assertion timeout too short for real connector calls | Increase `CamundaAssert.setAssertionTimeout` |
 | `ContainerFetchException` for `camunda/connectors-bundle:<version>` | No connectors-bundle tag for the version CPT derived from `camunda.version` — common with non-GA versions | Pin `camunda.version` to a GA release; or set `io.camunda.process.test.connectors-docker-image-version` explicitly |
-| Remote mode: `NullPointerException` on `ZEEBE_GRPC_ADDRESS` | Environment variable not set | Set the required env vars (see table above) |
+| Remote mode: startup fails resolving the cluster address | A required environment variable is unset, so the client has no address to connect to | Set the required env vars (see table above) |
 | Remote mode: process not found | BPMN not deployed to target cluster, or wrong cluster credentials | Deploy via Web Modeler or `c8ctl deploy`; verify `ZEEBE_GRPC_ADDRESS` points to the right cluster |
 | WM scenario file not discovered by `@TestCaseSource` | File not on classpath, or `<targetPath>` missing from pom.xml | Confirm the `<testResource>` block in pom.xml uses `<targetPath>integration-scenarios</targetPath>` and the glob matches the filename |
 

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -1,4 +1,4 @@
-# Running Web Modeler scenario files in CI/CD
+# Running Web Modeler scenario files
 
 Web Modeler exports test scenarios alongside BPMN/DMN files as part of its Git sync. These files use the same CPT 8.9 instruction grammar as hand-authored `.test.json` scenarios but have a different file envelope. This reference covers how to detect them, how to choose a test cluster, and how to get them running in one pass.
 
@@ -155,7 +155,7 @@ public class MyProcessIntegrationIT {
 
 Notes:
 - `connectors-enabled=true` starts the `camunda/connectors-bundle` container so the HTTP JSON connector and other outbound connectors execute for real.
-- The connectors bundle image tag is derived from `camunda.version` in `pom.xml`. Use a GA stable release — RC and SNAPSHOT tags are not published for this image. Set `io.camunda.process.test.connectors-docker-image-version` to override if needed.
+- The connectors bundle image tag is derived from `camunda.version` in `pom.xml`, so `camunda.version` must be a version that image was published for — see the version guidance in [setup.md](setup.md).
 - 60 seconds is a safe default timeout for a single external HTTP call. Increase it if the process has multiple sequential connector calls.
 
 #### Remote cluster (shared or WM cluster)
@@ -227,7 +227,7 @@ mvn verify
 |---------|-------|-----|
 | Element ID in `metadata.coveredFlowNodes` not found in BPMN | BPMN was modified after the scenario was exported from Web Modeler | Re-export the scenario from Web Modeler, or update element IDs manually |
 | `ASSERT_PROCESS_INSTANCE IS_COMPLETED` fails but process is running | Assertion timeout too short for real connector calls | Increase `CamundaAssert.setAssertionTimeout` |
-| `ContainerFetchException` for `camunda/connectors-bundle:<version>` | RC or SNAPSHOT tag not published on Docker Hub | Pin `camunda.version` to a GA stable release; or set `io.camunda.process.test.connectors-docker-image-version` explicitly |
+| `ContainerFetchException` for `camunda/connectors-bundle:<version>` | No connectors-bundle tag for the version CPT derived from `camunda.version` — common with non-GA versions | Pin `camunda.version` to a GA release; or set `io.camunda.process.test.connectors-docker-image-version` explicitly |
 | Remote mode: `NullPointerException` on `ZEEBE_GRPC_ADDRESS` | Environment variable not set | Set the required env vars (see table above) |
 | Remote mode: process not found | BPMN not deployed to target cluster, or wrong cluster credentials | Deploy via Web Modeler or `c8ctl deploy`; verify `ZEEBE_GRPC_ADDRESS` points to the right cluster |
 | WM scenario file not discovered by `@TestCaseSource` | File not on classpath, or `<targetPath>` missing from pom.xml | Confirm the `<testResource>` block in pom.xml uses `<targetPath>integration-scenarios</targetPath>` and the glob matches the filename |

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -61,8 +61,9 @@ camunda:
   process-test:
     runtime-mode: managed   # change to remote for shared/WM cluster
   client:
-    # Addresses sit directly under camunda.client. The camunda.client.zeebe.*
-    # nesting is the pre-8.8 Spring Zeebe SDK shape and is not the current one.
+    # Addresses sit directly under camunda.client, per the Spring Boot Starter
+    # properties reference. The camunda.client.zeebe.* nesting is the older
+    # Spring Zeebe SDK shape, kept only for backwards compatibility.
     grpc-address: ${CAMUNDA_GRPC_ADDRESS:}
     rest-address: ${CAMUNDA_REST_ADDRESS:}
     auth:
@@ -71,7 +72,7 @@ camunda:
       issuer-url: ${CAMUNDA_OAUTH_URL:}
 ```
 
-`rest-address` is not optional for remote mode: the client prefers REST over gRPC by default (`camunda.client.prefer-rest-over-grpc` defaults to `true`), so a remote runtime configured with only a gRPC address has no address for the calls it actually makes.
+`rest-address` is not optional for remote mode: the client prefers REST over gRPC by default ([`camunda.client.prefer-rest-over-grpc`](https://docs.camunda.io/docs/apis-tools/camunda-spring-boot-starter/properties-reference/) defaults to `true`), so a remote runtime configured with only a gRPC address has no address for the calls it actually makes.
 
 For ephemeral mode the `client` block is unused; it can be left as-is for future flexibility.
 

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -6,7 +6,7 @@ Web Modeler exports test scenarios alongside BPMN/DMN files as part of its Git s
 
 A Web Modeler scenario file is present when:
 
-- **Location**: alongside BPMN/DMN in the project's resources directory (`src/main/resources/`, not `src/test/`)
+- **Location**: alongside BPMN/DMN in the project's resources directory — `src/main/resources/` in a standard Maven module, or `../resources/` relative to the sibling `test/` harness ([setup.md](setup.md#nodejs-project-layout)). Never under `src/test/`
 - **Filename**: `<Process Name> test scenarios.json` — spaces in the name, no `.test.json` suffix
 - **Format**: `processId` and `testCases` at root; no `$schema` field; each test case carries a `metadata` block with `processInstanceId` and `coveredFlowNodes` (the execution trace from a prior Web Modeler run)
 
@@ -88,8 +88,9 @@ Two additions are needed: a `<testResource>` block to put the WM scenario file o
   <testResources>
     <!-- existing testResource entries … -->
     <testResource>
-      <!-- standard Maven module: where WM exported the file.
-           Sibling test/ harness: ../resources (setup.md#nodejs-project-layout) -->
+      <!-- Where WM exported the file. Pick the line for your layout:
+             standard Maven module -> src/main/resources
+             sibling test/ harness -> ../resources  (setup.md#nodejs-project-layout) -->
       <directory>src/main/resources</directory>
       <targetPath>integration-scenarios</targetPath>
       <includes>

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -48,7 +48,7 @@ Ask the user which mode to use if it is not already clear from context.
 
 ### Step 2 — Create `application-integration.yml`
 
-Create `test/src/test/resources/application-integration.yml` (Spring profile `integration`). This file is committed to the repo and records the cluster choice. Credentials are always supplied via environment variables — never committed.
+Create `application-integration.yml` (Spring profile `integration`) in the test resources of the module that holds the tests — `src/test/resources/` in a standard Maven project, or `test/src/test/resources/` when the harness is the sibling `test/` module described in [setup.md](setup.md#nodejs-project-layout). This file is committed to the repo and records the cluster choice. Credentials are always supplied via environment variables — never committed.
 
 ```yaml
 # Cluster mode for Web Modeler integration tests.

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -145,7 +145,7 @@ public class MyProcessIntegrationIT {
         CamundaAssert.setAssertionTimeout(Duration.ofSeconds(60));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}")
     @TestCaseSource(directory = "/integration-scenarios")
     void shouldRunWebModelerScenario(final TestCase testCase, final String fileName) {
         testCaseRunner.run(testCase);
@@ -154,7 +154,7 @@ public class MyProcessIntegrationIT {
 ```
 
 Notes:
-- `connectors-enabled=true` starts the `camunda/connectors-bundle` container so the HTTP JSON connector and other outbound connectors execute for real.
+- `io.camunda.process.test.connectors-enabled=true` starts the `camunda/connectors-bundle` container so the HTTP JSON connector and other outbound connectors execute for real.
 - The connectors bundle image tag is derived from `camunda.version` in `pom.xml`, so `camunda.version` must be a version that image was published for — see the version guidance in [setup.md](setup.md).
 - 60 seconds is a safe default timeout for a single external HTTP call. Increase it if the process has multiple sequential connector calls.
 
@@ -192,7 +192,7 @@ public class MyProcessIntegrationIT {
         CamundaAssert.setAssertionTimeout(Duration.ofSeconds(120));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}")
     @TestCaseSource(directory = "/integration-scenarios")
     void shouldRunWebModelerScenario(final TestCase testCase, final String fileName) {
         testCaseRunner.run(testCase);

--- a/skills/camunda-process-test/references/web-modeler-scenarios.md
+++ b/skills/camunda-process-test/references/web-modeler-scenarios.md
@@ -88,10 +88,11 @@ Two additions are needed: a `<testResource>` block to put the WM scenario file o
   <testResources>
     <!-- existing testResource entries … -->
     <testResource>
-      <!-- Where WM exported the file. Pick the line for your layout:
-             standard Maven module -> src/main/resources
-             sibling test/ harness -> ../resources  (setup.md#nodejs-project-layout) -->
+      <!-- Where WM exported the file. Keep exactly one of these two lines:
+           the first for a standard Maven module, the second for the sibling
+           test/ harness (setup.md#nodejs-project-layout). -->
       <directory>src/main/resources</directory>
+      <!-- <directory>../resources</directory> -->
       <targetPath>integration-scenarios</targetPath>
       <includes>
         <!-- ** so scenarios exported into a subfolder are copied too; the space


### PR DESCRIPTION
## Summary

- Adds `references/web-modeler-scenarios.md` — self-contained one-shot guide for running Web Modeler-exported scenario files as integration tests
- Updates `SKILL.md` step 1 (Detect) to scan for `* test scenarios.json` files alongside BPMNs and route to the new reference
- Updates `references/setup.md` with the connectors bundle image version constraint and a pointer to the failsafe setup

## What the new reference covers

**Detection** — format fingerprint distinguishing WM scenario files from hand-authored `.test.json`: `processId` at root, no `$schema`, `metadata.coveredFlowNodes` per test case. Names both supported resource layouts (`src/main/resources/` in a standard Maven module, `../resources/` for the sibling `test/` harness).

**Cluster architecture decision** — table of three modes (ephemeral Testcontainers, remote-shared, remote-WM-cluster), tradeoffs, and where the decision is persisted in the repo (`application-integration.yml` Spring profile, committed).

**Templates** — two Java `*IT.java` templates (failsafe, not surefire):
- Ephemeral: `@SpringBootTest(camunda.process-test.connectors-enabled=true)` + `@TestDeployment` + 60s timeout
- Remote cluster: no `@TestDeployment` + 120s timeout + env var table for credentials

**pom.xml additions** — a `<testResource>` with `integration-scenarios` and a `maven-failsafe-plugin` snippet, both inside `<build>`.

**Troubleshooting table** — WM-specific failure rows (element ID drift, timeout, image version, missing env vars).

## Validated against

Built and tested the ephemeral pattern on `solutions/vehicle-eligibility-check/` in [HanselIdes/camunda-8-tutorials](https://github.com/HanselIdes/camunda-8-tutorials): `NhtsaIntegrationIT.java` runs 2 scenarios from `Vehicle Eligibility Check test scenarios.json` against the real NHTSA API — `Tests run: 2, Failures: 0`.

&gt; **Open question on this claim.** The review found that the connectors property in the guide was wrong (see below). If `io.camunda.process.test.connectors-enabled` never enabled connectors, this run should not have passed — so either the tutorial project sets the correct key and the guide transcribed it wrong, or something else was carrying it. Needs a check against what `NhtsaIntegrationIT` actually sets before this section can be treated as confirming the corrected template.

## Changed during review

**Property names, verified against docs.camunda.io rather than against what the repo already said.**

- **CPT properties are `camunda.process-test.*`, not `io.camunda.process.test.*`.** The latter is the Java package CPT&#39;s classes live in, not the Spring prefix. The guide contradicted itself: the `application-integration.yml` snippet already used `camunda.process-test.runtime-mode` while the `@SpringBootTest` block beside it used `io.camunda.process.test.connectors-enabled`. Spring ignores an unknown property silently, so the failure mode was connectors never starting and a connector job never completing.
- **Client addresses sit directly under `camunda.client`**; `camunda.client.zeebe.*` is the older Spring Zeebe SDK shape. The OIDC key is `auth.issuer-url`, not `auth.issuer`. Added `rest-address` — the client prefers REST over gRPC by default, so remote mode with only a gRPC address configures the hop it does not use.
- **`runtime-mode` values lowercased** to `managed` / `remote`, as the docs write them.
- **Env vars are `CAMUNDA_GRPC_ADDRESS` / `CAMUNDA_REST_ADDRESS`**, matching `camunda-job-workers/references/worker-sdk-spring.md` instead of introducing a second convention for the same value.

**Real defects in the snippets.**

- **The pom snippet was missing its `<build>` wrapper.** Maven ignores `<testResources>` and `<plugins>` declared anywhere else, silently — so the snippet produced a valid POM where scenarios never reached the test classpath and failsafe never ran. That is the &#34;WM scenario file not discovered&#34; symptom this guide&#39;s own troubleshooting table attributes to a missing `<targetPath>`.
- **The `<include>` glob needed `**/`.** A Maven `*` does not cross directories, so a scenario exported next to a BPMN in a subfolder of `src/main/resources` was never copied.
- **The `<testResource>` directory was wrong for both layouts, then documented for only one.** It started as `../src/main/resources`, which is correct for neither a standard Maven module nor the sibling `test/` harness (`setup.md#nodejs-project-layout` reads from `../resources`). It now defaults to `src/main/resources` and carries the harness path as an actual commented-out `<directory>` line rather than as prose, so a harness reader swaps a line instead of translating a sentence. Two active `<directory>` elements would be invalid, so the keep-exactly-one constraint is stated.
- **The Docker Hub tag check interpolated an undefined `${TAG}`.** Confirmed by running it: with `TAG` empty the URL collapses to the tag-listing endpoint, which returns `200` for every image, so the check reported &#34;exists&#34; for anything.
- **`@TestDeployment` now uses the `processes/` prefix**, matching the scaffold layout in `setup.md`.
- **The scenario-file example is fenced `jsonc`**, since it carries a `/* … */` comment and was not parseable as `json`.

**Progressive disclosure.**

- **Two integration-test-only sections moved out of `setup.md`** (failsafe plugin, connectors bundle image version) into `web-modeler-scenarios.md`, which is loaded on demand. `SKILL.md` routes to `setup.md` unconditionally, so every CPT task was reading 52% more of a page whose additions only matter for integration tests. This took the unconditionally-loaded path from +3,606 to +1,588 bytes over `main`, and the `rocket-launch` cost gate responded immediately — see the eval discussion in the thread.

**Documentation accuracy.**

- The guide referred to a `camunda.version` property that `setup.md` never defines — it pins `camunda-process-test.version`. The two now agree, with the upstream name noted where it differs.
- `SKILL.md`&#39;s reference blurbs promised &#34;agentic evaluation assertions&#34; in `authoring.md` and &#34;evaluation assertions&#34; in `test-context.md`; neither page has that content, so both read as they do on `main` again.
- Parameterized test display names set in both templates, so CI names the scenario that failed instead of an index.
- Earlier rounds: dropped the &#34;in CI/CD&#34; overclaim from the title, de-duplicated the connectors-bundle tag guidance from four places to one, corrected the tag-coverage claim after it turned out to be false, and stopped hard-coding the sibling-harness path for the integration profile.

**Pushed back on one finding.** Copilot asked me to hedge the `camunda.client.prefer-rest-over-grpc` default on the grounds that nothing in this repo supports it. The claim is correct per the properties reference and hedging it would weaken the reason `rest-address` is mandatory; the sentence now cites the reference inline instead.

## Follow-ups filed, not fixed here

- #92 — `connectors-runtime.md` on `main` carries the same wrong CPT property prefix. Also raises whether an eval should assert the emitted CPT config, since this skill ships these snippets into real projects.
- #93 — `camunda-job-workers/references/worker-sdk-spring.md` uses the pre-8.8 `camunda.client.zeebe.*` nesting.

## Known blocker

`license/cla` is red. `fd79eb3` and `849bac30` are authored by `Claude <noreply@anthropic.com>`, which cannot sign; the check was green through `20a5f2d` and every other commit is authored normally. Fixing it means re-authoring those two commits, squash-merging, or allowlisting the address. Rewriting history on this branch is deliberately left to @HanselIdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)