### PR TITLE
Add onboarding readiness checks to camunda-c8ctl

### DIFF
--- a/skills/camunda-c8ctl/SKILL.md
+++ b/skills/camunda-c8ctl/SKILL.md
@@ -51,7 +51,7 @@ c8ctl which profile 2>/dev/null || echo "no active profile"
 c8ctl cluster status 2>/dev/null || echo "local cluster: not running"
 ```
 
-- **Node.js** and **c8ctl** are required. If either is missing, install before continuing.
+- **Node.js** and **c8ctl** are required. Node must be **≥ 22.18.0**. If either is missing (or Node is older), install/upgrade before continuing.
 - If any default plugin is missing, the installed c8ctl is older than 3.0.0. **Ask the user to confirm before upgrading** — don't run the install unprompted — then run `npm install -g @camunda8/cli`.
 - Missing profile/local cluster is not an error; it only means profile or cluster setup is still pending.
 

--- a/skills/camunda-c8ctl/SKILL.md
+++ b/skills/camunda-c8ctl/SKILL.md
@@ -28,6 +28,33 @@ Install and use [c8ctl](https://github.com/camunda/c8ctl) — the minimal-depend
 
 ## Instructions
 
+### Quick readiness check (onboarding)
+
+Use this quick check when a user is new to c8ctl and you want to confirm the machine is ready before deeper setup:
+
+```bash
+# Required runtime
+node --version 2>/dev/null || echo "NOT FOUND"
+
+# Required CLI
+c8ctl --version 2>/dev/null || echo "NOT FOUND"
+
+# Required default plugins for camunda-* skills
+c8ctl bpmn --help >/dev/null 2>&1 && echo "bpmn: OK" || echo "bpmn: MISSING"
+c8ctl element-template --help >/dev/null 2>&1 && echo "element-template: OK" || echo "element-template: MISSING"
+c8ctl feel --help >/dev/null 2>&1 && echo "feel: OK" || echo "feel: MISSING"
+
+# Optional: check current active profile
+c8ctl which profile 2>/dev/null || echo "no active profile"
+
+# Optional: check whether a local c8run cluster is already running
+c8ctl cluster status 2>/dev/null || echo "local cluster: not running"
+```
+
+- **Node.js** and **c8ctl** are required. If either is missing, install before continuing.
+- If any default plugin is missing, upgrade c8ctl to a current version (`npm install -g @camunda8/cli`).
+- Missing profile/local cluster is not an error; it only means profile or cluster setup is still pending.
+
 ### Install
 
 Install c8ctl globally from npm. The other camunda-* skills depend on the `bpmn`, `element-template`, and `feel` plugins, which require **c8ctl ≥ 3.0.0**:

--- a/skills/camunda-c8ctl/SKILL.md
+++ b/skills/camunda-c8ctl/SKILL.md
@@ -52,7 +52,7 @@ c8ctl cluster status 2>/dev/null || echo "local cluster: not running"
 ```
 
 - **Node.js** and **c8ctl** are required. If either is missing, install before continuing.
-- If any default plugin is missing, upgrade c8ctl to a current version (`npm install -g @camunda8/cli`).
+- If any default plugin is missing, the installed c8ctl is older than 3.0.0. **Ask the user to confirm before upgrading** — don't run the install unprompted — then run `npm install -g @camunda8/cli`.
 - Missing profile/local cluster is not an error; it only means profile or cluster setup is still pending.
 
 ### Install


### PR DESCRIPTION
## Summary
This PR migrates the next public-safe item from issue #62: onboarding setup checks from ProcessOS into `camunda-c8ctl`.

## Source skill reference
Extracted from ProcessOS skill:
- `process-os-onboarding` (`process-os/skills/process-os-onboarding/SKILL.md`)

## What changed
Added a new section to `skills/camunda-c8ctl/SKILL.md`:
- **Quick readiness check (onboarding)**
- Includes a generic setup checklist for:
  - Node.js presence
  - c8ctl presence
  - default plugin availability (`bpmn`, `element-template`, `feel`)
  - active profile visibility
  - local cluster status
- Adds interpretation guidance for required vs optional checks.

## Public-safe boundary
Included only generic, reusable machine/setup checks.
Excluded ProcessOS-only content (lifecycle/governance commands, project-state checks, and internal workflow narration).

## Issue
Refs #62

closes #62
