### PR TITLE
feat: c8ctl 3.2.0 engine-version, FEEL auto-prepend, bpmn format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ c8ctl get topology --json   # confirm it's alive (use --json per command for scr
 All skill tooling is unified under c8ctl plugin commands:
 
 - **BPMN validation**: `c8ctl bpmn lint process.bpmn` (auto-detects Camunda execution platform version; uses `.bpmnlintrc` if present)
+- **BPMN canonicalization** *(c8ctl 3.2.0+)*: `c8ctl bpmn format [<file.bpmn>] [-i]` — round-trip through bpmn-moddle to normalize whitespace, attribute order, and element shapes (same pass as Modeler save); `-i` rewrites in place, default prints to stdout
 - **Element templates** (run `c8ctl element-template sync` **once** before any OOTB-ID command; file/URL applies bypass the cache):
   - `c8ctl element-template search "<query>" [--limit N] [--engine-version <x.y.z>]` — discover OOTB connector templates; `--engine-version` filters to the latest version compatible with that engine *(c8ctl 3.2.0+)* (default limit 20)
   - `c8ctl element-template info <id> [--engine-version <x.y.z>]` — show metadata card (applies-to, engines, docs link); `--engine-version` resolves via engine-compatibility *(c8ctl 3.2.0+)*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ c8ctl get topology --json   # confirm it's alive (use --json per command for scr
 
 ## Tooling
 
-All skill tooling is unified under c8ctl plugin commands. `bpmn format`, `--engine-version` on discovery commands, and auto-`=` for FEEL `--set` require **c8ctl ≥ 3.2.0**; if a flag is unrecognised, prompt the user to upgrade: `npm install -g @camunda8/cli`.
+All skill tooling is unified under c8ctl plugin commands:
 
 - **BPMN validation**: `c8ctl bpmn lint process.bpmn` (auto-detects Camunda execution platform version; uses `.bpmnlintrc` if present)
 - **BPMN canonicalization**: `c8ctl bpmn format [<file.bpmn>] [-i]` — round-trip through bpmn-moddle to normalize whitespace, attribute order, and element shapes (same pass as Modeler save); `-i` rewrites in place, default prints to stdout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,9 @@ All skill tooling is unified under c8ctl plugin commands:
 
 - **BPMN validation**: `c8ctl bpmn lint process.bpmn` (auto-detects Camunda execution platform version; uses `.bpmnlintrc` if present)
 - **Element templates** (run `c8ctl element-template sync` **once** before any OOTB-ID command; file/URL applies bypass the cache):
-  - `c8ctl element-template search "<query>" [--limit N]` — discover OOTB connector templates (default limit 20)
-  - `c8ctl element-template info <id>` — show metadata card (applies-to, engines, docs link)
-  - `c8ctl element-template get-properties <id> [<name>...]` — list settable properties (condensed by default; supports glob filters and `--group <id>`); add `--detailed` for full per-property cards (Required, FEEL, Active when, Pattern)
+  - `c8ctl element-template search "<query>" [--limit N] [--engine-version <x.y.z>]` — discover OOTB connector templates; `--engine-version` filters to the latest version compatible with that engine *(c8ctl 3.2.0+)* (default limit 20)
+  - `c8ctl element-template info <id> [--engine-version <x.y.z>]` — show metadata card (applies-to, engines, docs link); `--engine-version` resolves via engine-compatibility *(c8ctl 3.2.0+)*
+  - `c8ctl element-template get-properties <id> [<name>...] [--engine-version <x.y.z>]` — list settable properties (condensed by default; supports glob filters and `--group <id>`); add `--detailed` for full per-property cards (Required, FEEL, Active when, Pattern); `--engine-version` resolves via engine-compatibility *(c8ctl 3.2.0+)*
   - `c8ctl element-template apply -i <template> <element-id> <bpmn> [--set key=value ...]` — apply a template (omit `-i` to print to stdout)
   - `c8ctl element-template get <id>` — print raw template JSON
   - `c8ctl element-template sync [--prune]` — refresh the local OOTB cache (required once before first use; re-run to pick up upstream changes)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,14 +40,14 @@ c8ctl get topology --json   # confirm it's alive (use --json per command for scr
 
 ## Tooling
 
-All skill tooling is unified under c8ctl plugin commands:
+All skill tooling is unified under c8ctl plugin commands. `bpmn format`, `--engine-version` on discovery commands, and auto-`=` for FEEL `--set` require **c8ctl ≥ 3.2.0**; if a flag is unrecognised, prompt the user to upgrade: `npm install -g @camunda8/cli`.
 
 - **BPMN validation**: `c8ctl bpmn lint process.bpmn` (auto-detects Camunda execution platform version; uses `.bpmnlintrc` if present)
-- **BPMN canonicalization** *(c8ctl 3.2.0+)*: `c8ctl bpmn format [<file.bpmn>] [-i]` — round-trip through bpmn-moddle to normalize whitespace, attribute order, and element shapes (same pass as Modeler save); `-i` rewrites in place, default prints to stdout
+- **BPMN canonicalization**: `c8ctl bpmn format [<file.bpmn>] [-i]` — round-trip through bpmn-moddle to normalize whitespace, attribute order, and element shapes (same pass as Modeler save); `-i` rewrites in place, default prints to stdout
 - **Element templates** (run `c8ctl element-template sync` **once** before any OOTB-ID command; file/URL applies bypass the cache):
-  - `c8ctl element-template search "<query>" [--limit N] [--engine-version <x.y.z>]` — discover OOTB connector templates; `--engine-version` filters to the latest version compatible with that engine *(c8ctl 3.2.0+)* (default limit 20)
-  - `c8ctl element-template info <id> [--engine-version <x.y.z>]` — show metadata card (applies-to, engines, docs link); `--engine-version` resolves via engine-compatibility *(c8ctl 3.2.0+)*
-  - `c8ctl element-template get-properties <id> [<name>...] [--engine-version <x.y.z>]` — list settable properties (condensed by default; supports glob filters and `--group <id>`); add `--detailed` for full per-property cards (Required, FEEL, Active when, Pattern); `--engine-version` resolves via engine-compatibility *(c8ctl 3.2.0+)*
+  - `c8ctl element-template search "<query>" [--limit N] [--engine-version <x.y.z>]` — discover OOTB connector templates; `--engine-version` filters to the latest version compatible with that engine (default limit 20)
+  - `c8ctl element-template info <id> [--engine-version <x.y.z>]` — show metadata card (applies-to, engines, docs link); `--engine-version` resolves via engine-compatibility
+  - `c8ctl element-template get-properties <id> [<name>...] [--engine-version <x.y.z>]` — list settable properties (condensed by default; supports glob filters and `--group <id>`); add `--detailed` for full per-property cards (Required, FEEL, Active when, Pattern); `--engine-version` resolves via engine-compatibility
   - `c8ctl element-template apply -i <template> <element-id> <bpmn> [--set key=value ...]` — apply a template (omit `-i` to print to stdout)
   - `c8ctl element-template get <id>` — print raw template JSON
   - `c8ctl element-template sync [--prune]` — refresh the local OOTB cache (required once before first use; re-run to pick up upstream changes)

--- a/skills/camunda-bpmn/SKILL.md
+++ b/skills/camunda-bpmn/SKILL.md
@@ -18,7 +18,7 @@ Create and edit executable BPMN 2.0 processes for Camunda 8.8+. Generates valid 
 
 - Camunda 8.8+ cluster (local via c8run, SaaS, or Self-Managed)
 - c8ctl CLI installed and configured (`c8ctl add profile`) — provides `c8ctl bpmn lint`
-- **c8ctl ≥ 3.2.0** for `bpmn format`, `--engine-version` on discovery commands, and `--set` FEEL auto-`=`. If a command or flag is unavailable, ask the user to upgrade: `npm install -g @camunda8/cli`
+- **c8ctl ≥ 3.2.0** for `bpmn format`. If the command is unavailable, ask the user to upgrade: `npm install -g @camunda8/cli`
 
 ## Cross-References
 

--- a/skills/camunda-bpmn/SKILL.md
+++ b/skills/camunda-bpmn/SKILL.md
@@ -18,6 +18,7 @@ Create and edit executable BPMN 2.0 processes for Camunda 8.8+. Generates valid 
 
 - Camunda 8.8+ cluster (local via c8run, SaaS, or Self-Managed)
 - c8ctl CLI installed and configured (`c8ctl add profile`) — provides `c8ctl bpmn lint`
+- **c8ctl ≥ 3.2.0** for `c8ctl bpmn format`. If unrecognised, ask the user to upgrade: `npm install -g @camunda8/cli`
 
 ## Cross-References
 

--- a/skills/camunda-bpmn/SKILL.md
+++ b/skills/camunda-bpmn/SKILL.md
@@ -18,7 +18,7 @@ Create and edit executable BPMN 2.0 processes for Camunda 8.8+. Generates valid 
 
 - Camunda 8.8+ cluster (local via c8run, SaaS, or Self-Managed)
 - c8ctl CLI installed and configured (`c8ctl add profile`) — provides `c8ctl bpmn lint`
-- **c8ctl ≥ 3.2.0** for `c8ctl bpmn format`. If unrecognised, ask the user to upgrade: `npm install -g @camunda8/cli`
+- **c8ctl ≥ 3.2.0** for `bpmn format`, `--engine-version` on discovery commands, and `--set` FEEL auto-`=`. If a command or flag is unavailable, ask the user to upgrade: `npm install -g @camunda8/cli`
 
 ## Cross-References
 

--- a/skills/camunda-bpmn/references/canonical-style.md
+++ b/skills/camunda-bpmn/references/canonical-style.md
@@ -37,7 +37,19 @@ Write BPMN in canonical form up front. Then Modeler saves produce empty diffs (j
 </bpmn:definitions>
 ```
 
+## Canonicalizing with `c8ctl bpmn format` *(c8ctl 3.2.0+)*
+
+`c8ctl bpmn format` runs a bpmn-moddle round-trip — the same pass that Modeler and `c8ctl element-template apply` execute on save:
+
+```bash
+c8ctl bpmn format process.bpmn         # print canonical XML to stdout
+c8ctl bpmn format -i process.bpmn      # rewrite in place
+cat process.bpmn | c8ctl bpmn format   # read from stdin (stdout only; -i requires a file path)
+```
+
+Use it to canonicalize a hand-authored file before the first `Edit` call, or to normalize output from an external tool. After running `format -i`, re-read the file — the round-trip may reorder attributes or normalize whitespace, making prior string matches stale.
+
 ## Why it matters
 
-- **`Edit` stays reliable.** `Edit` matches `old_string` byte-for-byte. After any Modeler save or `c8ctl element-template apply` call, a hand-formatted file gets canonicalized and the agent's mental model goes stale — every edit then needs a re-read first.
+- **`Edit` stays reliable.** `Edit` matches `old_string` byte-for-byte. After any Modeler save, `c8ctl element-template apply`, or `c8ctl bpmn format` call, a hand-formatted file gets canonicalized and the agent's mental model goes stale — every edit then needs a re-read first.
 - **Diffs read clean.** A Modeler save reformats a non-canonical file. Subsequent PR diffs mix the semantic change with whitespace and attribute-reorder churn, hiding what actually changed.

--- a/skills/camunda-bpmn/references/canonical-style.md
+++ b/skills/camunda-bpmn/references/canonical-style.md
@@ -37,7 +37,7 @@ Write BPMN in canonical form up front. Then Modeler saves produce empty diffs (j
 </bpmn:definitions>
 ```
 
-## Canonicalizing with `c8ctl bpmn format` *(c8ctl 3.2.0+)*
+## Canonicalizing with `c8ctl bpmn format`
 
 `c8ctl bpmn format` runs a bpmn-moddle round-trip — the same pass that Modeler and `c8ctl element-template apply` execute on save:
 

--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -47,7 +47,7 @@ c8ctl element-template search "REST"                              # find HTTP/RE
 c8ctl element-template search "slack"                             # find Slack connectors
 c8ctl element-template search "kafka"                             # find Kafka connectors
 c8ctl element-template search "connector" --limit 5              # cap results (default 20)
-c8ctl element-template search "REST" --engine-version 8.8.0      # latest version compatible with 8.8.0 *(c8ctl 3.2.0+)*
+c8ctl element-template search "REST" --engine-version 8.8.0      # latest version compatible with 8.8.0
 ```
 
 Each result shows the template name, ID (e.g. `io.camunda.connectors.HttpJson.v2`), version, `appliesTo`, engine constraint, and description. The header reads `Showing N of M matches for '<query>'` — if `M > N`, narrow the query or raise `--limit`. Pick the ID that matches your use case.
@@ -58,8 +58,8 @@ Inbound integrations typically ship as a *family* of templates — one per BPMN 
 
 Two commands cover the questions you'll ask before applying:
 
-- **`c8ctl element-template info <id> [--engine-version <x.y.z>]`** *(c8ctl 3.2.0+)* — metadata card (applies-to, engine constraint, description, docs link). Pass `--engine-version` to resolve the latest version compatible with that engine. Useful when the connector is unfamiliar.
-- **`c8ctl element-template get-properties <id> [<name>...] [--engine-version <x.y.z>]`** *(c8ctl 3.2.0+)* — settable properties (condensed: name + description, grouped). Accepts positional names (shell-style globs work, quote them) and `--group <id>` to narrow. Pass `--engine-version` to resolve the latest version compatible with that engine. Add `--detailed` for per-property cards showing **Required**, **FEEL**, **Active when**, **Pattern**, **Default**, **Choices** — reach for `--detailed` when an `apply --set` call fails or when you need to know whether to prefix a value with `=`.
+- **`c8ctl element-template info <id> [--engine-version <x.y.z>]`** — metadata card (applies-to, engine constraint, description, docs link). Pass `--engine-version` to resolve the latest version compatible with that engine. Useful when the connector is unfamiliar.
+- **`c8ctl element-template get-properties <id> [<name>...] [--engine-version <x.y.z>]`** — settable properties (condensed: name + description, grouped). Accepts positional names (shell-style globs work, quote them) and `--group <id>` to narrow. Pass `--engine-version` to resolve the latest version compatible with that engine. Add `--detailed` for per-property cards showing **Required**, **FEEL**, **Active when**, **Pattern**, **Default**, **Choices** — reach for `--detailed` when an `apply --set` call fails or when you need to know whether to prefix a value with `=`.
 
 ```bash
 c8ctl element-template get-properties io.camunda.connectors.HttpJson.v2 url method
@@ -92,7 +92,7 @@ c8ctl element-template apply <id> <element> process.bpmn | c8ctl bpmn lint      
 
 Apply writes `zeebe:modelerTemplate`, `zeebe:modelerTemplateVersion`, `zeebe:modelerTemplateIcon`, `zeebe:taskDefinition`, the **entire `zeebe:ioMapping` block (inputs *and* outputs)**, and the `zeebe:taskHeaders` onto the element. All of those must stay consistent — `apply` owns them. In particular, custom `<zeebe:output>` mappings hand-added to a connector element will be wiped on the next `apply` — put downstream extraction on a separate activity, or on the next flow element's `<zeebe:ioMapping>` (end events accept it too).
 
-`apply` auto-resolves the latest OOTB template version compatible with the BPMN's `executionPlatformVersion`. Pass `--engine-version <x.y.z>` to `search`, `info`, or `get-properties` to apply the same engine-compatibility filter during discovery — `search` returns the latest compatible version per template, and `info` / `get-properties` resolve via the same check. *(c8ctl 3.2.0+)* A pinned `@<version>` (e.g. `io.camunda.connectors.HttpJson.v2@12`) always takes precedence over `--engine-version` and produces a warning when the two differ.
+`apply` auto-resolves the latest OOTB template version compatible with the BPMN's `executionPlatformVersion`. Pass `--engine-version <x.y.z>` to `search`, `info`, or `get-properties` to apply the same engine-compatibility filter during discovery — `search` returns the latest compatible version per template, and `info` / `get-properties` resolve via the same check. A pinned `@<version>` (e.g. `io.camunda.connectors.HttpJson.v2@12`) always takes precedence over `--engine-version` and produces a warning when the two differ.
 
 ### Setting Property Values at Apply Time
 
@@ -118,7 +118,7 @@ Note the `string(userId)` wrapper — `userId` is a number and FEEL does not aut
 
 `apply` errors with a helpful list of valid names if you pass an unknown property, and with the qualified-name list if a bare key is ambiguous.
 
-**FEEL value syntax.** `feel: required` values must start with `=`. The canonical form is `--set key='=value'`; `--set 'key==value'` (compact) also works. *(c8ctl 3.2.0+)* For `feel: required` properties, c8ctl auto-prepends `=` when the value doesn't start with one, so `--set key=expression` stores `=expression`; value-side whitespace is trimmed. Check `get-properties --detailed <name>` when unsure about the `feel` setting for a property.
+**FEEL value syntax.** `feel: required` values must start with `=`. The canonical form is `--set key='=value'`; `--set 'key==value'` (compact) also works. For `feel: required` properties, c8ctl auto-prepends `=` when the value doesn't start with one, so `--set key=expression` stores `=expression`; value-side whitespace is trimmed. Check `get-properties --detailed <name>` when unsure about the `feel` setting for a property.
 
 **Defaults bake in.** `apply` materializes every active property with a default into the BPMN — `<zeebe:input>`, `<zeebe:output>`, `<zeebe:taskHeaders>`, and `<zeebe:property>` entries — not just the keys you `--set`. The defaults are captured at apply time — if the template later ships a new default, this BPMN keeps the old value.
 

--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -18,6 +18,7 @@ Browse and configure pre-built Camunda connectors using element templates. Apply
 
 - c8ctl CLI installed and configured (`c8ctl add profile`) — provides `c8ctl element-template` commands
 - **Local OOTB catalog synced** — run `c8ctl element-template sync` **once** before using `search`, `info`, `get-properties`, `get`, or `apply` with an OOTB template ID. Re-run (optionally with `--prune`) to pick up upstream changes. Applying a template from a local file path or `https://` URL bypasses the cache and does not require sync.
+- **c8ctl ≥ 3.2.0** for `--engine-version` and `--set` FEEL auto-`=`. If a flag is unrecognised, ask the user to upgrade: `npm install -g @camunda8/cli`
 
 ## Cross-References
 

--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -43,10 +43,11 @@ Read `references/element-template-schema.md` for the reader's guide to property 
 **Always discover the template ID via `c8ctl element-template search` rather than guessing or recalling an ID from memory.** Template IDs and versions evolve — the search command reflects what's actually available in the local OOTB catalog.
 
 ```bash
-c8ctl element-template search "REST"             # find HTTP/REST connectors
-c8ctl element-template search "slack"            # find Slack connectors
-c8ctl element-template search "kafka"            # find Kafka connectors
-c8ctl element-template search "connector" --limit 5   # cap results (default 20)
+c8ctl element-template search "REST"                              # find HTTP/REST connectors
+c8ctl element-template search "slack"                             # find Slack connectors
+c8ctl element-template search "kafka"                             # find Kafka connectors
+c8ctl element-template search "connector" --limit 5              # cap results (default 20)
+c8ctl element-template search "REST" --engine-version 8.8.0      # latest version compatible with 8.8.0 *(c8ctl 3.2.0+)*
 ```
 
 Each result shows the template name, ID (e.g. `io.camunda.connectors.HttpJson.v2`), version, `appliesTo`, engine constraint, and description. The header reads `Showing N of M matches for '<query>'` — if `M > N`, narrow the query or raise `--limit`. Pick the ID that matches your use case.
@@ -57,8 +58,8 @@ Inbound integrations typically ship as a *family* of templates — one per BPMN 
 
 Two commands cover the questions you'll ask before applying:
 
-- **`c8ctl element-template info <id>`** — metadata card (applies-to, engine constraint, description, docs link). Useful when the connector is unfamiliar.
-- **`c8ctl element-template get-properties <id> [<name>...]`** — settable properties (condensed: name + description, grouped). Accepts positional names (shell-style globs work, quote them) and `--group <id>` to narrow. Add `--detailed` for per-property cards showing **Required**, **FEEL**, **Active when**, **Pattern**, **Default**, **Choices** — reach for `--detailed` when an `apply --set` call fails or when you need to know whether to prefix a value with `=`.
+- **`c8ctl element-template info <id> [--engine-version <x.y.z>]`** *(c8ctl 3.2.0+)* — metadata card (applies-to, engine constraint, description, docs link). Pass `--engine-version` to resolve the latest version compatible with that engine. Useful when the connector is unfamiliar.
+- **`c8ctl element-template get-properties <id> [<name>...] [--engine-version <x.y.z>]`** *(c8ctl 3.2.0+)* — settable properties (condensed: name + description, grouped). Accepts positional names (shell-style globs work, quote them) and `--group <id>` to narrow. Pass `--engine-version` to resolve the latest version compatible with that engine. Add `--detailed` for per-property cards showing **Required**, **FEEL**, **Active when**, **Pattern**, **Default**, **Choices** — reach for `--detailed` when an `apply --set` call fails or when you need to know whether to prefix a value with `=`.
 
 ```bash
 c8ctl element-template get-properties io.camunda.connectors.HttpJson.v2 url method
@@ -91,7 +92,7 @@ c8ctl element-template apply <id> <element> process.bpmn | c8ctl bpmn lint      
 
 Apply writes `zeebe:modelerTemplate`, `zeebe:modelerTemplateVersion`, `zeebe:modelerTemplateIcon`, `zeebe:taskDefinition`, the **entire `zeebe:ioMapping` block (inputs *and* outputs)**, and the `zeebe:taskHeaders` onto the element. All of those must stay consistent — `apply` owns them. In particular, custom `<zeebe:output>` mappings hand-added to a connector element will be wiped on the next `apply` — put downstream extraction on a separate activity, or on the next flow element's `<zeebe:ioMapping>` (end events accept it too).
 
-`apply` auto-resolves the latest OOTB template version compatible with the BPMN's `executionPlatformVersion`. The discovery commands (`search`, `info`, `get-properties`) are **not** engine-aware and always show the absolute latest template version, which may declare an engine constraint above your BPMN's version. Pin with `@<version>` (e.g. `io.camunda.connectors.HttpJson.v2@12`) on those commands to inspect what `apply` would actually pick.
+`apply` auto-resolves the latest OOTB template version compatible with the BPMN's `executionPlatformVersion`. Pass `--engine-version <x.y.z>` to `search`, `info`, or `get-properties` to apply the same engine-compatibility filter during discovery — `search` returns the latest compatible version per template, and `info` / `get-properties` resolve via the same check. *(c8ctl 3.2.0+)* A pinned `@<version>` (e.g. `io.camunda.connectors.HttpJson.v2@12`) always takes precedence over `--engine-version` and produces a warning when the two differ.
 
 ### Setting Property Values at Apply Time
 

--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -18,7 +18,7 @@ Browse and configure pre-built Camunda connectors using element templates. Apply
 
 - c8ctl CLI installed and configured (`c8ctl add profile`) — provides `c8ctl element-template` commands
 - **Local OOTB catalog synced** — run `c8ctl element-template sync` **once** before using `search`, `info`, `get-properties`, `get`, or `apply` with an OOTB template ID. Re-run (optionally with `--prune`) to pick up upstream changes. Applying a template from a local file path or `https://` URL bypasses the cache and does not require sync.
-- **c8ctl ≥ 3.2.0** for `--engine-version` and `--set` FEEL auto-`=`. If a flag is unrecognised, ask the user to upgrade: `npm install -g @camunda8/cli`
+- **c8ctl ≥ 3.2.0** for `bpmn format`, `--engine-version` on discovery commands, and `--set` FEEL auto-`=`. If a command or flag is unavailable, ask the user to upgrade: `npm install -g @camunda8/cli`
 
 ## Cross-References
 

--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -18,7 +18,7 @@ Browse and configure pre-built Camunda connectors using element templates. Apply
 
 - c8ctl CLI installed and configured (`c8ctl add profile`) — provides `c8ctl element-template` commands
 - **Local OOTB catalog synced** — run `c8ctl element-template sync` **once** before using `search`, `info`, `get-properties`, `get`, or `apply` with an OOTB template ID. Re-run (optionally with `--prune`) to pick up upstream changes. Applying a template from a local file path or `https://` URL bypasses the cache and does not require sync.
-- **c8ctl ≥ 3.2.0** for `bpmn format`, `--engine-version` on discovery commands, and `--set` FEEL auto-`=`. If a command or flag is unavailable, ask the user to upgrade: `npm install -g @camunda8/cli`
+- **c8ctl ≥ 3.2.0** for `--engine-version` on discovery commands and `--set` FEEL auto-`=`. If a command or flag is unavailable, ask the user to upgrade: `npm install -g @camunda8/cli`
 
 ## Cross-References
 

--- a/skills/camunda-connectors/SKILL.md
+++ b/skills/camunda-connectors/SKILL.md
@@ -118,7 +118,7 @@ Note the `string(userId)` wrapper — `userId` is a number and FEEL does not aut
 
 `apply` errors with a helpful list of valid names if you pass an unknown property, and with the qualified-name list if a bare key is ambiguous.
 
-**FEEL value syntax.** `feel: required` values must start with `=`. Use `--set key='=value'` (outer quotes make `=` obvious) or `--set 'key==value'` (compact). Avoid `--set 'key== value'` — the space writes `source="= ..."` and Modeler shows the property as un-set. `c8ctl` writes verbatim; check `get-properties --detailed <name>` when unsure.
+**FEEL value syntax.** `feel: required` values must start with `=`. The canonical form is `--set key='=value'`; `--set 'key==value'` (compact) also works. *(c8ctl 3.2.0+)* For `feel: required` properties, c8ctl auto-prepends `=` when the value doesn't start with one, so `--set key=expression` stores `=expression`; value-side whitespace is trimmed. Check `get-properties --detailed <name>` when unsure about the `feel` setting for a property.
 
 **Defaults bake in.** `apply` materializes every active property with a default into the BPMN — `<zeebe:input>`, `<zeebe:output>`, `<zeebe:taskHeaders>`, and `<zeebe:property>` entries — not just the keys you `--set`. The defaults are captured at apply time — if the template later ships a new default, this BPMN keeps the old value.
 

--- a/skills/camunda-connectors/references/element-template-schema.md
+++ b/skills/camunda-connectors/references/element-template-schema.md
@@ -10,7 +10,7 @@ When inspecting a template property (typically via `c8ctl element-template get-p
 2. **Does `constraints.notEmpty` apply?** → the property is required; `apply` will fail without a value.
 3. **Does `condition` apply?** → the property is active only when another property equals (or `oneOf`s) a specific value. Set the parent first.
 4. **What is `binding.type`?** → determines the BPMN XML the value lands in (`zeebe:input`, `zeebe:taskHeader`, etc. — see the mapping table below).
-5. **What is `feel`?** → `required` ⇒ value must start with `=`; c8ctl auto-prepends `=` for `--set` when absent *(c8ctl 3.2.0+)*. `optional` ⇒ plain literal or FEEL. `static` ⇒ raw value, persisted as FEEL automatically (Boolean, Number).
+5. **What is `feel`?** → `required` ⇒ value must start with `=`; c8ctl auto-prepends `=` for `--set` when absent. `optional` ⇒ plain literal or FEEL. `static` ⇒ raw value, persisted as FEEL automatically (Boolean, Number).
 6. **Is there a `value`?** → that's the default. Override only if needed.
 7. **Are there `choices`?** → the value must be one of them.
 

--- a/skills/camunda-connectors/references/element-template-schema.md
+++ b/skills/camunda-connectors/references/element-template-schema.md
@@ -10,7 +10,7 @@ When inspecting a template property (typically via `c8ctl element-template get-p
 2. **Does `constraints.notEmpty` apply?** → the property is required; `apply` will fail without a value.
 3. **Does `condition` apply?** → the property is active only when another property equals (or `oneOf`s) a specific value. Set the parent first.
 4. **What is `binding.type`?** → determines the BPMN XML the value lands in (`zeebe:input`, `zeebe:taskHeader`, etc. — see the mapping table below).
-5. **What is `feel`?** → `required` ⇒ value must start with `=`. `optional` ⇒ plain literal or FEEL. `static` ⇒ raw value, persisted as FEEL automatically (Boolean, Number).
+5. **What is `feel`?** → `required` ⇒ value must start with `=`; c8ctl auto-prepends `=` for `--set` when absent *(c8ctl 3.2.0+)*. `optional` ⇒ plain literal or FEEL. `static` ⇒ raw value, persisted as FEEL automatically (Boolean, Number).
 6. **Is there a `value`?** → that's the default. Override only if needed.
 7. **Are there `choices`?** → the value must be one of them.
 


### PR DESCRIPTION
## Description

Adapts skill guidance to three c8ctl improvements that shipped in 3.2.0 ([#397](https://github.com/camunda/c8ctl/pull/397), [#398](https://github.com/camunda/c8ctl/pull/398), [#400](https://github.com/camunda/c8ctl/pull/400)):

**`--engine-version` on discovery commands** (c8ctl issue [#396](https://github.com/camunda/c8ctl/issues/396), PR [#397](https://github.com/camunda/c8ctl/pull/397))
- `search`, `info`, and `get-properties` now accept `--engine-version <x.y.z>` to filter by engine compatibility — `search` returns the latest compatible version per template; `info`/`get-properties` resolve via the same check
- Retires the C-4 stopgap ("discovery commands are not engine-aware — pin with `@<version>`") in favour of the native flag

**`--set` FEEL auto-prepend and value trim** (c8ctl issue [#395](https://github.com/camunda/c8ctl/issues/395), PR [#398](https://github.com/camunda/c8ctl/pull/398))
- For `feel: required` properties, c8ctl auto-prepends `=` when the value doesn't start with one
- Value-side whitespace is trimmed (including after the `=` prefix); key names are not trimmed
- Keeps explicit `=expr` as the canonical form; surfaces auto-prepend as a safety net
- Removes the obsolete warning about leading whitespace after `=` producing invalid BPMN

**`c8ctl bpmn format`** (c8ctl issue [#399](https://github.com/camunda/c8ctl/issues/399), PR [#400](https://github.com/camunda/c8ctl/pull/400))
- New command that runs a bpmn-moddle round-trip (`fromXML` → `toXML({format:true})`) — the same canonicalization pass as Modeler save and `element-template apply`
- Documented in `AGENTS.md` and `camunda-bpmn/references/canonical-style.md` with usage examples and the re-read-after-format note

Closes #

## Checklist

- [x] `make lint` passes
- [x] Updated `SKILL.md` / `references/` if behaviour changed