### PR TITLE
feat: Improve camunda-c8ctl local cluster preflight guidance

### DIFF
--- a/skills/camunda-c8ctl/SKILL.md
+++ b/skills/camunda-c8ctl/SKILL.md
@@ -76,6 +76,24 @@ If the user hasn't decided and is doing local development, **suggest local c8run
 
 c8ctl ships with a default `cluster` plugin that wraps [c8run](https://docs.camunda.io/docs/self-managed/setup/deploy/local/c8run/). It downloads, starts, and stops a local Camunda 8 cluster for you.
 
+Before starting a new local cluster, run a quick preflight so you don't restart unnecessarily and you catch Java/runtime issues early:
+
+```bash
+# Is a local cluster already responding?
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/v2/topology
+
+# Is Java available (c8run needs JRE 21+)?
+java -version
+```
+
+- If topology returns `200`, a local cluster is already running; continue with your task.
+- If Java is missing or too old, install JRE/JDK 21+ first.
+- In some non-interactive shells, `java -version` can work while `JAVA_HOME` is still unset (common with `asdf`/`mise` shims). If startup fails even though Java is installed, set `JAVA_HOME` explicitly before `c8ctl cluster start`:
+
+```bash
+export JAVA_HOME="$(asdf where java 2>/dev/null || mise where java 2>/dev/null)"
+```
+
 **Examples**:
 
 ```bash
@@ -93,6 +111,9 @@ c8ctl cluster start alpha
 
 # Check status (running? what version? connection details?)
 c8ctl cluster status
+
+# Verify REST topology directly (HTTP 200 means ready)
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/v2/topology
 
 # Stream logs
 c8ctl cluster logs

--- a/skills/camunda-c8ctl/SKILL.md
+++ b/skills/camunda-c8ctl/SKILL.md
@@ -112,8 +112,8 @@ c8ctl cluster start alpha
 # Check status (running? what version? connection details?)
 c8ctl cluster status
 
-# Verify REST topology directly (HTTP 200 means ready)
-curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/v2/topology
+# Verify the cluster is responding after start
+c8ctl get topology
 
 # Stream logs
 c8ctl cluster logs

--- a/skills/camunda-c8ctl/references/local-cluster.md
+++ b/skills/camunda-c8ctl/references/local-cluster.md
@@ -80,12 +80,31 @@ An agent should *offer* these to the user rather than run them unprompted — in
 
 ## Common Workflows
 
+### Preflight: reuse an existing local cluster
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/v2/topology
+```
+
+If this returns `200`, a local cluster is already serving requests on `localhost:8080` and you can skip `c8ctl cluster start`.
+
 ### First-time local setup
 
 ```bash
 # One command — downloads binary, starts cluster, waits until healthy
 c8ctl cluster start
 c8ctl get topology   # confirm it's alive
+```
+
+### Java shim pitfall (asdf / mise)
+
+`c8ctl cluster start` runs c8run as a child process. In non-interactive shells, tool-manager shims can make `java -version` succeed while `JAVA_HOME` is still unset for child processes, which can cause startup failures.
+
+If Java is managed by asdf or mise and startup fails unexpectedly, set `JAVA_HOME` explicitly before starting the cluster:
+
+```bash
+export JAVA_HOME="$(asdf where java 2>/dev/null || mise where java 2>/dev/null)"
+c8ctl cluster start
 ```
 
 ### Switching between rolling minors


### PR DESCRIPTION
## Summary
This PR promotes the first public-safe improvement from the #62 list into `camunda-c8ctl` by strengthening local environment setup guidance.

## Source skill reference
Extracted from ProcessOS skill:
- `process-os-environment-setup` (`process-os/skills/process-os-environment-setup/SKILL.md`)

## What changed
1. Added a local preflight section to `skills/camunda-c8ctl/SKILL.md`:
   - topology probe to detect an already-running local cluster
   - explicit Java prerequisite check for c8run (JRE/JDK 21+)
   - `asdf`/`mise` `JAVA_HOME` troubleshooting for non-interactive shells
2. Added matching reusable guidance to `skills/camunda-c8ctl/references/local-cluster.md`:
   - preflight cluster reuse check
   - Java shim pitfall + mitigation snippet

## Public-safe boundary
Included only generic c8ctl/c8run setup and troubleshooting patterns.
No ProcessOS lifecycle/governance/state-file conventions were copied.

## Issue
Refs #62

closes #62
