### PR TITLE
feat(evals): support skills="all" sentinel for cross-skill scenarios

### DIFF
--- a/evals/scenarios/rocket-launch/outcomes.py
+++ b/evals/scenarios/rocket-launch/outcomes.py
@@ -20,7 +20,7 @@ from solvers.collect_artifacts import with_artifact_collection
 
 
 METADATA = EvalMetadata(
-    skills=["camunda-bpmn", "camunda-process-mgmt"],
+    skills="all",
     without_skill_excludes="all",
 )
 

--- a/evals/src/core/metadata.py
+++ b/evals/src/core/metadata.py
@@ -18,9 +18,11 @@ class EvalMetadata(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    skills: list[str] = Field(..., min_length=1)
+    skills: list[str] | Literal["all"] = Field(..., min_length=1)
     """Skills the eval depends on. CI-orchestration only (drives the
-    ``eval.yml`` path-filter); does NOT restrict the runtime skill surface."""
+    ``eval.yml`` path-filter); does NOT restrict the runtime skill surface.
+    ``"all"`` runs the eval on any skill change — use for cross-skill scenarios
+    that exercise the full catalog."""
 
     without_skill_excludes: list[str] | Literal["all"] | None = None
     """Skills the ``without_skill`` arm drops. Defaults to ``skills`` (drop the

--- a/evals/src/core/registry.py
+++ b/evals/src/core/registry.py
@@ -37,7 +37,7 @@ NAME_PATTERN = re.compile(r"^[a-z][a-z0-9-]*$")
 class EvalTarget:
     id: str  # "scenario:<id>" | "skill:<skill>" | "trigger:<skill>"
     kind: str
-    skills: list[str]
+    skills: list[str] | str  # str is the "all" sentinel
     path: str  # relative to EVALS_ROOT
     task: str | None = None  # explicit @task name, if any
     args: dict[str, str] = field(default_factory=dict)
@@ -102,7 +102,7 @@ def _outcome_targets(base: Path, scope: str) -> list[EvalTarget]:
             EvalTarget(
                 id=f"{scope}:{d.name}",
                 kind="outcome",
-                skills=list(meta.skills),
+                skills=meta.skills if meta.skills == "all" else list(meta.skills),
                 path=_rel(outcomes_py),
                 max_sandboxes=meta.max_sandboxes,
             )
@@ -146,7 +146,7 @@ def filter_by_changed_skills(
     targets: list[EvalTarget], changed_skills: list[str]
 ) -> list[EvalTarget]:
     changed = set(changed_skills)
-    return [t for t in targets if changed.intersection(t.skills)]
+    return [t for t in targets if t.skills == "all" or changed.intersection(t.skills)]
 
 
 def main() -> None:
@@ -174,7 +174,8 @@ def main() -> None:
         return
     print(f"{'id':<34} {'kind':<9} skills")
     for t in targets:
-        print(f"{t.id:<34} {t.kind:<9} {','.join(t.skills)}")
+        skills_str = t.skills if t.skills == "all" else ",".join(t.skills)
+        print(f"{t.id:<34} {t.kind:<9} {skills_str}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Adds a `skills="all"` sentinel to `EvalMetadata`, mirroring the existing `without_skill_excludes="all"` pattern. A scenario declaring `skills="all"` is included in the CI eval matrix whenever any skill changes, rather than requiring an explicit (and fragile) enumeration of every skill it exercises.

Cross-skill scenarios in `scenarios/` are inherently broadly dependent — maintaining a skill list there creates false negatives when new skills are added or the scenario is extended. `"all"` is the right default for them.

`rocket-launch` is switched to `skills="all"` as the first user (already had `without_skill_excludes="all"`, so the two sentinels now read symmetrically).

Closes #

## Checklist

- [ ] `make lint` passes
- [ ] Updated `SKILL.md` / `references/` if behaviour changed