### PR TITLE
docs(repo): make the eval suite a first-class, active maintainer directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,4 +64,6 @@ All skill tooling is unified under c8ctl plugin commands:
 
 ## Maintaining this repo
 
-Contributing to or maintaining the skills in this repo? See [CONTRIBUTING.md](CONTRIBUTING.md) for skill structure, the self-containment rule, cross-references, linting, evals, commit conventions, and the PR process. Working on the eval suite specifically? Start at [evals/README.md](evals/README.md).
+Contributing to or maintaining the skills in this repo? See [CONTRIBUTING.md](CONTRIBUTING.md) for skill structure, the self-containment rule, cross-references, linting, evals, commit conventions, and the PR process.
+
+**The skills have a behavioural eval suite (`evals/`), and it's meant to evolve with them.** When you add or change skill functionality, assess whether an eval should be added or adapted to cover it and raise it with the user — don't fabricate one where none earns its keep, but don't silently skip one that would catch a real failure mode. Evals are opt-in on CI and maintainer-gated by label: when a change warrants a run, the maintainer applies `evals:run` (skills the PR touches) or `evals:run-all` (whole suite) to the PR, or `evals:regenerate-baselines` after an intentional token-moving change. Surface this and suggest it — assume the user is a maintainer who can label — rather than waiting to be asked. Mechanics and the local loop: [evals/README.md](evals/README.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ skills/camunda-<name>/
 
 **Skills must be self-contained.** A skill directory is the unit of distribution — installers copy `skills/<name>/` into the consuming agent's skills path, and nothing else travels with it. `SKILL.md` and files under it may only reference paths inside their own skill directory or cross-reference other skills by name (see [SKILL.md Format](#skillmd-format)). Do not reach into sibling skills' `references/`/`scripts/`/`assets/`, and do not depend on any repo-level path. If two skills need the same asset, duplicate it or promote the shared content into a third skill that both cross-reference. This is what the [Agent Skills](https://agentskills.io) spec assumes, and it's why these skills work in Claude Code, Cursor, Copilot, Codex, Gemini CLI, and other compatible agents without modification.
 
-Eval suites are intentionally not checked in right now — see "Evals" below.
+Eval suites live at the repo root under `evals/`, not inside skill directories — skills must stay self-contained. See "Evals" below.
 
 ## SKILL.md Format
 
@@ -79,7 +79,12 @@ After install, the `azd waza` command is on PATH and `make lint` works. The Make
 The `evals/` suite verifies skills *work* — the right skill loads for a prompt,
 and the agent produces deployable, working artifacts. It's the behavioural gate
 alongside `waza check` (lint), built on [Inspect AI](https://inspect.aisi.org.uk/).
-Start at [`evals/README.md`](evals/README.md); the details live in three docs:
+Treat it as living: when you add or change skill functionality, assess whether an
+eval should cover it and discuss with a maintainer (don't fabricate one where
+none earns its keep); when a change warrants a CI run, label the PR `evals:run` /
+`evals:run-all`, or `evals:regenerate-baselines` after an intentional
+token-moving change. Start at [`evals/README.md`](evals/README.md); the details
+live in three docs:
 
 - [`evals/docs/concepts.md`](evals/docs/concepts.md) — the model: two kinds (trigger/outcome), two-phase sandbox, with/without-skill arms, the cost baseline
 - [`evals/docs/runbook.md`](evals/docs/runbook.md) — run · interpret · add · maintain evals (for contributors and AI agents)

--- a/evals/README.md
+++ b/evals/README.md
@@ -11,6 +11,7 @@ behavioural gate alongside `waza check` (lint); it's built on
 Prerequisites: [uv](https://docs.astral.sh/uv/); Docker for outcome evals only.
 
 ```bash
+export ANTHROPIC_API_KEY=sk-...                        # required — the evals call a model
 make run-trigger-evals SKILL=camunda-feel              # routing: does the skill load?  (no Docker)
 make build-docker-images                                   # one-time: build sandbox images
 make run-outcome-evals TARGET=skills/camunda-feel      # behaviour: does the agent get it right?


### PR DESCRIPTION
## Description

Agents (and users) were rediscovering the eval suite by poking around instead of being told it exists, and weren't proactively extending it or suggesting CI runs. Two root causes:

- **The always-loaded entry point said nothing about evals.** `AGENTS.md` (symlinked to `CLAUDE.md`) is the only file an agent reliably loads in this repo; its sole eval mention was a passive "Working on the eval suite specifically? Start at evals/README.md."
- **`CONTRIBUTING.md` actively lied:** "Eval suites are intentionally not checked in right now" — contradicted by the checked-in `evals/` tree and the Evals section directly below it. An agent reading that line concludes there's nothing to run or extend.

Changes:

- **`AGENTS.md` — passive pointer → active directive.** The suite is a living behavioural gate meant to evolve with the skills. When skill functionality changes, assess whether an eval should be added/adapted and raise it with the user. When a change warrants a run, actively suggest the maintainer label the PR (`evals:run` / `evals:run-all`, or `evals:regenerate-baselines` after an intentional token-moving change). Preserves the existing don't-fabricate-junk-evals stance.
- **`CONTRIBUTING.md` — fix the stale line** and add the same active framing to the Evals section.

Mechanics (local loop, labels, baselines) stay in `evals/README.md` and `evals/docs/` — these edits make the directive fire from the load-bearing surface without restating the details in a third place.

## Checklist

- [x] `make lint` passes
- [x] Updated `SKILL.md` / `references/` if behaviour changed
