### PR TITLE
refactor(test): run evals on the Anthropic API; split baseline tokens + capture duration

### DIFF
--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -137,10 +137,8 @@ jobs:
       - name: Run eval + regenerate baseline
         working-directory: evals
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION || 'us-east-1' }}
-          MODEL: ${{ vars.EVAL_MODEL || 'anthropic/bedrock/global.anthropic.claude-sonnet-4-6' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MODEL: ${{ vars.EVAL_MODEL || 'anthropic/claude-sonnet-4-6' }}
         run: |
           spec="${{ matrix.spec }}"
           dir="${spec%/outcomes.py}"   # skills/<name> or scenarios/<name>

--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -98,12 +98,10 @@ jobs:
       - name: Run eval
         working-directory: evals
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION || 'us-east-1' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           uv run inspect eval "${{ matrix.spec }}" --log-dir logs/ --display ${{ matrix.display }} ${{ matrix.limit }} \
-            --model "${{ vars.EVAL_MODEL || 'anthropic/bedrock/global.anthropic.claude-sonnet-4-6' }}" \
+            --model "${{ vars.EVAL_MODEL || 'anthropic/claude-sonnet-4-6' }}" \
             ${{ matrix.targs }}
 
       - name: Gate (evals-pass-fail)

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -9,7 +9,9 @@ name: 🧪 Run skill evals
 #   - evals:run-all   → every target (suite integration check)
 #   - evals:compare   → also run the without-skill arm of outcome evals
 # workflow_dispatch (requires write access) can run a single target and toggle
-# the comparison. Model: the EVAL_MODEL repo var (default a Bedrock Claude).
+# the comparison. Model: the EVAL_MODEL repo var (default an Anthropic Claude);
+# the key is ANTHROPIC_API_KEY, read by Inspect on the runner — the sandbox
+# bridge proxies model calls back to it, so the container carries no credential.
 on:
   workflow_dispatch:
     inputs:
@@ -164,16 +166,16 @@ jobs:
 
       - name: Run eval
         # Single model via EVAL_MODEL. For a multi-model sweep, add a `model`
-        # axis to the matrix include built in `detect`. AWS creds wire the
-        # default Bedrock provider; swap if EVAL_MODEL points elsewhere.
+        # axis to the matrix include built in `detect`. ANTHROPIC_API_KEY is
+        # read by Inspect on the runner; the sandbox bridge proxies model calls
+        # back to it (the container carries no credential). Point EVAL_MODEL
+        # elsewhere + swap the key if running another provider.
         working-directory: evals
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION || 'us-east-1' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           uv run inspect eval "${{ matrix.spec }}" --log-dir logs/ --display ${{ matrix.display }} ${{ matrix.limit }} \
-            --model "${{ vars.EVAL_MODEL || 'anthropic/bedrock/global.anthropic.claude-sonnet-4-6' }}" \
+            --model "${{ vars.EVAL_MODEL || 'anthropic/claude-sonnet-4-6' }}" \
             --temperature 0 \
             ${{ matrix.targs }}
 

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ run-outcome-evals:
 	for s in "$$@"; do \
 		ms=$$(printf '%s' "$$targets" | uv run python -c "import sys,json; print(next((t['max_sandboxes'] for t in json.load(sys.stdin) if t['path']==sys.argv[1]), 1))" "$$s"); \
 		echo "=== $$s (max-sandboxes $$ms) ==="; \
-		uv run inspect eval "$$s" --log-dir logs/ --max-sandboxes $$ms --model $(MODEL) --temperature $(TEMPERATURE) -T arm=$(ARM) -T agent=$(AGENT) $(ARGS) || exit $$?; \
+		uv run inspect eval "$$s" --log-dir logs/ --max-sandboxes $$ms --max-samples $$ms --model $(MODEL) --temperature $(TEMPERATURE) -T arm=$(ARM) -T agent=$(AGENT) $(ARGS) || exit $$?; \
 		uv run evals-extract-artifacts || exit $$?; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,11 @@ TARGET ?=
 #   make run-outcome-evals TARGET=scenarios/rocket-launch ARM=without_skill
 ARM ?= with_skill
 # Model + agent loop, passed to every `inspect eval`. The suite is
-# model-agnostic; MODEL is just the default and uses Bedrock (supply AWS creds
-# in the environment). Override per run for another provider, e.g.
-# MODEL=anthropic/claude-sonnet-4-6 with ANTHROPIC_API_KEY, or AGENT=claude_code.
-# CI uses the same default via the EVAL_MODEL repo variable — see
-# .github/workflows/eval.yml.
-MODEL ?= anthropic/bedrock/global.anthropic.claude-sonnet-4-6
+# model-agnostic; MODEL is just the default and runs on the Anthropic API
+# (set ANTHROPIC_API_KEY in the environment). EVAL_MODEL (env/CI) wins when set;
+# override per run for another provider or AGENT=claude_code. CI uses the same
+# default via the EVAL_MODEL repo variable — see .github/workflows/eval.yml.
+MODEL ?= $(if $(EVAL_MODEL),$(EVAL_MODEL),anthropic/claude-sonnet-4-6)
 AGENT ?= react
 # Arbitrary extra flags forwarded to `inspect eval`.
 # Example: make run-outcome-evals TARGET=scenarios/rocket-launch ARGS="--epochs 3"
@@ -59,7 +58,7 @@ help:
 	@echo "  SKILL     Skill name (e.g. camunda-feel). For run-trigger-evals."
 	@echo "  TARGET    Outcome eval dir path (skills/<name> or scenarios/<name>), for run-outcome-evals / regenerate-baseline."
 	@echo "  ARM       Comparison arm: with_skill (default) or without_skill."
-	@echo "  MODEL     Inspect model id (default anthropic/bedrock/global.anthropic.claude-sonnet-4-6; needs AWS creds)."
+	@echo "  MODEL     Inspect model id (default anthropic/claude-sonnet-4-6; needs ANTHROPIC_API_KEY)."
 	@echo "  AGENT       Agent loop: react (default) or claude_code."
 	@echo "  TEMPERATURE Temperature for inspect eval (default 0 — deterministic). Override with TEMPERATURE=1 for stochastic runs."
 	@echo "  ARGS        Extra flags forwarded to 'inspect eval' (run-trigger-evals / run-outcome-evals)."

--- a/evals/README.md
+++ b/evals/README.md
@@ -17,9 +17,9 @@ make run-outcome-evals TARGET=skills/camunda-feel      # behaviour: does the age
 make view-eval-logs                                   # trajectory viewer — http://localhost:7575
 ```
 
-The default model is `anthropic/bedrock/global.anthropic.claude-sonnet-4-6` (AWS
-creds in the environment); override with `MODEL=…` + that provider's creds. The
-uv project lives at the repo root, so `uv run …` works from anywhere without a `cd`.
+The default model is `anthropic/claude-sonnet-4-6` (`ANTHROPIC_API_KEY` in the
+environment); override with `MODEL=…` + that provider's creds. The uv project
+lives at the repo root, so `uv run …` works from anywhere without a `cd`.
 
 ## Layout
 

--- a/evals/docs/ci.md
+++ b/evals/docs/ci.md
@@ -33,7 +33,7 @@ the local loop see [`runbook.md`](runbook.md); for the model see
 **Gating is the label.** Only collaborators with triage or higher can label a
 PR, and `workflow_dispatch` requires write access — so there's no separate
 authorization job. Because the workflows use `pull_request` (not
-`pull_request_target`), a fork PR never receives the AWS secrets: model runs only
+`pull_request_target`), a fork PR never receives the model secret: model runs only
 happen on branches in this repo.
 
 ## Labels
@@ -140,20 +140,19 @@ prompts, modulo model non-determinism (`--epochs 3` to check flake).
 
 ## Credentials & secrets
 
-The model id is configuration. CI defaults to
-`anthropic/bedrock/global.anthropic.claude-sonnet-4-6` (Inspect's `anthropic`
-provider with the `bedrock/` qualifier), switchable in one place — the
-`EVAL_MODEL` repo variable. For the Bedrock default the workflows read:
+The model id is configuration. CI defaults to `anthropic/claude-sonnet-4-6`
+(Inspect's `anthropic` provider), switchable in one place — the `EVAL_MODEL` repo
+variable. The workflows read:
 
 | Kind | Name | Purpose |
 |---|---|---|
-| Secret | `AWS_ACCESS_KEY_ID` | model auth |
-| Secret | `AWS_SECRET_ACCESS_KEY` | model auth |
-| Variable | `AWS_DEFAULT_REGION` | region (default `us-east-1`) |
+| Secret | `ANTHROPIC_API_KEY` | model auth |
 | Variable | `EVAL_MODEL` | optional — overrides the CI model id |
 
-Set these under **Settings → Secrets and variables → Actions**. Point
-`EVAL_MODEL` at a non-AWS provider and swap the credential env in the run step.
+Set these under **Settings → Secrets and variables → Actions**. `ANTHROPIC_API_KEY`
+is read by Inspect on the runner; the sandbox bridge proxies model calls back to
+it, so the container carries no credential. Point `EVAL_MODEL` at another provider
+and swap the credential env in the run step.
 
 ## Cost controls
 

--- a/evals/docs/concepts.md
+++ b/evals/docs/concepts.md
@@ -44,7 +44,7 @@ Inspect's `react()` loop with `bash_session`, `text_editor`, `grep`,
 all 13 skills to the model. Cross-skill routing falls out of *which* skills the
 model chooses to load (a transcript signal), not from seeding files. The model
 is picked with Inspect's `--model` flag (default
-`anthropic/bedrock/global.anthropic.claude-sonnet-4-6`, set via the `EVAL_MODEL`
+`anthropic/claude-sonnet-4-6`, set via the `EVAL_MODEL`
 repo variable in CI). Two agent loops are selectable via `AGENT=` (`-T
 agent=`): `react` (the default, with the tools above) and `claude_code`, the
 `inspect_swe` Claude Code bridge. CI pins `react`; a full cross-harness matrix
@@ -124,17 +124,23 @@ If both arms pass equally, the skill may not be earning its keep. `without_skill
 is a *comparison, not a bar* — it's never gated. Triggers can't do this (you
 can't measure "the right skill loads" with it removed), so they run one arm only.
 
-## The cost baseline (tokens only)
+## The cost baseline (input+output tokens)
 
 Each outcome eval dir holds an `outcomes_baseline.json` recording, per arm, each
-passing sample's token count (plus turns and tool-calls):
+passing sample's token split (`input` / `cache_write` / `cache_read` / `output`)
+plus turns, tool-calls, and wall-clock duration:
 
 ```json
 {
-  "model": "anthropic/bedrock/global.anthropic.claude-sonnet-4-6",
+  "model": "anthropic/claude-sonnet-4-6",
   "with_skill": {
     "samples": {
-      "gateway-condition": { "tokens": 4200, "turns": 3, "tool_calls": 2 }
+      "gateway-condition": {
+        "tokens": { "input": 9, "cache_write": 0, "cache_read": 41000, "output": 620 },
+        "turns": 3,
+        "tool_calls": 2,
+        "duration_s": 18
+      }
     }
   }
 }
@@ -147,16 +153,20 @@ A few terms, plainly:
 - **Median** — the middle of those runs. The baseline stores the **median across
   epochs** so one weird outlier run doesn't set the number.
 - **The `× 1.5` ceiling** — a sample may spend up to **1.5× its recorded
-  tokens** before the gate flags it. Loose enough to absorb normal run-to-run
-  wobble, tight enough to catch a real blow-up. It's a coarse cost *tripwire*,
-  not a precise budget.
+  input+output tokens** before the gate flags it. Loose enough to absorb normal
+  run-to-run wobble, tight enough to catch a real blow-up. It's a coarse cost
+  *tripwire*, not a precise budget.
 
 What's gated and what isn't:
 
-- **Only `tokens` is gated.** `turns` and `tool_calls` are stored purely so the
-  summary can show a *delta* ("+20% tokens, +2 turns") and point at *why* a cost
-  moved — they're never a ceiling of their own (a second gate on noisy,
-  correlated counts would just flake).
+- **Only `input + output` is gated.** Cache-read is ~90% of the all-in total and
+  is the cheapest, most volatile category — gating the total would police cache
+  churn rather than the work the agent actually did. `cache_write`/`cache_read`
+  are recorded (and the summary flags a ≥10% swing) for diagnosis, never gated.
+- **`turns`, `tool_calls`, and `duration_s` are diagnostic too.** They're stored
+  purely so the summary can show a *delta* ("+20% I+O, +2 turns") and point at
+  *why* a cost moved — never a ceiling of their own (a second gate on noisy,
+  correlated counts would just flake; duration is runner-noisy).
 - **Outcome correctness is gated by the scorers, never the baseline.** The
   baseline is a cost ceiling, full stop.
 - **A baseline is all-green or nothing.** Regeneration writes one only from a

--- a/evals/docs/concepts.md
+++ b/evals/docs/concepts.md
@@ -163,6 +163,12 @@ What's gated and what isn't:
   is the cheapest, most volatile category — gating the total would police cache
   churn rather than the work the agent actually did. `cache_write`/`cache_read`
   are recorded (and the summary flags a ≥10% swing) for diagnosis, never gated.
+  They're also **timing-dependent across regenerations and indicative only**:
+  prompt caching shifts the static prefix between the write/read buckets
+  depending on whether an earlier epoch (run within the cache TTL) already warmed
+  it, so the committed split can move run-to-run even when nothing changed. The
+  gated I+O is unaffected — a cached prefix bills as `cache_*`, never as fresh
+  `input`, so `input` stays tiny whether the cache is warm or cold.
 - **`turns`, `tool_calls`, and `duration_s` are diagnostic too.** They're stored
   purely so the summary can show a *delta* ("+20% I+O, +2 turns") and point at
   *why* a cost moved — never a ceiling of their own (a second gate on noisy,

--- a/evals/docs/runbook.md
+++ b/evals/docs/runbook.md
@@ -35,11 +35,9 @@ builds via `docker buildx bake`; Buildx ships with Docker Desktop and modern
 docker-ce) and [uv](https://docs.astral.sh/uv/) — the harness auto-installs
 Python deps via `uv sync`. Triggers need neither Docker nor a cluster.
 
-**Credentials:** the default model is
-`anthropic/bedrock/global.anthropic.claude-sonnet-4-6` — supply AWS creds in the
-environment. For another provider pass `MODEL=…` plus that provider's creds (e.g.
-`MODEL=anthropic/claude-sonnet-4-6` with `ANTHROPIC_API_KEY`). Read creds from the
-environment; never write them to disk.
+**Credentials:** the default model is `anthropic/claude-sonnet-4-6` — supply
+`ANTHROPIC_API_KEY` in the environment. For another provider pass `MODEL=…` plus
+that provider's creds. Read creds from the environment; never write them to disk.
 
 ## The local loop
 

--- a/evals/scenarios/rocket-launch/outcomes_baseline.json
+++ b/evals/scenarios/rocket-launch/outcomes_baseline.json
@@ -4,14 +4,14 @@
     "samples": {
       "timer-countdown": {
         "tokens": {
-          "input": 25,
-          "cache_write": 22179,
-          "cache_read": 598876,
-          "output": 7455
+          "input": 16,
+          "cache_write": 19496,
+          "cache_read": 313206,
+          "output": 4854
         },
-        "turns": 23,
-        "tool_calls": 25,
-        "duration_s": 208
+        "turns": 14,
+        "tool_calls": 16,
+        "duration_s": 153
       }
     }
   }

--- a/evals/scenarios/rocket-launch/outcomes_baseline.json
+++ b/evals/scenarios/rocket-launch/outcomes_baseline.json
@@ -1,11 +1,17 @@
 {
-  "model": "anthropic/bedrock/global.anthropic.claude-sonnet-4-6",
+  "model": "anthropic/claude-sonnet-4-6",
   "with_skill": {
     "samples": {
       "timer-countdown": {
-        "tokens": 465076,
-        "turns": 21,
-        "tool_calls": 22
+        "tokens": {
+          "input": 25,
+          "cache_write": 22179,
+          "cache_read": 598876,
+          "output": 7455
+        },
+        "turns": 23,
+        "tool_calls": 25,
+        "duration_s": 208
       }
     }
   }

--- a/evals/skills/camunda-bpmn/outcomes_baseline.json
+++ b/evals/skills/camunda-bpmn/outcomes_baseline.json
@@ -1,16 +1,28 @@
 {
-  "model": "anthropic/bedrock/global.anthropic.claude-sonnet-4-6",
+  "model": "anthropic/claude-sonnet-4-6",
   "with_skill": {
     "samples": {
       "exclusive-gateway-routing": {
-        "tokens": 67246,
+        "tokens": {
+          "input": 7,
+          "cache_write": 8081,
+          "cache_read": 66007,
+          "output": 4548
+        },
         "turns": 5,
-        "tool_calls": 5
+        "tool_calls": 5,
+        "duration_s": 101
       },
       "linear-invoice-review": {
-        "tokens": 77856,
-        "turns": 6,
-        "tool_calls": 6
+        "tokens": {
+          "input": 7,
+          "cache_write": 1754,
+          "cache_read": 69650,
+          "output": 2295
+        },
+        "turns": 5,
+        "tool_calls": 5,
+        "duration_s": 74
       }
     }
   }

--- a/evals/skills/camunda-bpmn/outcomes_baseline.json
+++ b/evals/skills/camunda-bpmn/outcomes_baseline.json
@@ -5,24 +5,24 @@
       "exclusive-gateway-routing": {
         "tokens": {
           "input": 7,
-          "cache_write": 8081,
-          "cache_read": 66007,
-          "output": 4548
+          "cache_write": 8105,
+          "cache_read": 65917,
+          "output": 4470
         },
         "turns": 5,
         "tool_calls": 5,
-        "duration_s": 101
+        "duration_s": 98
       },
       "linear-invoice-review": {
         "tokens": {
           "input": 7,
-          "cache_write": 1754,
-          "cache_read": 69650,
-          "output": 2295
+          "cache_write": 5995,
+          "cache_read": 63754,
+          "output": 2315
         },
         "turns": 5,
         "tool_calls": 5,
-        "duration_s": 74
+        "duration_s": 78
       }
     }
   }

--- a/evals/skills/camunda-c8ctl/outcomes_baseline.json
+++ b/evals/skills/camunda-c8ctl/outcomes_baseline.json
@@ -5,35 +5,35 @@
       "get-topology": {
         "tokens": {
           "input": 8,
-          "cache_write": 760,
-          "cache_read": 65501,
-          "output": 812
+          "cache_write": 900,
+          "cache_read": 68751,
+          "output": 953
         },
         "turns": 6,
         "tool_calls": 5,
-        "duration_s": 47
+        "duration_s": 49
       },
       "install-cli": {
         "tokens": {
-          "input": 13,
-          "cache_write": 2837,
-          "cache_read": 122490,
-          "output": 1830
+          "input": 11,
+          "cache_write": 1572,
+          "cache_read": 107370,
+          "output": 1432
         },
-        "turns": 10,
+        "turns": 9,
         "tool_calls": 8,
         "duration_s": 86
       },
       "list-users": {
         "tokens": {
           "input": 8,
-          "cache_write": 495,
-          "cache_read": 64901,
-          "output": 735
+          "cache_write": 502,
+          "cache_read": 68680,
+          "output": 693
         },
         "turns": 6,
         "tool_calls": 5,
-        "duration_s": 46
+        "duration_s": 45
       }
     }
   }

--- a/evals/skills/camunda-c8ctl/outcomes_baseline.json
+++ b/evals/skills/camunda-c8ctl/outcomes_baseline.json
@@ -1,21 +1,39 @@
 {
-  "model": "anthropic/bedrock/global.anthropic.claude-sonnet-4-6",
+  "model": "anthropic/claude-sonnet-4-6",
   "with_skill": {
     "samples": {
       "get-topology": {
-        "tokens": 57155,
+        "tokens": {
+          "input": 8,
+          "cache_write": 760,
+          "cache_read": 65501,
+          "output": 812
+        },
         "turns": 6,
-        "tool_calls": 5
+        "tool_calls": 5,
+        "duration_s": 47
       },
       "install-cli": {
-        "tokens": 90110,
-        "turns": 9,
-        "tool_calls": 8
+        "tokens": {
+          "input": 13,
+          "cache_write": 2837,
+          "cache_read": 122490,
+          "output": 1830
+        },
+        "turns": 10,
+        "tool_calls": 8,
+        "duration_s": 86
       },
       "list-users": {
-        "tokens": 56652,
+        "tokens": {
+          "input": 8,
+          "cache_write": 495,
+          "cache_read": 64901,
+          "output": 735
+        },
         "turns": 6,
-        "tool_calls": 5
+        "tool_calls": 5,
+        "duration_s": 46
       }
     }
   }

--- a/evals/skills/camunda-development/outcomes.py
+++ b/evals/skills/camunda-development/outcomes.py
@@ -31,7 +31,7 @@ METADATA = EvalMetadata(
         "camunda-ai-agents",
     ],
     without_skill_excludes="all",
-    max_sandboxes=10,  # judge-only, no cluster — run all samples concurrently
+    max_sandboxes=15,  # judge-only, no cluster — run samples concurrently
 )
 
 # Strict pass/fail (no partial credit) — routing has one right answer.

--- a/evals/skills/camunda-development/outcomes_baseline.json
+++ b/evals/skills/camunda-development/outcomes_baseline.json
@@ -5,53 +5,53 @@
       "ai-agent-ticket-triage": {
         "tokens": {
           "input": 7,
-          "cache_write": 9368,
+          "cache_write": 9239,
           "cache_read": 27108,
-          "output": 2387
+          "output": 2244
         },
         "turns": 3,
         "tool_calls": 2,
-        "duration_s": 67
+        "duration_s": 62
       },
       "custom-inbound-webhook": {
         "tokens": {
           "input": 8,
-          "cache_write": 11465,
+          "cache_write": 11617,
           "cache_read": 41034,
-          "output": 2032
+          "output": 2158
         },
         "turns": 4,
         "tool_calls": 3,
-        "duration_s": 67
+        "duration_s": 69
       },
       "public-rest-api": {
         "tokens": {
           "input": 7,
-          "cache_write": 7750,
+          "cache_write": 7847,
           "cache_read": 27066,
-          "output": 1175
+          "output": 1366
         },
         "turns": 3,
         "tool_calls": 2,
-        "duration_s": 38
+        "duration_s": 44
       },
       "reusable-internal-api": {
         "tokens": {
           "input": 7,
-          "cache_write": 7976,
+          "cache_write": 8033,
           "cache_read": 27114,
-          "output": 2050
+          "output": 2097
         },
         "turns": 3,
         "tool_calls": 2,
-        "duration_s": 61
+        "duration_s": 64
       },
       "slack-notification": {
         "tokens": {
           "input": 7,
-          "cache_write": 7790,
+          "cache_write": 7779,
           "cache_read": 27070,
-          "output": 1237
+          "output": 1217
         },
         "turns": 3,
         "tool_calls": 2,
@@ -60,24 +60,24 @@
       "spring-embedded-throughput": {
         "tokens": {
           "input": 8,
-          "cache_write": 12260,
+          "cache_write": 12307,
           "cache_read": 40521,
-          "output": 2312
+          "output": 2361
         },
         "turns": 4,
         "tool_calls": 4,
-        "duration_s": 74
+        "duration_s": 75
       },
       "ts-node-stack": {
         "tokens": {
           "input": 8,
-          "cache_write": 9434,
+          "cache_write": 9390,
           "cache_read": 40455,
-          "output": 2179
+          "output": 2110
         },
         "turns": 4,
         "tool_calls": 3,
-        "duration_s": 69
+        "duration_s": 70
       }
     }
   }

--- a/evals/skills/camunda-development/outcomes_baseline.json
+++ b/evals/skills/camunda-development/outcomes_baseline.json
@@ -1,41 +1,83 @@
 {
-  "model": "anthropic/bedrock/global.anthropic.claude-sonnet-4-6",
+  "model": "anthropic/claude-sonnet-4-6",
   "with_skill": {
     "samples": {
       "ai-agent-ticket-triage": {
-        "tokens": 31777,
+        "tokens": {
+          "input": 7,
+          "cache_write": 9368,
+          "cache_read": 27108,
+          "output": 2387
+        },
         "turns": 3,
-        "tool_calls": 2
+        "tool_calls": 2,
+        "duration_s": 67
       },
       "custom-inbound-webhook": {
-        "tokens": 29634,
-        "turns": 3,
-        "tool_calls": 2
+        "tokens": {
+          "input": 8,
+          "cache_write": 11465,
+          "cache_read": 41034,
+          "output": 2032
+        },
+        "turns": 4,
+        "tool_calls": 3,
+        "duration_s": 67
       },
       "public-rest-api": {
-        "tokens": 16749,
-        "turns": 2,
-        "tool_calls": 1
+        "tokens": {
+          "input": 7,
+          "cache_write": 7750,
+          "cache_read": 27066,
+          "output": 1175
+        },
+        "turns": 3,
+        "tool_calls": 2,
+        "duration_s": 38
       },
       "reusable-internal-api": {
-        "tokens": 30295,
+        "tokens": {
+          "input": 7,
+          "cache_write": 7976,
+          "cache_read": 27114,
+          "output": 2050
+        },
         "turns": 3,
-        "tool_calls": 2
+        "tool_calls": 2,
+        "duration_s": 61
       },
       "slack-notification": {
-        "tokens": 29735,
+        "tokens": {
+          "input": 7,
+          "cache_write": 7790,
+          "cache_read": 27070,
+          "output": 1237
+        },
         "turns": 3,
-        "tool_calls": 2
+        "tool_calls": 2,
+        "duration_s": 41
       },
       "spring-embedded-throughput": {
-        "tokens": 46092,
+        "tokens": {
+          "input": 8,
+          "cache_write": 12260,
+          "cache_read": 40521,
+          "output": 2312
+        },
         "turns": 4,
-        "tool_calls": 4
+        "tool_calls": 4,
+        "duration_s": 74
       },
       "ts-node-stack": {
-        "tokens": 42977,
+        "tokens": {
+          "input": 8,
+          "cache_write": 9434,
+          "cache_read": 40455,
+          "output": 2179
+        },
         "turns": 4,
-        "tool_calls": 3
+        "tool_calls": 3,
+        "duration_s": 69
       }
     }
   }

--- a/evals/skills/camunda-feel/outcomes_baseline.json
+++ b/evals/skills/camunda-feel/outcomes_baseline.json
@@ -1,21 +1,39 @@
 {
-  "model": "anthropic/bedrock/global.anthropic.claude-sonnet-4-6",
+  "model": "anthropic/claude-sonnet-4-6",
   "with_skill": {
     "samples": {
       "bool-guard": {
-        "tokens": 23536,
+        "tokens": {
+          "input": 5,
+          "cache_write": 160,
+          "cache_read": 29691,
+          "output": 310
+        },
         "turns": 3,
-        "tool_calls": 2
+        "tool_calls": 2,
+        "duration_s": 27
       },
       "list-sum": {
-        "tokens": 32585,
-        "turns": 4,
-        "tool_calls": 3
+        "tokens": {
+          "input": 7,
+          "cache_write": 505,
+          "cache_read": 51524,
+          "output": 624
+        },
+        "turns": 5,
+        "tool_calls": 4,
+        "duration_s": 41
       },
       "string-greeting": {
-        "tokens": 32422,
+        "tokens": {
+          "input": 6,
+          "cache_write": 499,
+          "cache_read": 40703,
+          "output": 500
+        },
         "turns": 4,
-        "tool_calls": 3
+        "tool_calls": 4,
+        "duration_s": 38
       }
     }
   }

--- a/evals/skills/camunda-feel/outcomes_baseline.json
+++ b/evals/skills/camunda-feel/outcomes_baseline.json
@@ -5,8 +5,8 @@
       "bool-guard": {
         "tokens": {
           "input": 5,
-          "cache_write": 160,
-          "cache_read": 29691,
+          "cache_write": 2449,
+          "cache_read": 27474,
           "output": 310
         },
         "turns": 3,
@@ -16,20 +16,20 @@
       "list-sum": {
         "tokens": {
           "input": 7,
-          "cache_write": 505,
-          "cache_read": 51524,
-          "output": 624
+          "cache_write": 506,
+          "cache_read": 51512,
+          "output": 647
         },
         "turns": 5,
         "tool_calls": 4,
-        "duration_s": 41
+        "duration_s": 42
       },
       "string-greeting": {
         "tokens": {
           "input": 6,
-          "cache_write": 499,
-          "cache_read": 40703,
-          "output": 500
+          "cache_write": 484,
+          "cache_read": 40709,
+          "output": 514
         },
         "turns": 4,
         "tool_calls": 4,

--- a/evals/src/core/metrics.py
+++ b/evals/src/core/metrics.py
@@ -1,8 +1,9 @@
-"""Shared metric helpers for reading Inspect eval logs.
+"""Shared helpers for reading Inspect eval logs.
 
-Used by ``scripts.regenerate_baseline`` to write the outcomes_baseline.json and by
-``scripts.pass_fail`` to gate against it. Kept domain-agnostic — no
-scenario-specific shaping lives here.
+Used by ``scripts.pass_fail`` (per-sample outcome + cost gate),
+``scripts.regenerate_baseline`` (writes ``outcomes_baseline.json``), and
+``scripts.summarize`` (the PR-comment / job-summary render). Domain-agnostic:
+no scenario-specific shaping lives here.
 """
 
 from __future__ import annotations
@@ -14,21 +15,21 @@ from inspect_ai.scorer import value_to_float
 
 from core.paths import SCENARIO_EVALS_DIR, SKILL_EVALS_DIR
 
-# Inspect's own Value→float conversion: letter grades C/P/I map to
-# 1.0/0.5/0.0, numbers pass through, and bool / "true" / "false" /
-# numeric strings are handled too. Using the framework helper keeps us
-# aligned with how ``accuracy()`` scores the same values, instead of
-# hand-rolling a letter map.
+# Inspect's own Value→float conversion: letter grades C/P/I map to 1.0/0.5/0.0,
+# numbers pass through, bool / "true" / "false" / numeric strings too. Using the
+# framework helper keeps us aligned with how ``accuracy()`` scores the same
+# values, instead of hand-rolling a letter map.
 score_to_float = value_to_float()
 
 
 def is_gating(score) -> bool:
     """Whether a Score contributes to the gating decision.
 
-    A scorer can mark its Scores non-gating by setting
-    ``metadata["gating"] = False`` (e.g. ``assert_skill_loaded`` in its
-    diagnostic mode) — those are surfaced for visibility but excluded
-    from gating decisions. Scores without the tag default to gating.
+    A scorer marks its Scores non-gating with ``metadata["gating"] = False``
+    (e.g. ``assert_skill_loaded`` in diagnostic mode) — those are surfaced for
+    visibility but excluded from the gate. Scores without the tag default to
+    gating. NB: built-in scorers (e.g. ``model_graded_qa``) can't carry the tag,
+    so they default to gating — intended.
     """
     meta = getattr(score, "metadata", None) or {}
     return meta.get("gating", True) is not False
@@ -38,10 +39,9 @@ def gating_by_scorer(log) -> dict[str, bool]:
     """Whether each scorer gates, keyed by scorer name.
 
     Read from raw ``log.samples`` (where every Score keeps its ``metadata``)
-    rather than from the reductions: a reducer may drop per-score metadata when
-    the epoch values differ, which would silently flip a diagnostic scorer like
-    ``assert_skill_loaded`` back to gating. A scorer's gating flag is constant
-    across samples, so the first occurrence wins.
+    rather than the reductions: a reducer may drop per-score metadata when epoch
+    values differ, silently flipping a diagnostic scorer back to gating. A
+    scorer's gating flag is constant across samples, so the first occurrence wins.
     """
     result: dict[str, bool] = {}
     for sample in getattr(log, "samples", None) or []:
@@ -56,10 +56,9 @@ def reduced_scores(log) -> dict[str, dict[str, float]]:
 
     Reads ``log.reductions`` (one entry per scorer × reducer, each holding the
     epoch-reduced score per sample id) instead of raw ``log.samples`` (one row
-    per id×epoch). At epochs=1 the reduction is the identity, so this is correct
-    for single- and multi-epoch runs alike. When several reducers are
-    configured, ``mean`` wins. Falls back to raw scores if a log predates
-    reductions.
+    per id×epoch). At epochs=1 the reduction is the identity. When several
+    reducers are configured, ``mean`` wins. Falls back to raw scores if a log
+    predates reductions.
     """
     by_scorer: dict[str, object] = {}
     for red in getattr(log, "reductions", None) or []:
@@ -97,11 +96,9 @@ def _usage_field(sample, field: str) -> float:
 
 
 def sample_tokens(sample) -> float:
-    """Total tokens consumed by a single sample across all models.
-
-    ``total_tokens`` is the all-in figure (input + output + cache read/write);
-    it's what the cost baseline gates on, so usage reporting uses it too.
-    """
+    """Total tokens consumed by a sample across all models — the all-in figure
+    (input + output + cache read/write). Shown for context; the cost gate keys
+    on input+output (see ``reduced_metrics``)."""
     return _usage_field(sample, "total_tokens")
 
 
@@ -117,23 +114,57 @@ def sample_tool_calls(sample) -> int:
     return sum(len(getattr(m, "tool_calls", None) or []) for m in msgs)
 
 
-# Per-sample signals reduced into the baseline. ``tokens`` gates the cost
-# ceiling; ``turns`` and ``tool_calls`` are diagnostic — stored so the summary
-# can show a delta ("+20% tokens, +2 turns"), never gated.
-REDUCED_FIELDS = ("tokens", "turns", "tool_calls")
+def sample_duration_s(sample) -> float:
+    """Per-sample wall time in seconds."""
+    return float(getattr(sample, "total_time", 0) or 0)
+
+
+# Token categories in display order; their sum is the all-in total, which prompt
+# caching makes far larger than fresh input + output. ``input``/``output`` feed
+# the cost gate (the work the agent actually did); ``cache_write``/``cache_read``
+# are recorded for diagnosis only — cache-read dominates the total and is the
+# cheapest category, so gating the total effectively gates cache churn.
+USAGE_FIELDS = ("input", "cache_write", "cache_read", "output")
+_USAGE_SOURCE = {
+    "input": "input_tokens",
+    "cache_write": "input_tokens_cache_write",
+    "cache_read": "input_tokens_cache_read",
+    "output": "output_tokens",
+}
+
+
+def token_usage(log) -> dict[str, float]:
+    """Per-category token totals across all samples (the keys in USAGE_FIELDS)."""
+    samples = getattr(log, "samples", None) or []
+    return {
+        f: sum(_usage_field(s, _USAGE_SOURCE[f]) for s in samples) for f in USAGE_FIELDS
+    }
+
+
+# Per-sample signals reduced into the baseline. The four ``USAGE_FIELDS`` carry
+# the I/CW/CR/O split (the gate keys on input+output); ``tokens`` is the all-in
+# total, and ``turns``/``tool_calls``/``duration_s`` are diagnostic — stored so
+# the summary can show a delta, never gated.
+REDUCED_FIELDS = (*USAGE_FIELDS, "tokens", "turns", "tool_calls", "duration_s")
 
 
 def reduced_metrics(log) -> dict[str, dict[str, float]]:
-    """Per-sample-id ``{tokens, turns, tool_calls}``, each the median across
-    epochs. These live on the raw samples (the reduced score carries no usage),
-    so we group ``log.samples`` by id and median each — robust to a single
-    runaway rollout, and the per-id granularity the cost gate and baseline use.
-    At epochs=1 it's just the sample's own values.
+    """Per-sample-id ``{REDUCED_FIELDS}``, each the median across epochs.
+
+    These live on the raw samples (the reduced score carries no usage), so we
+    group ``log.samples`` by id and median each — robust to a single runaway
+    rollout, and the per-id granularity the cost gate and baseline use. At
+    epochs=1 it's just the sample's own values.
     """
     getters = {
+        "input": lambda s: _usage_field(s, "input_tokens"),
+        "cache_write": lambda s: _usage_field(s, "input_tokens_cache_write"),
+        "cache_read": lambda s: _usage_field(s, "input_tokens_cache_read"),
+        "output": lambda s: _usage_field(s, "output_tokens"),
         "tokens": sample_tokens,
         "turns": sample_turns,
         "tool_calls": sample_tool_calls,
+        "duration_s": sample_duration_s,
     }
     by_id: dict[str, dict[str, list[float]]] = {}
     for sample in getattr(log, "samples", None) or []:
@@ -146,45 +177,20 @@ def reduced_metrics(log) -> dict[str, dict[str, float]]:
     }
 
 
-# Token categories in the order we display them; their sum is the all-in
-# total, which prompt caching makes far larger than fresh input + output.
-USAGE_FIELDS = (
-    "input_tokens",
-    "input_tokens_cache_write",
-    "input_tokens_cache_read",
-    "output_tokens",
-)
-
-
-def token_usage(log) -> dict[str, float]:
-    """Per-category token totals across all samples (the keys in USAGE_FIELDS)."""
-    samples = getattr(log, "samples", None) or []
-    return {f: sum(_usage_field(s, f) for s in samples) for f in USAGE_FIELDS}
-
-
 def model_id(log) -> str | None:
     """The model id the eval ran against (from the log's eval header)."""
     eval_meta = getattr(log, "eval", None)
     return getattr(eval_meta, "model", None) if eval_meta else None
 
 
-def sample_duration_s(sample) -> float:
-    """Per-sample wall time in seconds."""
-    return float(getattr(sample, "total_time", 0) or 0)
-
-
-def duration_s(log) -> float:
-    """Mean per-sample wall time (seconds).
-
-    Inspect tracks duration per sample, not on the log-level stats
-    object. With ``max_samples=1`` this is just the run's wall time;
-    with parallel samples it's the average — note that the arm-level
-    wall clock is bounded by the SLOWEST sample, not the sum.
-    """
-    samples = getattr(log, "samples", None) or []
-    if not samples:
-        return 0.0
-    return sum(sample_duration_s(s) for s in samples) / len(samples)
+def eval_name(log) -> str | None:
+    """The eval's display name: the log's task name, kebab-cased
+    (Inspect task names are snake_case; on-disk dirs are kebab-case)."""
+    eval_meta = getattr(log, "eval", None)
+    if eval_meta is None:
+        return None
+    task = getattr(eval_meta, "task", None)
+    return task.replace("_", "-") if task else None
 
 
 def task_arg(log, name: str, default: str | None = None) -> str | None:
@@ -194,20 +200,6 @@ def task_arg(log, name: str, default: str | None = None) -> str | None:
         return default
     args = getattr(eval_meta, "task_args", None) or {}
     return args.get(name, default)
-
-
-def eval_name(log) -> str | None:
-    """The eval's display name: the log's task name, kebab-cased.
-
-    Inspect task names are snake_case (``camunda_feel``); the on-disk
-    directory is kebab-case (``camunda-feel``). Returns ``None`` if the
-    log lacks a task name.
-    """
-    eval_meta = getattr(log, "eval", None)
-    if eval_meta is None:
-        return None
-    task = getattr(eval_meta, "task", None)
-    return task.replace("_", "-") if task else None
 
 
 def baseline_dir(name: str | None) -> Path | None:

--- a/evals/src/scripts/build_matrix.py
+++ b/evals/src/scripts/build_matrix.py
@@ -30,8 +30,11 @@ def build_specs(targets: list[EvalTarget], compare: bool) -> list[dict]:
 
     Triggers are sandbox-free single-shot routing calls (samples run in
     parallel). Outcome evals run one sandbox per sample (= a Camunda cluster),
-    so concurrency is capped from the target's ``max_sandboxes``, and they run
-    ``with_skill`` plus ``without_skill`` when ``compare``.
+    so concurrency is capped from the target's ``max_sandboxes`` — passed as both
+    ``--max-sandboxes`` AND ``--max-samples`` (Inspect's ``max_samples`` defaults
+    to 1, so without the latter samples run serially however many sandboxes are
+    allowed; cluster targets keep this at 1, judge-only targets parallelize).
+    They run ``with_skill`` plus ``without_skill`` when ``compare``.
     """
     specs: list[dict] = []
     for t in targets:
@@ -61,7 +64,7 @@ def build_specs(targets: list[EvalTarget], compare: bool) -> list[dict]:
                     "targs": f"-T agent=react -T arm={arm} {base_targs}".strip(),
                     "arm": arm,
                     "sandbox": True,
-                    "limit": f"--max-sandboxes {t.max_sandboxes}",
+                    "limit": f"--max-sandboxes {t.max_sandboxes} --max-samples {t.max_sandboxes}",
                     "display": "conversation",
                 }
             )

--- a/evals/src/scripts/pass_fail.py
+++ b/evals/src/scripts/pass_fail.py
@@ -5,7 +5,11 @@ existing comparison):
 
 1. **Outcome** — every gating scorer on a sample must score ≥ ``--threshold``
    (default 1.0). The "works / doesn't work anymore" signal. Diagnostic
-   scorers (``metadata.gating == False``) are shown but don't gate.
+   scorers (``metadata.gating == False``) are shown but don't gate. A sample
+   that ran but never scored (errored / aborted), or a run with no scored
+   samples at all, fails too — the gate sees only scored samples, so an
+   all-errored run must not pass by omission (mirrors the all-green guard in
+   ``regenerate_baseline``).
 2. **Cost** — only when an ``outcomes_baseline.json`` exists for the eval AND
    the sample passed outcome: observed **input + output** tokens must be ≤
    ``baseline.<arm>.samples.<id>`` (input + output) ``× 1.5`` (upper ceiling
@@ -227,6 +231,16 @@ def main() -> None:
     arm = task_arg(log, "arm")
     rows, outcome_passed = _outcome_rows(log, args.threshold)
 
+    # A sample that ran but never scored (errored / aborted), or a run with no
+    # scored samples at all, is a failure — not a pass by omission. The outcome
+    # gate above only sees scored samples, so catch the gap here against the ids
+    # that actually ran. ``s.id`` repeats across epochs; the set dedupes it, so
+    # this is epoch-safe (same comparison regenerate_baseline uses).
+    scored_ids = {r["sample_id"] for r in rows}
+    ran_ids = {str(s.id) for s in (getattr(log, "samples", None) or [])}
+    unscored = sorted(ran_ids - scored_ids)
+    run_complete = bool(rows) and not unscored
+
     cost_checks: list[dict] = []
     cost_passed = True
     cost_skipped: str | None = None
@@ -237,7 +251,7 @@ def main() -> None:
             if cost_skipped is None:
                 cost_checks, cost_passed = _cost_checks(rows, baseline, arm)
 
-    overall = outcome_passed and cost_passed
+    overall = outcome_passed and cost_passed and run_complete
     if args.json:
         print(
             json.dumps(
@@ -246,6 +260,7 @@ def main() -> None:
                     "arm": arm,
                     "threshold": args.threshold,
                     "samples": rows,
+                    "unscored": unscored,
                     "cost_checks": cost_checks,
                     "cost_gate_skipped": cost_skipped,
                     "pass": overall,
@@ -256,6 +271,13 @@ def main() -> None:
         )
     else:
         print(_render(rows, cost_checks, name, arm, args.threshold))
+        if not rows:
+            print("\n[FAIL] no samples scored")
+        elif unscored:
+            print(
+                f"\n[FAIL] {len(unscored)} sample(s) ran but never scored "
+                f"(errored/aborted): {', '.join(unscored)}"
+            )
         if cost_skipped:
             print(f"\n[warn] {cost_skipped}")
     sys.exit(0 if overall else 1)

--- a/evals/src/scripts/pass_fail.py
+++ b/evals/src/scripts/pass_fail.py
@@ -6,12 +6,16 @@ existing comparison):
 1. **Outcome** — every gating scorer on a sample must score ≥ ``--threshold``
    (default 1.0). The "works / doesn't work anymore" signal. Diagnostic
    scorers (``metadata.gating == False``) are shown but don't gate.
-2. **Cost** — only when an ``outcomes_baseline.json`` exists for the eval AND the sample
-   passed outcome: observed tokens must be ≤ ``baseline.<arm>.samples.<id>.tokens
-   × 1.5`` (upper ceiling only). The "still works but costs ~2× now" signal.
-   A sample with no baseline entry is reported, not gated. The whole cost stage
-   is skipped (with a warning) when the run's model differs from the baseline's
-   — token ceilings are model-specific, so cross-model gating is invalid.
+2. **Cost** — only when an ``outcomes_baseline.json`` exists for the eval AND
+   the sample passed outcome: observed **input + output** tokens must be ≤
+   ``baseline.<arm>.samples.<id>`` (input + output) ``× 1.5`` (upper ceiling
+   only). The "still works but costs ~2× now" signal. We gate input+output, not
+   the all-in total: the total is ~90% cache-read — the cheapest, most volatile
+   category — so a total-token ceiling polices cache churn while letting real
+   output growth through. Cache-read/-write are recorded (in the baseline and
+   the summary) for diagnosis, not gated. A sample with no baseline entry is
+   reported, not gated. The whole cost stage is skipped (with a warning) when
+   the run's model differs from the baseline's — ceilings are model-specific.
 
 Exit 0 on full pass, 1 otherwise. Wire as the CI gate after a run.
 
@@ -28,12 +32,13 @@ from pathlib import Path
 from inspect_ai.log import list_eval_logs, read_eval_log
 
 from core.metrics import (
+    REDUCED_FIELDS,
     baseline_dir,
+    eval_name,
     gating_by_scorer,
     model_id,
     reduced_metrics,
     reduced_scores,
-    eval_name,
     task_arg,
 )
 from core.paths import EVALS_ROOT
@@ -54,14 +59,34 @@ def _resolve_log_path(arg: str | None) -> str:
     return max(logs, key=lambda li: li.name).name
 
 
+def _io(d: dict) -> float | None:
+    """input + output (the gated quantity) from a flat metrics dict — a
+    ``reduced_metrics`` row, whose token categories sit at the top level. None
+    when either component is missing."""
+    i, o = d.get("input"), d.get("output")
+    if isinstance(i, (int, float)) and isinstance(o, (int, float)):
+        return float(i) + float(o)
+    return None
+
+
+def _baseline_io(entry: dict) -> float | None:
+    """input + output from a committed baseline entry, whose token categories are
+    nested under ``tokens`` (``{input, cache_write, cache_read, output}``). None
+    when the entry predates the nested schema or is partial."""
+    if not isinstance(entry, dict):
+        return None
+    tokens = entry.get("tokens")
+    return _io(tokens) if isinstance(tokens, dict) else None
+
+
 def _outcome_rows(log, threshold: float) -> tuple[list[dict], bool]:
     """Per-sample scorer breakdown + overall outcome-pass bit.
 
     One row per distinct sample id, reading epoch-reduced scores
-    (``reduced_scores``) and cost/effort signals (``reduced_metrics``) — so a multi-epoch run
-    yields one verdict per sample, not one per id×epoch. With a ``mean`` reducer
-    and the default threshold 1.0, a sample must pass *every* epoch to be green;
-    a flaky 2/3 reduces to 0.67 and fails.
+    (``reduced_scores``) and cost/effort signals (``reduced_metrics``) — so a
+    multi-epoch run yields one verdict per sample, not one per id×epoch. With a
+    ``mean`` reducer and the default threshold 1.0, a sample must pass *every*
+    epoch to be green; a flaky 2/3 reduces to 0.67 and fails.
     """
     gating = gating_by_scorer(log)
     metrics = reduced_metrics(log)
@@ -78,10 +103,9 @@ def _outcome_rows(log, threshold: float) -> tuple[list[dict], bool]:
                 "sample_id": sample_id,
                 "scorers": values,
                 "diagnostic": sorted(diagnostic),
-                # tokens gates the cost ceiling; turns/tool_calls are diagnostic.
-                "tokens": m.get("tokens", 0.0),
-                "turns": m.get("turns", 0.0),
-                "tool_calls": m.get("tool_calls", 0.0),
+                # input/output gate the cost ceiling; cache_*/tokens/turns/
+                # tool_calls/duration_s are diagnostic (see REDUCED_FIELDS).
+                **{f: m.get(f, 0.0) for f in REDUCED_FIELDS},
                 "pass": ok,
             }
         )
@@ -104,12 +128,11 @@ def _load_baseline(name: str | None) -> dict | None:
 def _model_mismatch(log, baseline: dict) -> str | None:
     """A reason string when the run's model differs from the baseline's, else None.
 
-    Token ceilings are model-specific (see concepts), so gating a run against a
-    baseline recorded on a different model is invalid — it false-fails on a
-    pricier model and false-passes on a cheaper one. When both models are known
-    and differ, the caller skips the cost gate. ``"unknown"`` on either side
-    (an older baseline, a log without a model) is treated as no-info, not a
-    mismatch — gate as before.
+    Token ceilings are model-specific, so gating a run against a baseline
+    recorded on a different model is invalid — it false-fails on a pricier model
+    and false-passes on a cheaper one. When both models are known and differ, the
+    caller skips the cost gate. ``"unknown"`` on either side (an older baseline,
+    a log without a model) is treated as no-info, not a mismatch — gate as before.
     """
     run = model_id(log)
     base = baseline.get("model")
@@ -121,7 +144,7 @@ def _model_mismatch(log, baseline: dict) -> str | None:
 def _cost_checks(
     rows: list[dict], baseline: dict, arm: str | None
 ) -> tuple[list[dict], bool]:
-    """Per-sample token ceiling for samples that passed outcome."""
+    """Per-sample input+output ceiling for samples that passed outcome."""
     arm_block = baseline.get(arm or "with_skill") or {}
     sample_baselines = arm_block.get("samples") or {}
     checks: list[dict] = []
@@ -130,8 +153,8 @@ def _cost_checks(
         if not row["pass"]:
             continue
         entry = sample_baselines.get(row["sample_id"])
-        tokens = entry.get("tokens") if isinstance(entry, dict) else None
-        if not isinstance(tokens, (int, float)):
+        base_io = _baseline_io(entry)
+        if base_io is None:
             checks.append(
                 {
                     "sample_id": row["sample_id"],
@@ -140,16 +163,19 @@ def _cost_checks(
                 }
             )
             continue
-        ceiling = tokens * CEILING_MULTIPLIER
-        ok = row["tokens"] <= ceiling
+        obs_io = _io(row) or 0.0
+        ceiling = base_io * CEILING_MULTIPLIER
+        ok = obs_io <= ceiling
         all_passed = all_passed and ok
         checks.append(
             {
                 "sample_id": row["sample_id"],
                 "pass": ok,
-                "tokens": round(row["tokens"]),
-                "baseline": tokens,
+                "io": round(obs_io),
+                "baseline": round(base_io),
                 "ceiling": round(ceiling),
+                # total tokens carried for the summary's headline; not gated.
+                "tokens": round(row.get("tokens", 0.0)),
             }
         )
     return checks, all_passed
@@ -161,21 +187,27 @@ def _render(rows, cost_checks, name, arm, threshold) -> str:
         "",
     ]
     for r in rows:
-        scs = " ".join(f"{n}={v:.2f}" for n, v in sorted(r["scorers"].items()))
+        scs = " ".join(
+            f"{n}={v:.2f}{'*' if n in r['diagnostic'] else ''}"
+            for n, v in sorted(r["scorers"].items())
+        )
         lines.append(f"  [{'PASS' if r['pass'] else 'FAIL'}] {r['sample_id']}: {scs}")
     passed = sum(1 for r in rows if r["pass"])
     lines.append(
-        f"\noutcome: {passed}/{len(rows)} sample(s) passed every gating scorer (≥ {threshold})"
+        f"\noutcome: {passed}/{len(rows)} sample(s) passed every gating scorer "
+        f"(≥ {threshold})"
     )
+    if any(r["diagnostic"] for r in rows):
+        lines.append("(* = diagnostic scorer, shown but not gating)")
     if cost_checks:
-        lines.append("\ntoken budget (baseline × 1.5):")
+        lines.append("\ncost gate — input+output (baseline × 1.5):")
         for c in cost_checks:
             if "note" in c:
                 lines.append(f"  [warn] {c['sample_id']}: {c['note']}")
             else:
                 lines.append(
                     f"  [{'PASS' if c['pass'] else 'FAIL'}] {c['sample_id']}: "
-                    f"{c['tokens']} / ceiling {c['ceiling']} (baseline {c['baseline']})"
+                    f"io {c['io']} / ceiling {c['ceiling']} (baseline {c['baseline']})"
                 )
     return "\n".join(lines)
 

--- a/evals/src/scripts/regenerate_baseline.py
+++ b/evals/src/scripts/regenerate_baseline.py
@@ -1,18 +1,19 @@
 """Regenerate an eval's ``outcomes_baseline.json`` from its most recent run.
 
-Records, per arm, the model and each sample's median token count across epochs
-— the ceiling gate in ``pass_fail`` allows up to ``tokens × 1.5``. No bands, no
-duration: outcome is gated per-sample by the scorers, not by a stored aggregate
-that would drift as samples are added.
+Records, per arm, the model and each sample's median metrics across epochs: the
+I/CW/CR/O token split + all-in total, plus turns, tool_calls, and duration. The
+cost gate in ``pass_fail`` keys on **input + output** (≤ baseline × 1.5); the
+cache-read/-write split, total tokens, turns, tool_calls, and duration_s are
+diagnostic — stored so the summary can show a delta, never gated.
 
-A baseline is an all-green snapshot or nothing: if any sample in the run
-failed a gating scorer (or errored / never scored), regeneration refuses to
-write and exits non-zero, naming the offenders. A partial baseline would leave
-half the eval ungated, and a failed sample's token count is unrepresentative
-anyway (a token-limit flail inflates it, an early error deflates it). Fix the
-eval, get a clean run, then regenerate.
+A baseline is an all-green snapshot or nothing: if any sample in the run failed
+a gating scorer (or errored / never scored), regeneration refuses to write and
+exits non-zero, naming the offenders. A partial baseline would leave half the
+eval ungated, and a failed sample's tokens are unrepresentative anyway (a
+token-limit flail inflates them, an early error deflates them). Fix the eval,
+get a clean run, then regenerate.
 
-    evals-regenerate-baseline --target camunda-feel [--arm with_skill]
+    evals-regenerate-baseline --target skills/camunda-feel [--arm with_skill]
 
 ``--target`` is the eval dir path (``skills/<name>`` or ``scenarios/<name>``).
 Review the diff before committing; regenerate one target at a time.
@@ -31,6 +32,14 @@ from core.paths import EVALS_ROOT
 from scripts.pass_fail import _outcome_rows
 
 LOGS_DIR = EVALS_ROOT / "logs"
+
+# Per-sample baseline layout. The four token categories nest under ``tokens``
+# (input/output feed the cost gate; cache_write/cache_read are recorded for
+# diagnosis); turns/tool_calls/duration_s sit top-level as effort diagnostics.
+# No all-in total — it's just the sum of the four, and nothing reads it. Stored
+# as rounded ints for a stable, readable diff.
+TOKEN_FIELDS = ("input", "cache_write", "cache_read", "output")
+EFFORT_FIELDS = ("turns", "tool_calls", "duration_s")
 
 
 def main() -> int:
@@ -98,15 +107,13 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
-    # Record the median per-id tokens/turns/tool_calls (rows carry the
-    # epoch-reduced figures); tokens gate the cost ceiling, turns and tool_calls
-    # are diagnostic (stored for the summary's delta, never gated). Sorted by id
-    # so the committed JSON is stable regardless of log ordering.
+    # Record the median per-id split + diagnostics (rows carry the epoch-reduced
+    # figures). Sorted by id so the committed JSON is stable regardless of log
+    # ordering.
     samples = {
         r["sample_id"]: {
-            "tokens": round(r["tokens"]),
-            "turns": round(r["turns"]),
-            "tool_calls": round(r["tool_calls"]),
+            "tokens": {f: round(r.get(f, 0.0)) for f in TOKEN_FIELDS},
+            **{f: round(r.get(f, 0.0)) for f in EFFORT_FIELDS},
         }
         for r in sorted(rows, key=lambda r: r["sample_id"])
     }

--- a/evals/src/scripts/summarize.py
+++ b/evals/src/scripts/summarize.py
@@ -216,8 +216,20 @@ def render(
     grand = dict.fromkeys(USAGE_FIELDS, 0.0)  # run-wide token total (every arm)
     models: set[str] = set()
 
+    # Job-retry resilience: the summarize step merges every attempt's per-job log
+    # artifact, so re-running a failed job leaves two logs for the same eval×arm.
+    # Keep only the newest per (eval_name, arm) — else the table doubles the row
+    # and the headline double-counts that eval's tokens. Logs are timestamp-
+    # prefixed, so the greatest filename is the latest run.
+    latest: dict[tuple[str, str], tuple[str, object]] = {}
     for info in infos:
-        log = read_eval_log(getattr(info, "name", str(info)))
+        iname = getattr(info, "name", str(info))
+        log = read_eval_log(iname)
+        key = (eval_name(log) or "(unknown)", task_arg(log, "arm") or "with_skill")
+        if key not in latest or iname > latest[key][0]:
+            latest[key] = (iname, log)
+
+    for _iname, log in sorted(latest.values(), key=lambda v: v[0]):
         name = eval_name(log) or "(unknown)"
         is_trigger = name.startswith("trigger-")
         arm = task_arg(log, "arm") or "with_skill"

--- a/evals/src/scripts/summarize.py
+++ b/evals/src/scripts/summarize.py
@@ -4,7 +4,10 @@ Always: a headline verdict and the run's model + token usage (total tokens with
 an `[I/CW/CR/O]` input / cache-write / cache-read / output split), an outcome
 table (pass + the gated **I+O** tokens vs committed baseline), a trigger routing
 table, and a with/without-skill delta when an ``evals:compare`` run provides both
-arms. ``--detail`` adds a per-eval token-split column plus a per-sample breakdown
+arms. When an outcome eval has a failing sample, a **Needs attention** section
+names the sample and the gating scorer that dipped (or the cost-ceiling breach),
+so the lean PR comment is self-sufficient — no opening the matrix job's Gate step.
+``--detail`` adds a per-eval token-split column plus a per-sample breakdown
 (I+O / turns / tool-calls / duration vs baseline) — the job-summary deep dive,
 omitted from the lean PR comment.
 
@@ -275,6 +278,14 @@ def render(
                     "turns": r["turns"],
                     "tool_calls": r["tool_calls"],
                     "duration_s": r["duration_s"],
+                    # The gating scorers that dipped below threshold on this
+                    # sample — what to name in "Needs attention". Diagnostic
+                    # scorers (metadata.gating == False) don't gate, so skip them.
+                    "fail_scorers": {
+                        n: v
+                        for n, v in r["scorers"].items()
+                        if n not in r["diagnostic"] and v < 1.0
+                    },
                     "base": b
                     if isinstance((b := arm_samples.get(r["sample_id"])), dict)
                     else None,
@@ -343,6 +354,28 @@ def render(
             ],
             ["l", "c", "r"] + (["l"] if detail else []),
         )
+
+        # Name exactly which sample + scorer (or cost ceiling) tripped, so the
+        # lean PR comment is self-sufficient — no opening the matrix job's Gate
+        # step to find out. Shown in both the lean and --detail surfaces.
+        attention_lines: list[str] = []
+        for name, _p, _t, cost, _ls, _bs, samples in sorted(
+            results, key=lambda r: r[0]
+        ):
+            for s in samples:
+                if s["fail_scorers"]:
+                    scs = ", ".join(
+                        f"{n} `{v:.2f}`" for n, v in sorted(s["fail_scorers"].items())
+                    )
+                    attention_lines.append(f"- `{name}` › `{s['id']}` — {scs} (< 1.0)")
+            for c in cost or []:
+                if "io" in c and not c.get("pass", True):
+                    attention_lines.append(
+                        f"- `{name}` › `{c['sample_id']}` — I+O `{_fmt(c['io'])}` "
+                        f"> ceiling `{_fmt(c['ceiling'])}` (baseline `{_fmt(c['baseline'])}`)"
+                    )
+        if attention_lines:
+            out += ["", "#### Needs attention", *attention_lines]
 
     if detail and results:
         out += ["", "#### Per-sample detail"]

--- a/evals/src/scripts/summarize.py
+++ b/evals/src/scripts/summarize.py
@@ -1,17 +1,17 @@
 """Render a Markdown summary of an eval run. Non-gating signal.
 
-Always: a headline verdict and the run's model + token usage (total tokens
-with an `[I/CW/CR/O]` input / cache-write / cache-read / output split), an
-outcome table (pass + tokens vs committed baseline), a trigger routing table,
-and a with/without-skill delta when an
-``evals:compare`` run provides both arms. ``--detail`` adds a per-eval token
-column plus a per-sample breakdown (tokens/turns/tool-calls vs baseline) — the
-job-summary deep dive, omitted from the lean PR comment.
+Always: a headline verdict and the run's model + token usage (total tokens with
+an `[I/CW/CR/O]` input / cache-write / cache-read / output split), an outcome
+table (pass + the gated **I+O** tokens vs committed baseline), a trigger routing
+table, and a with/without-skill delta when an ``evals:compare`` run provides both
+arms. ``--detail`` adds a per-eval token-split column plus a per-sample breakdown
+(I+O / turns / tool-calls / duration vs baseline) — the job-summary deep dive,
+omitted from the lean PR comment.
 
-Tables are column-aligned so the raw output is readable on a CLI; GitHub
-renders them identically. Consumed by ``.github/workflows/eval.yml`` (PR
-comment + ``$GITHUB_STEP_SUMMARY``) and ``eval-nightly.yml`` (job summary).
-The workflow prepends its own hidden find-comment marker for the PR comment.
+Tables are column-aligned so the raw output is readable on a CLI; GitHub renders
+them identically. Consumed by ``.github/workflows/eval.yml`` (PR comment +
+``$GITHUB_STEP_SUMMARY``) and ``eval-nightly.yml`` (job summary). The workflow
+prepends its own hidden find-comment marker for the PR comment.
 """
 
 from __future__ import annotations
@@ -24,16 +24,18 @@ from inspect_ai.log import list_eval_logs, read_eval_log
 
 from core.metrics import (
     USAGE_FIELDS,
+    eval_name,
     eval_source_path,
     model_id,
-    eval_name,
     task_arg,
     token_usage,
 )
 from core.paths import EVALS_ROOT
 from scripts.pass_fail import (
     CEILING_MULTIPLIER,
+    _baseline_io,
     _cost_checks,
+    _io,
     _load_baseline,
     _outcome_rows,
 )
@@ -95,6 +97,7 @@ def _verdict(passed: int, total: int) -> str:
 
 
 def _token_cell(cost_checks: list[dict] | None) -> str:
+    """The outcome-table cost cell: summed observed I+O vs summed baseline I+O."""
     if cost_checks is None:
         return "— no baseline"
     graded = [c for c in cost_checks if "baseline" in c]
@@ -104,7 +107,7 @@ def _token_cell(cost_checks: list[dict] | None) -> str:
     hint = f" · {no_base} no baseline" if no_base else ""
     if not graded:
         return "— regenerate baseline" + hint
-    observed = sum(c["tokens"] for c in graded)
+    observed = sum(c["io"] for c in graded)
     base = sum(c["baseline"] for c in graded)
     pct = (observed - base) / base * 100 if base else 0.0
     over = [c for c in graded if not c["pass"]]
@@ -112,19 +115,19 @@ def _token_cell(cost_checks: list[dict] | None) -> str:
     return f"{icon} `{_fmt(observed)}` ({pct:+.0f}% vs `{_fmt(base)}`){hint}"
 
 
-def _over_ceiling(obs: float, base: dict | None) -> bool:
-    b = base.get("tokens") if base else None
-    return isinstance(b, (int, float)) and obs > b * CEILING_MULTIPLIER
+def _over_ceiling(obs_io: float, base: dict | None) -> bool:
+    b = _baseline_io(base) if isinstance(base, dict) else None
+    return isinstance(b, (int, float)) and obs_io > b * CEILING_MULTIPLIER
 
 
-def _tok_detail(obs: float, base: dict | None) -> str:
-    """Per-sample observed tokens, backticked, with Δ% vs baseline when it
-    moved (≥5%); a bare value otherwise, or ``(new)`` with no baseline."""
-    b = base.get("tokens") if base else None
+def _io_detail(obs_io: float, base: dict | None) -> str:
+    """Per-sample observed I+O, backticked, with Δ% vs baseline when it moved
+    (≥5%); a bare value otherwise, or ``(new)`` with no baseline."""
+    b = _baseline_io(base) if isinstance(base, dict) else None
     if not isinstance(b, (int, float)):
-        return f"`{_fmt(obs)}` (new)"
-    pct = (obs - b) / b * 100 if b else 0.0
-    return f"`{_fmt(obs)}` {pct:+.0f}%" if abs(pct) >= 5 else f"`{_fmt(obs)}`"
+        return f"`{_fmt(obs_io)}` (new)"
+    pct = (obs_io - b) / b * 100 if b else 0.0
+    return f"`{_fmt(obs_io)}` {pct:+.0f}%" if abs(pct) >= 5 else f"`{_fmt(obs_io)}`"
 
 
 def _count_detail(obs: float, base: dict | None, key: str) -> str:
@@ -137,16 +140,44 @@ def _count_detail(obs: float, base: dict | None, key: str) -> str:
     return f"`{obs}`"
 
 
+def _dur_detail(obs_s: float, base: dict | None) -> str:
+    """Per-sample wall time in seconds, backticked, with Δ% vs baseline when it
+    moved (≥10%). Diagnostic only — runner-noisy, never gates."""
+    obs = round(obs_s)
+    b = base.get("duration_s") if base else None
+    if not isinstance(b, (int, float)) or not b:
+        return f"`{obs}s`"
+    pct = (obs - b) / b * 100
+    return f"`{obs}s` {pct:+.0f}%" if abs(pct) >= 10 else f"`{obs}s`"
+
+
 def _usage(u: dict[str, float]) -> str:
     """Token breakdown: total tokens [I, CW, CR, O] (their sum)."""
     i, cw, cr, o = (round(u[f]) for f in USAGE_FIELDS)
     return f"{i + cw + cr + o:,} tokens [I: {i:,}, CW: {cw:,}, CR: {cr:,}, O: {o:,}]"
 
 
-def _split(u: dict[str, float]) -> str:
-    """Per-eval token split as a backticked (monospace) I·CW·CR·O cell."""
+def _split(u: dict[str, float], base: dict | None = None) -> str:
+    """Per-eval token split as a backticked (monospace) I·CW·CR·O cell.
+
+    With a baseline split, appends Δ% on the **cache** categories (CW/CR) when
+    they moved ≥10% — the diagnostic the cost gate (I+O only) doesn't surface, so
+    a cache-read blow-up is visible even though it never gates. I and O carry no
+    Δ here; their movement is the gated quantity shown in the I+O column.
+    """
+
+    def cache(cat: str, val: float) -> str:
+        val = round(val)
+        b = base.get(cat) if base else None
+        if isinstance(b, (int, float)) and b and abs((val - b) / b * 100) >= 10:
+            return f"{val:,} ({(val - b) / b * 100:+.0f}%)"
+        return f"{val:,}"
+
     i, cw, cr, o = (round(u[f]) for f in USAGE_FIELDS)
-    return f"`I {i:,} · CW {cw:,} · CR {cr:,} · O {o:,}`"
+    return (
+        f"`I {i:,} · CW {cache('cache_write', cw)} · "
+        f"CR {cache('cache_read', cr)} · O {o:,}`"
+    )
 
 
 def _name_cell(name: str, blob_base: str | None, is_trigger: bool) -> str:
@@ -169,8 +200,8 @@ def render(
     """Render the run summary as Markdown.
 
     ``detail`` adds a per-eval token-split (I·CW·CR·O) column and a per-sample
-    breakdown (tokens/turns/tool-calls, each with its Δ vs baseline) — the
-    job-summary deep dive, omitted from the lean PR comment. ``blob_base``
+    breakdown (I+O / turns / tool-calls / duration, each with its Δ vs baseline)
+    — the job-summary deep dive, omitted from the lean PR comment. ``blob_base``
     (a ``…/blob/<ref>`` URL) links each eval name to its source; ``run_url``
     appends a footer pointing at the run (used by the PR comment).
     """
@@ -180,7 +211,7 @@ def render(
 
     # rows carry their gating-arm usage dict so --detail can append a token column
     triggers: list[tuple] = []  # (skill, passed, total, usage)
-    results: list[tuple] = []  # (name, passed, total, cost, usage)
+    results: list[tuple] = []  # (name, passed, total, cost, split, base_split, samples)
     outcomes: dict[str, dict[str, float]] = {}  # name -> {arm: rate} for the delta
     grand = dict.fromkeys(USAGE_FIELDS, 0.0)  # run-wide token total (every arm)
     models: set[str] = set()
@@ -208,19 +239,47 @@ def render(
                 _cost_checks(rows, baseline, arm)[0] if baseline is not None else None
             )
             arm_samples = ((baseline or {}).get(arm) or {}).get("samples") or {}
+            # Per-eval split from the reduced rows (median per sample), not the
+            # raw token_usage(log) sum — so it's epoch-robust and comparable to
+            # the baseline's per-sample medians. The baseline split sums the
+            # nested tokens.* across the arm's samples; None when no baseline.
+            live_split = {f: sum(r.get(f, 0.0) for r in rows) for f in USAGE_FIELDS}
+            base_split = (
+                {
+                    f: sum(
+                        t.get(f, 0)
+                        for s in arm_samples.values()
+                        if isinstance((t := s.get("tokens")), dict)
+                    )
+                    for f in USAGE_FIELDS
+                }
+                if arm_samples
+                else None
+            )
             samples_detail = [
                 {
                     "id": r["sample_id"],
-                    "tokens": r["tokens"],
+                    "io": _io(r) or 0.0,
                     "turns": r["turns"],
                     "tool_calls": r["tool_calls"],
+                    "duration_s": r["duration_s"],
                     "base": b
                     if isinstance((b := arm_samples.get(r["sample_id"])), dict)
                     else None,
                 }
                 for r in sorted(rows, key=lambda r: r["sample_id"])
             ]
-            results.append((name, passed, total, cost_checks, u, samples_detail))
+            results.append(
+                (
+                    name,
+                    passed,
+                    total,
+                    cost_checks,
+                    live_split,
+                    base_split,
+                    samples_detail,
+                )
+            )
 
     def outcome_ok(it) -> bool:
         return it[1] == it[2] and it[2]
@@ -250,13 +309,14 @@ def render(
         f"{headline}. Non-blocking signal (doesn't block merge).",
         "",
         f"Model {model_str} · {_usage(grand)}",
-        "_I input · CW cache-write · CR cache-read · O output._",
+        "_I input · CW cache-write · CR cache-read · O output. Cost gate keys on "
+        "I+O; CW/CR are diagnostic._",
     ]
 
     if results:
         out += ["", "#### Outcome evals"]
         out += _table(
-            ["Eval", "Outcome", "Tokens (vs baseline)"]
+            ["Eval", "Outcome", "I+O (vs baseline)"]
             + (["Token split (I·CW·CR·O)"] if detail else []),
             [
                 [
@@ -264,8 +324,8 @@ def render(
                     _verdict(passed, total),
                     _token_cell(cost),
                 ]
-                + ([_split(u)] if detail else [])
-                for name, passed, total, cost, u, _ in sorted(
+                + ([_split(split, base_split)] if detail else [])
+                for name, passed, total, cost, split, base_split, _ in sorted(
                     results, key=lambda r: r[0]
                 )
             ],
@@ -275,24 +335,28 @@ def render(
     if detail and results:
         out += ["", "#### Per-sample detail"]
         out += _table(
-            ["Eval · Sample", "Tokens (vs baseline)", "Turns", "Tools"],
+            ["Eval · Sample", "I+O (vs baseline)", "Turns", "Tools", "Duration"],
             [
                 [
-                    f"{'🔴 ' if _over_ceiling(s['tokens'], s['base']) else ''}"
+                    f"{'🔴 ' if _over_ceiling(s['io'], s['base']) else ''}"
                     f"{name.removeprefix('camunda-')} · `{s['id']}`",
-                    _tok_detail(s["tokens"], s["base"]),
+                    _io_detail(s["io"], s["base"]),
                     _count_detail(s["turns"], s["base"], "turns"),
                     _count_detail(s["tool_calls"], s["base"], "tool_calls"),
+                    _dur_detail(s["duration_s"], s["base"]),
                 ]
-                for name, _p, _t, _c, _u, samples in sorted(results, key=lambda r: r[0])
+                for name, _p, _t, _c, _ls, _bs, samples in sorted(
+                    results, key=lambda r: r[0]
+                )
                 for s in samples
             ],
-            ["l", "r", "r", "r"],
+            ["l", "r", "r", "r", "r"],
         )
         out += [
             "",
-            "_Δ is vs the committed baseline; a bare number means within ±5% "
-            "(tokens) or unchanged (turns/tools). “(new)” = no baseline yet._",
+            "_Δ is vs the committed baseline; a bare number means within ±5% (I+O), "
+            "±10% (duration), or unchanged (turns/tools). “(new)” = no baseline yet. "
+            "Only I+O gates; duration is diagnostic._",
         ]
 
     if triggers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,10 @@ description = "Qualitative evaluation suite for camunda/skills. See docs/evals/c
 readme = "evals/README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "aioboto3>=15.5.0",
-    "anthropic>=0.104.0",
-    "inspect-ai>=0.3.158",
-    "inspect-swe>=0.2.55",
-    "openai>=2.38.0",
+    "inspect-ai==0.3.237",
+    "inspect-swe==0.2.62",
+    "anthropic==0.107.1",
+    "pydantic>=2.10",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.104.0"
+version = "0.107.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -207,9 +207,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/01/8bfa68b886aa436775325a108700f7da39e290870199ce9251934de3e4aa/anthropic-0.104.0.tar.gz", hash = "sha256:1ae8ef4709e90cc2068c8e8a63c1ecb63cc5360d325a4bef8b296aad76148be3", size = 849329, upload-time = "2026-05-21T20:02:05.346Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/f1/c6076a92e0bf6b0dfa126e213b3f9e8a510acd73567953210713aae6c256/anthropic-0.107.1.tar.gz", hash = "sha256:8e7169a6ab57fb806b778d9af018c867bad688144efec8969cdb4c5ccecd6670", size = 856312, upload-time = "2026-06-07T17:18:57.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/6c/595f1893352dbb4d88f1c2f0983296638783936b2063564aca9abb189990/anthropic-0.104.0-py3-none-any.whl", hash = "sha256:18f73ba3429aab237cdd146a486d20b4da3c008fb4a3ba83f237b27793e884c7", size = 832920, upload-time = "2026-05-21T20:02:07.853Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0e/71432f0777a263701955a23ebcc6650485c2753be9afbce2a6a8d72526e3/anthropic-0.107.1-py3-none-any.whl", hash = "sha256:b74338d08000ba105dfc8adae29af3713ece845a4bffec9986a20697e087c7b3", size = 838729, upload-time = "2026-06-07T17:18:58.729Z" },
 ]
 
 [[package]]
@@ -280,11 +280,10 @@ name = "camunda-skills-evals"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "aioboto3" },
     { name = "anthropic" },
     { name = "inspect-ai" },
     { name = "inspect-swe" },
-    { name = "openai" },
+    { name = "pydantic" },
 ]
 
 [package.dev-dependencies]
@@ -295,11 +294,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aioboto3", specifier = ">=15.5.0" },
-    { name = "anthropic", specifier = ">=0.104.0" },
-    { name = "inspect-ai", specifier = ">=0.3.158" },
-    { name = "inspect-swe", specifier = ">=0.2.55" },
-    { name = "openai", specifier = ">=2.38.0" },
+    { name = "anthropic", specifier = "==0.107.1" },
+    { name = "inspect-ai", specifier = "==0.3.237" },
+    { name = "inspect-swe", specifier = "==0.2.62" },
+    { name = "pydantic", specifier = ">=2.10" },
 ]
 
 [package.metadata.requires-dev]
@@ -684,9 +682,10 @@ wheels = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.224"
+version = "0.3.237"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "agent-client-protocol" },
     { name = "aioboto3" },
     { name = "anyio" },
     { name = "beautifulsoup4" },
@@ -726,14 +725,14 @@ dependencies = [
     { name = "zipp" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b2/dfe0e2724a0ea146f406f6d8e1ab922623b10ad49e66986fea1552e578d6/inspect_ai-0.3.224.tar.gz", hash = "sha256:d3b2b4dd04a34f7662744c29b082fbdbb0e1974de980e5a8225cf81ffa1b24af", size = 45866722, upload-time = "2026-05-20T20:40:49.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/a4/8092f31655cb26edb142a86a5f3ae0985e0360ba8e188f262d02c83e9ec1/inspect_ai-0.3.237.tar.gz", hash = "sha256:2b5b431bc660a1d99e90e5bf788a18c129ffe4e7651c4365710f9c1b85fc1138", size = 49107895, upload-time = "2026-06-07T18:15:20.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/13/2285ad3b8cc918064cdbfc5a928670bd7dc4084d31f4196bfc9502ec464b/inspect_ai-0.3.224-py3-none-any.whl", hash = "sha256:9487bef3f8f5d4d8cbbd48696bb5552400582aad86362ed6a546f38960807d8a", size = 36211398, upload-time = "2026-05-20T20:40:42.736Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8a/9d1db9444c9d171d22de54fbb2d6b772d3d207c10a507f1fa1386015b8e4/inspect_ai-0.3.237-py3-none-any.whl", hash = "sha256:1598ec5300c429424ba84fac6dbb9f6b1aeab5fe86fd599a9625d3360483daaf", size = 36456668, upload-time = "2026-06-07T18:15:13.077Z" },
 ]
 
 [[package]]
 name = "inspect-swe"
-version = "0.2.55"
+version = "0.2.62"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -747,9 +746,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/72/07a82c1b2f15a28d3dacd3037fdfcb2ddd795fa2de2827671ed2dc8c21f6/inspect_swe-0.2.55.tar.gz", hash = "sha256:8df1ea82b151ff2da63aa80ad9c5caa1e3ea6ae22cfdba4ef7cdcb8abdd440fc", size = 74527, upload-time = "2026-05-16T14:40:53.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/03/0a414bd6d3e03e42e4e3a5b073a40856c227387f6fd18ca202891d9d3172/inspect_swe-0.2.62.tar.gz", hash = "sha256:ca38789843b2e98e15dab969140b905d3bf0d452de6157e7cb3dc965e81802fe", size = 95094, upload-time = "2026-06-05T11:07:04.97Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/00/ea7c4c7990198d3a2d45e06d8a188d15d3b4057c66d1604eca1f431e81da/inspect_swe-0.2.55-py3-none-any.whl", hash = "sha256:88053bde223d890f9f26780e4c5397a3ecb1f0c4eca938c18abed08b9654f32f", size = 104984, upload-time = "2026-05-16T14:40:51.268Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/2a/db3502aca3fed455d467fbd0b4badc7a7e0c2931bacb2719c47b1af8c41a/inspect_swe-0.2.62-py3-none-any.whl", hash = "sha256:61a3dafe2eae49300c76d656627930112f3b33ceaf41b78ab4fc60a210ee66dd", size = 128000, upload-time = "2026-06-05T11:07:03.479Z" },
 ]
 
 [[package]]
@@ -1219,25 +1218,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
     { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
     { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
-]
-
-[[package]]
-name = "openai"
-version = "2.38.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/12/cfa322c5f5dd8fa21aab9a7a8e979e7a11123800f86ca8d82eb68a83d213/openai-2.38.0.tar.gz", hash = "sha256:798694c6cf74145541fda94325b6f8f72d8e1fd0262cc137c8d728177a6a4ce3", size = 772764, upload-time = "2026-05-21T21:23:42.105Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/bf/ccff9be562e24207716d04ef9dc931c76aff0c89a7265da43e2104d7fe06/openai-2.38.0-py3-none-any.whl", hash = "sha256:ec6661c57b2dcc47414a767e6e3335c7ed3d19c9696999283a3c82e95c756a3c", size = 1344910, upload-time = "2026-05-21T21:23:39.636Z" },
 ]
 
 [[package]]
@@ -1971,18 +1951,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
     { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
     { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
-]
-
-[[package]]
-name = "tqdm"
-version = "4.67.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Runs the eval harness on the Anthropic API and enriches the per-sample cost baseline.

**Provider** — the suite defaults to `anthropic/claude-sonnet-4-6` with `ANTHROPIC_API_KEY`. The three eval workflows and the `Makefile` carry the key (Inspect reads it on the runner; the sandbox bridge proxies model calls back, so the container holds no credential). Dropped the unused `aioboto3`/`openai` dependencies and pinned `inspect-ai`, `inspect-swe`, and `anthropic`.

**Baseline split + duration** — each baseline sample now records an `{input, cache_write, cache_read, output}` token split plus wall-clock `duration_s`. The cost gate keys on **input + output** (`baseline × 1.5`): cache-read dominates the all-in total and is the cheapest, most volatile category, so gating the total policed cache churn rather than the agent's work. The PR-comment summary surfaces the `I·CW·CR·O` split (flagging ≥10% cache swings) and a duration column; cache categories and duration are diagnostic, never gated.

The cost gate tolerates a sample whose baseline predates the nested schema (and a run whose model differs from the baseline's): it reports `no baseline (regenerate)` and self-skips rather than failing. So committed baselines stay valid until they're regenerated.

**Required follow-up before cost gating is active again:** every committed `outcomes_baseline.json` carries the old model id and flat-token shape, so cost gating self-skips for now. Regenerate the baselines on CI under the current model by applying the `evals:regenerate-baselines` label to this PR, then review the committed diff.

## Checklist

- [ ] `make lint` passes
- [x] Updated `SKILL.md` / `references/` if behaviour changed — n/a, eval harness only


---

**Also in this PR — gate hardening:** `evals-pass-fail` only inspected samples that produced a score, so a sample that ran but never scored (sandbox/cluster/model error, aborted run) — or a run where no sample scored at all — passed by omission and showed a green gate. It now compares the scored ids against the ids that actually ran (epoch-safe, the same check `regenerate_baseline` already uses) and fails on any ran-but-unscored sample or an empty run. Stays non-blocking.
