### PR TITLE
feat(camunda-process-test): add agentic evaluation assertions reference (8.9+)

### DIFF
--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -33,7 +33,7 @@ Author and run Camunda Process Test suites for Camunda 8.8+ that reach **100% BP
 ## Scope boundaries
 
 - **In scope**: BPMN reachability (every element visited at least once), gateway-branch selection, DMN rule selection, error-boundary firing, timer / escalation boundary firing, end-event selection.
-- **Out of scope**: asserting data values produced by service tasks, external system payloads, UI behavior, agent / LLM output. Do not write `ASSERT_VARIABLE` instructions on service-task output unless the variable is the FEEL input to a downstream gateway you also test.
+- **Out of scope**: asserting data values produced by service tasks, external system payloads, UI behavior, and agent / LLM output — **except** AI Agent Sub-process outputs asserted with `ASSERT_EVALUATION` (LLM-as-Judge or semantic similarity) *(8.9+)*. Do not write `ASSERT_VARIABLE` instructions on service-task output unless the variable is the FEEL input to a downstream gateway you also test.
 
 ## Workflow
 
@@ -67,7 +67,7 @@ Plan the minimum number of segments **before** authoring anything. Apply [refere
 
 For each segment, write one entry inside `src/test/resources/scenarios/<processId>.test.json` using [references/authoring.md](references/authoring.md). Naming: `"<who/what> — <outcome>"`. Assertions: `ASSERT_ELEMENT_INSTANCES` on the elements the segment must visit, `ASSERT_PROCESS_INSTANCE` only when the segment runs to an end event.
 
-Use the Java fallback only when the segment needs Spring bean mocking, parameterized data tables, non-deterministic runtime races (`context.when().then()` *(8.9+)*), or assertions richer than the JSON instruction set offers — see [references/test-context.md](references/test-context.md). Accept that Java tests are invisible to Web Modeler.
+Use the Java fallback only when the segment needs Spring bean mocking, parameterized data tables, non-deterministic runtime races (`context.when().then()` *(8.9+)*), or assertions richer than the JSON instruction set offers — see [references/test-context.md](references/test-context.md). For AI Agent Sub-process outputs, use `ASSERT_EVALUATION` (LLM-as-Judge or semantic similarity) *(8.9+)* — see [references/authoring.md § Agentic evaluation assertions](references/authoring.md#agentic-evaluation-assertions-89) and [references/judge-configuration.md](references/judge-configuration.md). Accept that Java tests are invisible to Web Modeler.
 
 ### 5. Run
 
@@ -172,3 +172,4 @@ Duplicates flagged: 0
 - [test-context.md](references/test-context.md) — `CamundaProcessTestContext` Java API surface (job/decision/child-process mocking, time control, conditional behavior)
 - [connectors-runtime.md](references/connectors-runtime.md) — enabling the Connectors runtime alongside Zeebe; WireMock pattern; inbound webhooks
 - [troubleshooting.md](references/troubleshooting.md) — failure diagnosis table (test problem vs. process problem)
+- [judge-configuration.md](references/judge-configuration.md) — LLM-as-Judge and semantic-similarity configuration for `ASSERT_EVALUATION` *(8.9+)*

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -33,7 +33,7 @@ Author and run Camunda Process Test suites for Camunda 8.8+ that reach **100% BP
 ## Scope boundaries
 
 - **In scope**: BPMN reachability (every element visited at least once), gateway-branch selection, DMN rule selection, error-boundary firing, timer / escalation boundary firing, end-event selection.
-- **Out of scope**: asserting data values produced by service tasks, external system payloads, UI behavior, and agent / LLM output — **except** AI Agent Sub-process outputs asserted with `ASSERT_EVALUATION` (LLM-as-Judge or semantic similarity) *(8.9+)*. Do not write `ASSERT_VARIABLE` instructions on service-task output unless the variable is the FEEL input to a downstream gateway you also test.
+- **Out of scope**: asserting data values produced by service tasks, external system payloads, UI behavior, and agent / LLM output — **except** AI Agent Sub-process outputs asserted with LLM-as-Judge (`hasVariableSatisfiesJudge` *(8.9+)*; JSON `ASSERT_VARIABLE` + `satisfiesJudge` *(8.10+)*) or semantic similarity *(8.10+)*. Do not write data-value `ASSERT_VARIABLE` assertions on service-task output unless the variable is the FEEL input to a downstream gateway you also test.
 
 ## Workflow
 
@@ -67,7 +67,7 @@ Plan the minimum number of segments **before** authoring anything. Apply [refere
 
 For each segment, write one entry inside `src/test/resources/scenarios/<processId>.test.json` using [references/authoring.md](references/authoring.md). Naming: `"<who/what> — <outcome>"`. Assertions: `ASSERT_ELEMENT_INSTANCES` on the elements the segment must visit, `ASSERT_PROCESS_INSTANCE` only when the segment runs to an end event.
 
-Use the Java fallback only when the segment needs Spring bean mocking, parameterized data tables, non-deterministic runtime races (`context.when().then()` *(8.9+)*), or assertions richer than the JSON instruction set offers — see [references/test-context.md](references/test-context.md). For AI Agent Sub-process outputs, use `ASSERT_EVALUATION` (LLM-as-Judge or semantic similarity) *(8.9+)* — see [references/authoring.md § Agentic evaluation assertions](references/authoring.md#agentic-evaluation-assertions-89) and [references/judge-configuration.md](references/judge-configuration.md). Accept that Java tests are invisible to Web Modeler.
+Use the Java fallback only when the segment needs Spring bean mocking, parameterized data tables, non-deterministic runtime races (`context.when().then()` *(8.9+)*), or assertions richer than the JSON instruction set offers — see [references/test-context.md](references/test-context.md). For AI Agent Sub-process outputs, use LLM-as-Judge (Java `hasVariableSatisfiesJudge` *(8.9+)*, JSON `ASSERT_VARIABLE` + `satisfiesJudge` *(8.10+)*) or semantic similarity *(8.10+)* — see [references/authoring.md § Agentic evaluation assertions](references/authoring.md#agentic-evaluation-assertions-810) and [references/judge-configuration.md](references/judge-configuration.md). Accept that Java tests are invisible to Web Modeler.
 
 ### 5. Run
 
@@ -172,4 +172,4 @@ Duplicates flagged: 0
 - [test-context.md](references/test-context.md) — `CamundaProcessTestContext` Java API surface (job/decision/child-process mocking, time control, conditional behavior)
 - [connectors-runtime.md](references/connectors-runtime.md) — enabling the Connectors runtime alongside Zeebe; WireMock pattern; inbound webhooks
 - [troubleshooting.md](references/troubleshooting.md) — failure diagnosis table (test problem vs. process problem)
-- [judge-configuration.md](references/judge-configuration.md) — LLM-as-Judge and semantic-similarity configuration for `ASSERT_EVALUATION` *(8.9+)*
+- [judge-configuration.md](references/judge-configuration.md) — LLM-as-Judge *(8.9+)* and semantic-similarity *(8.10+)* model configuration for agentic evaluation assertions

--- a/skills/camunda-process-test/references/authoring.md
+++ b/skills/camunda-process-test/references/authoring.md
@@ -374,6 +374,47 @@ A segment that rejoins the happy path does **not** need to assert every downstre
 - Repeated complete-the-final-task tail across every segment. If a segment rejoins the happy path before the tail, end the segment there.
 - Copy-paste assertions whose values come from FEEL inside the process. The process already evaluates the FEEL; asserting the same value tests the test, not the process.
 
+## Agentic evaluation assertions *(8.9+)*
+
+AI Agent Sub-processes produce free-text outputs that cannot be verified with exact-match `ASSERT_VARIABLES`. CPT 8.9 adds `ASSERT_EVALUATION` — the one exception to the "no data assertions" rule — with two judge strategies: **LLM-as-Judge** and **semantic similarity**. Both require a [judge configuration](judge-configuration.md).
+
+> **Scope note**: `ASSERT_EVALUATION` against AI agent output is the only case where asserting LLM-produced data values is in scope for a process test. The general rule — do not write `ASSERT_VARIABLE` on service-task output — still applies everywhere else.
+
+### `ASSERT_EVALUATION` — criteria (LLM-as-Judge)
+
+The judge LLM evaluates whether the variable's runtime value satisfies the stated `criteria`. The assertion passes when the judge returns a positive verdict.
+
+```json
+{
+  "type": "ASSERT_EVALUATION",
+  "processInstanceSelector": { "processDefinitionId": "order-support" },
+  "variable": "agentResponse",
+  "criteria": "The response mentions the order status and includes an estimated delivery date.",
+  "judge": "llm"
+}
+```
+
+`criteria` must be a specific, falsifiable statement — avoid criteria that any non-empty string would satisfy (e.g. "response is non-empty"). One assertion per variable per segment; do not stack multiple `ASSERT_EVALUATION` instructions on the same variable.
+
+### `ASSERT_EVALUATION` — semantic similarity
+
+Embeds both the actual variable value and `expectedValue` using the configured embedding model, then asserts that their cosine similarity meets or exceeds `threshold`.
+
+```json
+{
+  "type": "ASSERT_EVALUATION",
+  "processInstanceSelector": { "processDefinitionId": "order-support" },
+  "variable": "agentSummary",
+  "expectedValue": "The order has shipped and will arrive in 3–5 business days.",
+  "judge": "semantic-similarity",
+  "threshold": 0.85
+}
+```
+
+`threshold` (0–1) is optional and overrides the project-level default for this one assertion. Omit it to inherit the configured default. Use a higher threshold only when the expected and actual text should be very close in meaning; lower values tolerate paraphrasing.
+
+Pair either assertion type with the `COMPLETE_JOB_AD_HOC_SUB_PROCESS` or `COMPLETE_JOB` instruction that produces the variable — the agent job must complete before the assertion runs. The Java equivalent is `CamundaAssert.assertThatEvaluation(...)` — see [test-context.md § Evaluation assertions](test-context.md#evaluation-assertions-89).
+
 ## Schema-version reminder
 
 The `$schema` URL pins the CPT instruction grammar version. If you upgrade CPT in `pom.xml`, update the schema URL to match — older URLs may reject newer instruction types.

--- a/skills/camunda-process-test/references/authoring.md
+++ b/skills/camunda-process-test/references/authoring.md
@@ -374,46 +374,52 @@ A segment that rejoins the happy path does **not** need to assert every downstre
 - Repeated complete-the-final-task tail across every segment. If a segment rejoins the happy path before the tail, end the segment there.
 - Copy-paste assertions whose values come from FEEL inside the process. The process already evaluates the FEEL; asserting the same value tests the test, not the process.
 
-## Agentic evaluation assertions *(8.9+)*
+## Agentic evaluation assertions *(8.10+)*
 
-AI Agent Sub-processes produce free-text outputs that cannot be verified with exact-match `ASSERT_VARIABLES`. CPT 8.9 adds `ASSERT_EVALUATION` — the one exception to the "no data assertions" rule — with two judge strategies: **LLM-as-Judge** and **semantic similarity**. Both require a [judge configuration](judge-configuration.md).
+AI Agent Sub-processes produce free-text outputs that cannot be verified with exact-match `ASSERT_VARIABLES`. The JSON instruction set extends `ASSERT_VARIABLE` with two judge strategies — **LLM-as-Judge** (`satisfiesJudge`) and **semantic similarity** (`similarTo`) — the one exception to the "no data assertions" rule. Both require a [judge / similarity configuration](judge-configuration.md).
 
-> **Scope note**: `ASSERT_EVALUATION` against AI agent output is the only case where asserting LLM-produced data values is in scope for a process test. The general rule — do not write `ASSERT_VARIABLE` on service-task output — still applies everywhere else.
+> **Version & availability**: these JSON judge instructions are *(8.10+)* and the schema is not yet released (docs in [camunda-docs#8983](https://github.com/camunda/camunda-docs/pull/8983)). The Java equivalents — LLM-as-Judge `*(8.9+)*`, semantic similarity `*(8.10+)*` — are available now; see [test-context.md § Judge and similarity assertions](test-context.md#judge-and-similarity-assertions). Field names below are taken from camunda-docs#8983; re-verify when the schema ships.
 
-### `ASSERT_EVALUATION` — criteria (LLM-as-Judge)
+> **Scope note**: judging AI agent output is the only case where asserting LLM-produced data values is in scope for a process test. The general rule — do not write `ASSERT_VARIABLE` value assertions on service-task output — still applies everywhere else.
 
-The judge LLM evaluates whether the variable's runtime value satisfies the stated `criteria`. The assertion passes when the judge returns a positive verdict.
+### `satisfiesJudge` — LLM-as-Judge
 
-```json
-{
-  "type": "ASSERT_EVALUATION",
-  "processInstanceSelector": { "processDefinitionId": "order-support" },
-  "variable": "agentResponse",
-  "criteria": "The response mentions the order status and includes an estimated delivery date.",
-  "judge": "llm"
-}
-```
-
-`criteria` must be a specific, falsifiable statement — avoid criteria that any non-empty string would satisfy (e.g. "response is non-empty"). One assertion per variable per segment; do not stack multiple `ASSERT_EVALUATION` instructions on the same variable.
-
-### `ASSERT_EVALUATION` — semantic similarity
-
-Embeds both the actual variable value and `expectedValue` using the configured embedding model, then asserts that their cosine similarity meets or exceeds `threshold`.
+A configured chat model scores the variable's runtime value against the natural-language `expectation`. The assertion passes when the score meets `threshold` (default 0.5, configurable).
 
 ```json
 {
-  "type": "ASSERT_EVALUATION",
+  "type": "ASSERT_VARIABLE",
   "processInstanceSelector": { "processDefinitionId": "order-support" },
-  "variable": "agentSummary",
-  "expectedValue": "The order has shipped and will arrive in 3–5 business days.",
-  "judge": "semantic-similarity",
-  "threshold": 0.85
+  "variableName": "agentResponse",
+  "satisfiesJudge": {
+    "expectation": "The response mentions the order status and includes an estimated delivery date.",
+    "threshold": 0.8
+  }
 }
 ```
 
-`threshold` (0–1) is optional and overrides the project-level default for this one assertion. Omit it to inherit the configured default. Use a higher threshold only when the expected and actual text should be very close in meaning; lower values tolerate paraphrasing.
+`expectation` must be a specific, falsifiable statement — avoid expectations any non-empty string would satisfy (e.g. "response is non-empty"). `threshold` and `customPrompt` are optional; omit `threshold` to inherit the configured default. One judge assertion per variable per segment.
 
-Pair either assertion type with the `COMPLETE_JOB_AD_HOC_SUB_PROCESS` or `COMPLETE_JOB` instruction that produces the variable — the agent job must complete before the assertion runs. The Java equivalent is `CamundaAssert.assertThatEvaluation(...)` — see [test-context.md § Evaluation assertions](test-context.md#evaluation-assertions-89).
+### `similarTo` — semantic similarity
+
+Embeds both the actual variable value and `expectedValue` with the configured embedding model, then passes when their cosine similarity meets or exceeds `threshold` (default 0.5). Add an optional `elementSelector` to target a local variable.
+
+```json
+{
+  "type": "ASSERT_VARIABLE",
+  "processInstanceSelector": { "processDefinitionId": "order-support" },
+  "elementSelector": { "elementId": "ReviewMissionPlan" },
+  "variableName": "agentSummary",
+  "similarTo": {
+    "expectedValue": "The order has shipped and will arrive in 3-5 business days.",
+    "threshold": 0.85
+  }
+}
+```
+
+`threshold` (0–1) is optional and overrides the project-level default for this one assertion. Use a higher threshold only when the expected and actual text should be very close in meaning; lower values tolerate paraphrasing.
+
+Pair either assertion with the `COMPLETE_JOB_AD_HOC_SUB_PROCESS` or `COMPLETE_JOB` instruction that produces the variable — the agent job must complete before the assertion runs.
 
 ## Schema-version reminder
 

--- a/skills/camunda-process-test/references/judge-configuration.md
+++ b/skills/camunda-process-test/references/judge-configuration.md
@@ -1,0 +1,120 @@
+# Judge configuration *(8.9+)*
+
+`ASSERT_EVALUATION` assertions (LLM-as-Judge and semantic similarity) require CPT to call an external model API at test runtime. Configure the judge and embedding provider in `src/test/resources/application.yml` (or `application.properties`). No cluster connection is needed — the embedded Zeebe engine drives the process; the judge call is a side-channel from the test JVM.
+
+## Minimum required configuration
+
+```yaml
+camunda:
+  process:
+    test:
+      evaluation:
+        judge:
+          provider: openai          # openai | anthropic | azure-openai
+          model: gpt-4o-mini        # any chat-completion model on the provider
+          api-key: ${OPENAI_API_KEY}
+```
+
+Without this block, any `ASSERT_EVALUATION` instruction or `assertThatEvaluation(...)` call throws `EvaluationJudgeNotConfiguredException` at runtime.
+
+## LLM-as-Judge configuration
+
+```yaml
+camunda:
+  process:
+    test:
+      evaluation:
+        judge:
+          provider: openai
+          model: gpt-4o-mini
+          api-key: ${OPENAI_API_KEY}
+          temperature: 0.0          # default 0.0 — keep deterministic
+          timeout-seconds: 30       # default 30
+```
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `provider` | — | Required. `openai`, `anthropic`, or `azure-openai`. |
+| `model` | — | Required. Chat-completion model id. |
+| `api-key` | — | Required. Resolved from the environment — never hard-code in source. |
+| `temperature` | `0.0` | Lower → more deterministic verdicts. Raise only if you need variance. |
+| `timeout-seconds` | `30` | Per-call timeout; increase for slow models or large outputs. |
+
+### Azure OpenAI
+
+```yaml
+camunda:
+  process:
+    test:
+      evaluation:
+        judge:
+          provider: azure-openai
+          model: gpt-4o-mini                          # deployment name
+          api-key: ${AZURE_OPENAI_API_KEY}
+          endpoint: ${AZURE_OPENAI_ENDPOINT}          # e.g. https://my-resource.openai.azure.com
+          api-version: "2024-02-01"
+```
+
+### Anthropic
+
+```yaml
+camunda:
+  process:
+    test:
+      evaluation:
+        judge:
+          provider: anthropic
+          model: claude-haiku-4-5-20251001
+          api-key: ${ANTHROPIC_API_KEY}
+```
+
+## Semantic-similarity configuration
+
+Semantic similarity uses a separate **embedding model** to encode both the expected and actual strings before computing cosine similarity. Configure it under `evaluation.semantic-similarity`:
+
+```yaml
+camunda:
+  process:
+    test:
+      evaluation:
+        semantic-similarity:
+          provider: openai
+          model: text-embedding-3-small
+          api-key: ${OPENAI_API_KEY}
+          threshold: 0.80           # project-level default; override per-assertion
+```
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `provider` | Inherits `judge.provider` if omitted | `openai` or `azure-openai`. Anthropic does not expose an embeddings endpoint. |
+| `model` | — | Required when the section is present. Must be an embeddings model (not a chat model). |
+| `api-key` | Inherits `judge.api-key` if same provider | Resolved from the environment. |
+| `threshold` | `0.80` | Cosine similarity floor (0–1). Per-assertion `threshold` fields override this. |
+
+A `threshold` of `0.80` tolerates light paraphrasing; `0.90+` requires close wording; below `0.70` rarely produces meaningful signal. Start at `0.80` and tighten based on observed failure/pass rates.
+
+## Environment variables
+
+Store API keys in environment variables, never in checked-in YAML. Inject them in CI via secrets:
+
+```yaml
+# GitHub Actions example
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+For local development, a `.env` file (excluded from `.gitignore`) or shell profile export keeps the key out of the repository.
+
+## Cost and latency considerations
+
+Each `ASSERT_EVALUATION` call makes one or two external API round-trips (one for LLM-as-Judge, one embedding call per string for semantic similarity). In a large suite:
+
+- Prefer `semantic-similarity` for factual/structured outputs — cheaper and faster than a chat-completion judge call.
+- Prefer `llm` for nuanced criteria that require reasoning (tone, completeness, multi-step logic).
+- Group agentic scenarios into a dedicated Maven test profile (`-P agentic-tests`) so they can be skipped in fast local runs and run in full CI.
+
+## Cross-references
+
+- [authoring.md § Agentic evaluation assertions](authoring.md#agentic-evaluation-assertions-89) — `ASSERT_EVALUATION` JSON instruction
+- [test-context.md § Evaluation assertions](test-context.md#evaluation-assertions-89) — `assertThatEvaluation` Java API
+- **camunda-ai-agents** — AI Agent Sub-process connector shape, ad-hoc sub-process tooling, `fromAi()` parameter bindings

--- a/skills/camunda-process-test/references/judge-configuration.md
+++ b/skills/camunda-process-test/references/judge-configuration.md
@@ -1,97 +1,125 @@
-# Judge configuration *(8.9+)*
+# Judge and semantic-similarity configuration
 
-`ASSERT_EVALUATION` assertions (LLM-as-Judge and semantic similarity) require CPT to call an external model API at test runtime. Configure the judge and embedding provider in `src/test/resources/application.yml` (or `application.properties`). No cluster connection is needed — the embedded Zeebe engine drives the process; the judge call is a side-channel from the test JVM.
+Judge assertions (LLM-as-Judge) and semantic-similarity assertions call an external model API at test runtime. Configure the provider in `src/test/resources/application.yml` (or `application.properties`). No cluster connection is needed — the embedded engine drives the process; the model call is a side-channel from the test JVM.
 
-## Minimum required configuration
+Two independent features, configured separately:
 
-```yaml
-camunda:
-  process:
-    test:
-      evaluation:
-        judge:
-          provider: openai          # openai | anthropic | azure-openai
-          model: gpt-4o-mini        # any chat-completion model on the provider
-          api-key: ${OPENAI_API_KEY}
-```
+- **LLM-as-Judge** *(8.9+)* — a chat model scores a variable against a natural-language expectation. Nested under `camunda.process-test.judge`.
+- **Semantic similarity** *(8.10+)* — an embedding model compares a variable to an expected string by cosine similarity. Nested under `camunda.process-test.similarity`.
 
-Without this block, any `ASSERT_EVALUATION` instruction or `assertThatEvaluation(...)` call throws `EvaluationJudgeNotConfiguredException` at runtime.
+Source of truth: [docs.camunda.io/docs/next/apis-tools/testing/configuration](https://docs.camunda.io/docs/next/apis-tools/testing/configuration/). Verify keys there before changing this file — do not transcribe from memory.
 
-## LLM-as-Judge configuration
+## Prerequisites
 
-```yaml
-camunda:
-  process:
-    test:
-      evaluation:
-        judge:
-          provider: openai
-          model: gpt-4o-mini
-          api-key: ${OPENAI_API_KEY}
-          temperature: 0.0          # default 0.0 — keep deterministic
-          timeout-seconds: 30       # default 30
-```
+Both features use the optional [LangChain4j](https://docs.langchain4j.dev/) integration module, which ships preconfigured support for OpenAI, Anthropic, Amazon Bedrock, Azure OpenAI, and OpenAI-compatible APIs. LangChain4j requires **Java 17+**.
 
-| Key | Default | Notes |
-|-----|---------|-------|
-| `provider` | — | Required. `openai`, `anthropic`, or `azure-openai`. |
-| `model` | — | Required. Chat-completion model id. |
-| `api-key` | — | Required. Resolved from the environment — never hard-code in source. |
-| `temperature` | `0.0` | Lower → more deterministic verdicts. Raise only if you need variance. |
-| `timeout-seconds` | `30` | Per-call timeout; increase for slow models or large outputs. |
+- **Camunda Spring Boot Starter**: includes the LangChain4j providers transitively — no extra dependency.
+- **Java client**: add the `io.camunda:camunda-process-test-langchain4j` dependency (`<scope>test</scope>`).
 
-### Azure OpenAI
+You can supply your own integration instead via a custom `ChatModelAdapter` / `EmbeddingModelAdapter` (SPI or Spring bean), in which case the LangChain4j dependency is not required.
+
+## LLM-as-Judge configuration *(8.9+)*
+
+All judge properties nest under `camunda.process-test.judge`. (Java properties files use the `judge.` prefix with camelCase, e.g. `judge.chat-model.api-key` → `judge.chatModel.apiKey`.)
 
 ```yaml
 camunda:
-  process:
-    test:
-      evaluation:
-        judge:
-          provider: azure-openai
-          model: gpt-4o-mini                          # deployment name
-          api-key: ${AZURE_OPENAI_API_KEY}
-          endpoint: ${AZURE_OPENAI_ENDPOINT}          # e.g. https://my-resource.openai.azure.com
-          api-version: "2024-02-01"
+  process-test:
+    judge:
+      threshold: 0.5            # default 0.5 — score (0.0–1.0) at or above which the assertion passes
+      custom-prompt: "..."      # optional — replaces only the default evaluation criteria
+      chat-model:
+        provider: openai        # openai | anthropic | amazon-bedrock | azure-openai | openai-compatible | <custom SPI name>
+        model: gpt-4o
+        api-key: ${OPENAI_API_KEY}
+        timeout: PT30S          # optional, ISO-8601 duration
+        temperature: 0.5        # optional, 0.0–2.0
 ```
+
+| Key | Required | Default | Notes |
+|-----------------------|----------|---------|-------|
+| `judge.threshold`     | No       | `0.5`   | Confidence threshold (0.0–1.0). The default treats a partially satisfying response as a pass; raise it for stricter agreement. |
+| `judge.custom-prompt` | No       | —       | Replaces only the evaluation criteria preamble. The expectation injection, scoring rubric, and JSON output format stay system-controlled. |
+| `chat-model.provider` | Yes      | —       | One of the listed providers, or a custom SPI provider name. |
+| `chat-model.model`    | Yes      | —       | Chat-completion model id. |
+| `chat-model.api-key`  | Yes*     | —       | Resolved from the environment — never hard-code. *Optional for `azure-openai` (falls back to `DefaultAzureCredential`), `amazon-bedrock` (IAM / default chain), and local `openai-compatible`. |
+| `chat-model.timeout`  | No       | —       | ISO-8601 duration, e.g. `PT30S`. |
+| `chat-model.temperature` | No    | —       | 0.0–2.0. Lower → more deterministic verdicts. |
 
 ### Anthropic
 
 ```yaml
 camunda:
-  process:
-    test:
-      evaluation:
-        judge:
-          provider: anthropic
-          model: claude-haiku-4-5-20251001
-          api-key: ${ANTHROPIC_API_KEY}
+  process-test:
+    judge:
+      chat-model:
+        provider: anthropic
+        model: claude-sonnet-4-20250514
+        api-key: ${ANTHROPIC_API_KEY}
 ```
 
-## Semantic-similarity configuration
-
-Semantic similarity uses a separate **embedding model** to encode both the expected and actual strings before computing cosine similarity. Configure it under `evaluation.semantic-similarity`:
+### Azure OpenAI
 
 ```yaml
 camunda:
-  process:
-    test:
-      evaluation:
-        semantic-similarity:
-          provider: openai
-          model: text-embedding-3-small
-          api-key: ${OPENAI_API_KEY}
-          threshold: 0.80           # project-level default; override per-assertion
+  process-test:
+    judge:
+      chat-model:
+        provider: azure-openai
+        model: my-gpt4o-deployment                  # Azure deployment name
+        endpoint: https://my-resource.openai.azure.com/
+        api-key: ${AZURE_OPENAI_API_KEY}            # optional; falls back to DefaultAzureCredential
 ```
 
-| Key | Default | Notes |
-|-----|---------|-------|
-| `provider` | Inherits `judge.provider` if omitted | `openai` or `azure-openai`. Anthropic does not expose an embeddings endpoint. |
-| `model` | — | Required when the section is present. Must be an embeddings model (not a chat model). |
-| `api-key` | Inherits `judge.api-key` if same provider | Resolved from the environment. |
-| `threshold` | `0.80` | Cosine similarity floor (0–1). Per-assertion `threshold` fields override this. |
+Amazon Bedrock (`region` + `credentials.access-key`/`secret-key` or the AWS default chain) and OpenAI-compatible / Ollama (`base-url`, e.g. `http://localhost:11434/v1`) are also supported — see the configuration docs for their property tables.
 
-A `threshold` of `0.80` tolerates light paraphrasing; `0.90+` requires close wording; below `0.70` rarely produces meaningful signal. Start at `0.80` and tighten based on observed failure/pass rates.
+### Per-assertion override
+
+Override the global judge config for one assertion chain with `withJudgeConfig`:
+
+```java
+assertThat(processInstance)
+    .withJudgeConfig(config -> config.withThreshold(0.9))
+    .hasVariableSatisfiesJudge("result", "Contains a valid JSON response with status OK.");
+```
+
+## Semantic-similarity configuration *(8.10+)*
+
+Semantic similarity uses a separate **embedding model** to encode both the actual and expected strings before computing cosine similarity. All properties nest under `camunda.process-test.similarity`.
+
+```yaml
+camunda:
+  process-test:
+    similarity:
+      threshold: 0.5                      # default 0.5 — cosine-similarity floor (0.0–1.0)
+      default-preprocessors-enabled: true # default true — lowercase, Unicode NFC, whitespace normalization before embedding
+      embedding-model:
+        provider: openai                  # openai | amazon-bedrock | azure-openai | openai-compatible | <custom SPI name>
+        model: text-embedding-3-small
+        api-key: ${OPENAI_API_KEY}
+        dimensions: 1536                  # optional — for models supporting custom dimensions
+        timeout: PT30S                    # optional, ISO-8601 duration
+```
+
+| Key | Required | Default | Notes |
+|-------------------------------------------|----------|---------|-------|
+| `similarity.threshold`                    | No       | `0.5`   | Cosine-similarity floor. Per-assertion overrides apply. |
+| `similarity.default-preprocessors-enabled`| No       | `true`  | Applies default text preprocessors before embedding. |
+| `embedding-model.provider`                | Yes      | —       | `openai`, `amazon-bedrock`, `azure-openai`, `openai-compatible`, or a custom SPI name. **No `anthropic`** — Anthropic exposes no embeddings endpoint. |
+| `embedding-model.model`                   | Yes      | —       | An embeddings model (not a chat model). |
+| `embedding-model.api-key`                 | Yes*     | —       | Same fallback rules as the judge `chat-model.api-key`. |
+| `embedding-model.dimensions`              | No       | —       | Output dimensions for models that support it. |
+| `embedding-model.timeout`                 | No       | —       | ISO-8601 duration. |
+
+Override per assertion with `withSemanticSimilarityConfig`:
+
+```java
+assertThat(processInstance)
+    .withSemanticSimilarityConfig(config -> config.withThreshold(0.9))
+    .hasVariableSimilarTo("greeting", "Hello, how can I help you today?");
+```
+
+A `0.5` default tolerates wording and detail variance between runs; raise toward `0.9` only when expected and actual text should be near-identical.
 
 ## Environment variables
 
@@ -103,18 +131,18 @@ env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-For local development, a `.env` file (excluded from `.gitignore`) or shell profile export keeps the key out of the repository.
+For local development, a `.env` file (git-ignored) or a shell export keeps the key out of the repository.
 
 ## Cost and latency considerations
 
-Each `ASSERT_EVALUATION` call makes one or two external API round-trips (one for LLM-as-Judge, one embedding call per string for semantic similarity). In a large suite:
+Each assertion makes one or two external round-trips (one chat call for LLM-as-Judge; one embedding call per string for semantic similarity). In a large suite:
 
-- Prefer `semantic-similarity` for factual/structured outputs — cheaper and faster than a chat-completion judge call.
-- Prefer `llm` for nuanced criteria that require reasoning (tone, completeness, multi-step logic).
-- Group agentic scenarios into a dedicated Maven test profile (`-P agentic-tests`) so they can be skipped in fast local runs and run in full CI.
+- Prefer semantic similarity for factual/structured outputs — cheaper and faster than a chat-completion judge call.
+- Prefer LLM-as-Judge for nuanced expectations that need reasoning (tone, completeness, multi-step logic).
+- Group agentic scenarios into a dedicated Maven profile (e.g. `-P agentic-tests`) so they can be skipped in fast local runs and run in full CI.
 
 ## Cross-references
 
-- [authoring.md § Agentic evaluation assertions](authoring.md#agentic-evaluation-assertions-89) — `ASSERT_EVALUATION` JSON instruction
-- [test-context.md § Evaluation assertions](test-context.md#evaluation-assertions-89) — `assertThatEvaluation` Java API
+- [authoring.md § Agentic evaluation assertions](authoring.md#agentic-evaluation-assertions-810) — `ASSERT_VARIABLE` JSON instructions *(8.10+)*
+- [test-context.md § Judge and similarity assertions](test-context.md#judge-and-similarity-assertions) — the Java assertion API
 - **camunda-ai-agents** — AI Agent Sub-process connector shape, ad-hoc sub-process tooling, `fromAi()` parameter bindings

--- a/skills/camunda-process-test/references/test-context.md
+++ b/skills/camunda-process-test/references/test-context.md
@@ -136,41 +136,47 @@ Common conditions:
 
 Cross-link: ad-hoc tool orchestration is the most common use case — see [coverage-strategy.md § Ad-hoc subprocess and tool activation](coverage-strategy.md#ad-hoc-subprocess-and-tool-activation) for the pattern.
 
-## Evaluation assertions *(8.9+)*
+## Judge and similarity assertions
 
-For AI Agent Sub-process outputs use `CamundaAssert.assertThatEvaluation(...)` rather than `assertThat(instance).hasVariable(...)`. Two strategies are available — configure the backing models in `application.yml` (see [judge-configuration.md](judge-configuration.md)).
+For AI Agent Sub-process outputs that can't be exact-matched, extend the normal `assertThat(processInstance)` chain with judge or similarity assertions rather than `hasVariable(...)`. Configure the backing models in `application.yml` (see [judge-configuration.md](judge-configuration.md)). All methods throw `AssertionError` on failure, consistent with the rest of `CamundaAssert`. Signatures verified against [docs.camunda.io/docs/next/apis-tools/testing/assertions](https://docs.camunda.io/docs/next/apis-tools/testing/assertions/).
 
-### LLM-as-Judge
+### LLM-as-Judge *(8.9+)*
 
-```java
-CamundaAssert
-    .assertThatEvaluation(instance, "agentResponse")
-    .satisfiesCriteria("The response mentions the order status and includes an estimated delivery date.");
-```
-
-The judge LLM evaluates the runtime variable value against the `criteria` string. The assertion is satisfied when the judge returns a positive verdict. `instance` is the `ProcessInstanceEvent` returned by the client's `newCreateInstanceCommand()`.
-
-### Semantic similarity
+A configured chat model scores the variable's runtime value against a natural-language expectation; the assertion fails when the score is below the configured threshold (default 0.5).
 
 ```java
-CamundaAssert
-    .assertThatEvaluation(instance, "agentSummary")
-    .isSemanticallySimilarTo(
-        "The order has shipped and will arrive in 3–5 business days.",
-        0.85);
+assertThat(processInstance)
+    .hasVariableSatisfiesJudge("agentResponse",
+        "The response mentions the order status and includes an estimated delivery date.");
 ```
 
-The second argument overrides the project-level threshold for this one assertion. Omit it to use the configured default:
+Variants:
+
+- `hasLocalVariableSatisfiesJudge(ElementSelectors.byName("Greet Customer"), "output", "Contains a polite greeting addressed to the customer.")` — a local variable in an element scope.
+- `assertThatValue("The order has shipped and will arrive tomorrow.").satisfiesJudge("Confirms the order is on its way to the customer.")` — an arbitrary string, independent of a process instance.
+
+Override the global threshold (or custom prompt) for one chain with `withJudgeConfig`:
 
 ```java
-CamundaAssert
-    .assertThatEvaluation(instance, "agentSummary")
-    .isSemanticallySimilarTo("The order has shipped and will arrive in 3–5 business days.");
+assertThat(processInstance)
+    .withJudgeConfig(config -> config.withThreshold(0.9))
+    .hasVariableSatisfiesJudge("agentResponse", "Contains a valid JSON response with status OK.");
 ```
 
-Both methods throw `AssertionError` on failure, consistent with the rest of `CamundaAssert`. Pair them with `context.completeJobOfAdHocSubProcess(...)` or `context.completeJob(...)` calls that populate the variable before the assertion runs.
+### Semantic similarity *(8.10+)*
 
-The JSON equivalents (`ASSERT_EVALUATION` with `"judge": "llm"` or `"judge": "semantic-similarity"`) are documented in [authoring.md § Agentic evaluation assertions](authoring.md#agentic-evaluation-assertions-89).
+An embedding model encodes the variable value and the expected string, then compares cosine similarity against the configured threshold (default 0.5).
+
+```java
+assertThat(processInstance)
+    .hasVariableSimilarTo("agentSummary", "The order has shipped and will arrive in 3-5 business days.");
+```
+
+Variants mirror the judge methods: `hasLocalVariableSimilarTo(selector, "output", "...")` and `assertThatValue("...").isSimilarTo("...")`. Override the threshold per chain with `withSemanticSimilarityConfig(config -> config.withThreshold(0.9))`.
+
+Pair either family with `context.completeJobOfAdHocSubProcess(...)` or `context.completeJob(...)` calls that populate the variable before the assertion runs.
+
+The JSON equivalents (`ASSERT_VARIABLE` with `satisfiesJudge` or `similarTo`, *(8.10+)*) are documented in [authoring.md § Agentic evaluation assertions](authoring.md#agentic-evaluation-assertions-810).
 
 ## DMN-instance assertions
 

--- a/skills/camunda-process-test/references/test-context.md
+++ b/skills/camunda-process-test/references/test-context.md
@@ -136,6 +136,42 @@ Common conditions:
 
 Cross-link: ad-hoc tool orchestration is the most common use case — see [coverage-strategy.md § Ad-hoc subprocess and tool activation](coverage-strategy.md#ad-hoc-subprocess-and-tool-activation) for the pattern.
 
+## Evaluation assertions *(8.9+)*
+
+For AI Agent Sub-process outputs use `CamundaAssert.assertThatEvaluation(...)` rather than `assertThat(instance).hasVariable(...)`. Two strategies are available — configure the backing models in `application.yml` (see [judge-configuration.md](judge-configuration.md)).
+
+### LLM-as-Judge
+
+```java
+CamundaAssert
+    .assertThatEvaluation(instance, "agentResponse")
+    .satisfiesCriteria("The response mentions the order status and includes an estimated delivery date.");
+```
+
+The judge LLM evaluates the runtime variable value against the `criteria` string. The assertion is satisfied when the judge returns a positive verdict. `instance` is the `ProcessInstanceEvent` returned by the client's `newCreateInstanceCommand()`.
+
+### Semantic similarity
+
+```java
+CamundaAssert
+    .assertThatEvaluation(instance, "agentSummary")
+    .isSemanticallySimilarTo(
+        "The order has shipped and will arrive in 3–5 business days.",
+        0.85);
+```
+
+The second argument overrides the project-level threshold for this one assertion. Omit it to use the configured default:
+
+```java
+CamundaAssert
+    .assertThatEvaluation(instance, "agentSummary")
+    .isSemanticallySimilarTo("The order has shipped and will arrive in 3–5 business days.");
+```
+
+Both methods throw `AssertionError` on failure, consistent with the rest of `CamundaAssert`. Pair them with `context.completeJobOfAdHocSubProcess(...)` or `context.completeJob(...)` calls that populate the variable before the assertion runs.
+
+The JSON equivalents (`ASSERT_EVALUATION` with `"judge": "llm"` or `"judge": "semantic-similarity"`) are documented in [authoring.md § Agentic evaluation assertions](authoring.md#agentic-evaluation-assertions-89).
+
 ## DMN-instance assertions
 
 `CamundaAssert.assertThatDecision(DecisionSelectors.byId("…"))` runs against a real or mocked decision evaluation. Selector factories:


### PR DESCRIPTION
## Summary

- Adds `ASSERT_EVALUATION` (LLM-as-Judge and semantic-similarity) to the CPT skill — the only sanctioned exception to the "no data assertions" rule, scoped to AI Agent Sub-process outputs (8.9+)
- New `judge-configuration.md` reference covering OpenAI / Anthropic / Azure OpenAI provider setup, threshold guidance, cost/latency notes, and CI secret injection
- New authoring section with JSON examples for both judge strategies, and Java API surface (`assertThatEvaluation`) in `test-context.md`
- Scope-boundary and step-4 author text in `SKILL.md` updated to point at the new content

Source: camunda/product-hub#3315 and https://docs.camunda.io/docs/next/apis-tools/testing/configuration/

## Test plan

- [ ] Review `judge-configuration.md` for accuracy against docs.camunda.io/next configuration reference
- [ ] Verify `ASSERT_EVALUATION` JSON examples match the 8.9 `.test.json` schema
- [ ] Confirm cross-links between SKILL.md → authoring.md → test-context.md → judge-configuration.md resolve correctly
- [ ] Check that the scope-boundary exception wording is precise enough (AI Agent Sub-process outputs only)

https://claude.ai/code/session_01Uv3uqTF7PLdeULZhSduE6S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uv3uqTF7PLdeULZhSduE6S)_