### PR TITLE
Add form schema linting workflow to camunda-forms

### DIFF
--- a/skills/camunda-forms/SKILL.md
+++ b/skills/camunda-forms/SKILL.md
@@ -198,11 +198,12 @@ npm install --save-dev ajv ajv-errors @bpmn-io/form-json-schema
 cat > validate-form.cjs << 'EOF'
 const Ajv = require('ajv');
 const addErrors = require('ajv-errors');
+const fs = require('fs');
 const schema = require('@bpmn-io/form-json-schema/resources/schema.json');
 const file = process.argv[2];
 if (!file) { console.error('Usage: node validate-form.cjs <form-file>'); process.exit(1); }
 let form;
-try { form = JSON.parse(require('fs').readFileSync(file, 'utf8')); }
+try { form = JSON.parse(fs.readFileSync(file, 'utf8')); }
 catch (e) { console.error(`Cannot read/parse ${file}: ${e.message}`); process.exit(1); }
 const ajv = new Ajv({ allErrors: true, strict: false });
 addErrors(ajv);

--- a/skills/camunda-forms/SKILL.md
+++ b/skills/camunda-forms/SKILL.md
@@ -195,6 +195,7 @@ After creating or editing `.form` files, validate them against the official Camu
 ```bash
 npm install --save-dev ajv ajv-errors @bpmn-io/form-json-schema
 
+# Write the validation helper (add validate-form.cjs to .gitignore if you don't want to commit it)
 cat > validate-form.cjs << 'EOF'
 const Ajv = require('ajv');
 const addErrors = require('ajv-errors');
@@ -215,13 +216,14 @@ EOF
 node validate-form.cjs path/to/form.form
 ```
 
-For multiple forms, loop over each file and keep fixing until all validate cleanly:
+For multiple forms (including nested directories), loop over every file and collect all failures before exiting:
 
 ```bash
 failed=0
-for f in *.form; do
+# Use find for recursive discovery; replace with *.form for flat directories
+while IFS= read -r f; do
   node validate-form.cjs "$f" || { echo "FAILED: $f"; failed=1; }
-done
+done < <(find . -name '*.form' -not -path '*/node_modules/*')
 exit $failed
 ```
 

--- a/skills/camunda-forms/SKILL.md
+++ b/skills/camunda-forms/SKILL.md
@@ -188,6 +188,29 @@ Generate complete `.form` JSON files. Ensure:
 - `layout.row` values increment sequentially (`row_0`, `row_1`, ...)
 - Metadata fields are present and correct
 
+### Schema Validation Loop (Lint Before Deploy)
+
+After creating or editing `.form` files, validate them against the official Camunda form schema before deployment:
+
+```bash
+npm install --save-dev ajv-cli @bpmn-io/form-json-schema
+npx ajv validate \
+  -s node_modules/@bpmn-io/form-json-schema/resources/schema.json \
+  -d path/to/form.form
+```
+
+For multiple forms, run the same command per file (or script over `*.form`) and keep fixing until all files validate cleanly.
+
+Common schema keywords and fixes:
+
+| Keyword | Typical meaning | Typical fix |
+|---|---|---|
+| `required` | Required field missing | Add the missing property named in the error message |
+| `additionalProperties` | Unknown property for this object | Remove the unsupported property |
+| `type` | Wrong JSON value type | Change value to the expected type (string/number/boolean/object/array) |
+| `enum` / `const` | Value not in allowed set | Replace with one of the allowed values |
+| `pattern` | String format invalid (often `id`/`key`) | Rename to match the required regex (usually alnum/underscore style) |
+
 ## Troubleshooting
 
 - **Form doesn't appear in Tasklist** — verify the user task in BPMN includes `<zeebe:userTask/>` and `<zeebe:formDefinition formId="..."/>` matching the form's `id` field. The legacy `formKey` attribute was removed in Camunda 8.10.

--- a/skills/camunda-forms/SKILL.md
+++ b/skills/camunda-forms/SKILL.md
@@ -199,11 +199,15 @@ cat > validate-form.cjs << 'EOF'
 const Ajv = require('ajv');
 const addErrors = require('ajv-errors');
 const schema = require('@bpmn-io/form-json-schema/resources/schema.json');
-const form = JSON.parse(require('fs').readFileSync(process.argv[2], 'utf8'));
+const file = process.argv[2];
+if (!file) { console.error('Usage: node validate-form.cjs <form-file>'); process.exit(1); }
+let form;
+try { form = JSON.parse(require('fs').readFileSync(file, 'utf8')); }
+catch (e) { console.error(`Cannot read/parse ${file}: ${e.message}`); process.exit(1); }
 const ajv = new Ajv({ allErrors: true, strict: false });
 addErrors(ajv);
 const validate = ajv.compile(schema);
-if (!validate(form)) { console.error(ajv.errorsText(validate.errors)); process.exit(1); }
+if (!validate(form)) { console.error(JSON.stringify(validate.errors, null, 2)); process.exit(1); }
 console.log('Valid ✓');
 EOF
 
@@ -213,7 +217,11 @@ node validate-form.cjs path/to/form.form
 For multiple forms, loop over each file and keep fixing until all validate cleanly:
 
 ```bash
-for f in *.form; do node validate-form.cjs "$f" || echo "FAILED: $f"; done
+failed=0
+for f in *.form; do
+  node validate-form.cjs "$f" || { echo "FAILED: $f"; failed=1; }
+done
+exit $failed
 ```
 
 Common schema keywords and fixes:

--- a/skills/camunda-forms/SKILL.md
+++ b/skills/camunda-forms/SKILL.md
@@ -195,14 +195,14 @@ After creating or editing `.form` files, validate them against the official Camu
 ```bash
 npm install --save-dev ajv ajv-errors @bpmn-io/form-json-schema
 
-# Write the validation helper (add validate-form.cjs to .gitignore if you don't want to commit it)
+# Create the validation helper and commit it as a project tool
 cat > validate-form.cjs << 'EOF'
 const Ajv = require('ajv');
 const addErrors = require('ajv-errors');
 const fs = require('fs');
 const schema = require('@bpmn-io/form-json-schema/resources/schema.json');
 const file = process.argv[2];
-if (!file) { console.error('Usage: node validate-form.cjs <form-file>'); process.exit(1); }
+if (!file) { console.error('Usage: node validate-form.cjs <path-to-form.form>'); process.exit(1); }
 let form;
 try { form = JSON.parse(fs.readFileSync(file, 'utf8')); }
 catch (e) { console.error(`Cannot read/parse ${file}: ${e.message}`); process.exit(1); }

--- a/skills/camunda-forms/SKILL.md
+++ b/skills/camunda-forms/SKILL.md
@@ -190,16 +190,32 @@ Generate complete `.form` JSON files. Ensure:
 
 ### Schema Validation Loop (Lint Before Deploy)
 
-After creating or editing `.form` files, validate them against the official Camunda form schema before deployment:
+After creating or editing `.form` files, validate them against the official Camunda form schema before deployment. Use `ajv` with the `ajv-errors` plugin directly — `ajv-cli` cannot be used because the schema uses the `errorMessage` keyword that `ajv-cli` does not support:
 
 ```bash
-npm install --save-dev ajv-cli @bpmn-io/form-json-schema
-npx ajv validate \
-  -s node_modules/@bpmn-io/form-json-schema/resources/schema.json \
-  -d path/to/form.form
+npm install --save-dev ajv ajv-errors @bpmn-io/form-json-schema
+
+cat > /tmp/validate-form.cjs << 'EOF'
+const Ajv = require('ajv');
+const addErrors = require('ajv-errors');
+const schema = require('@bpmn-io/form-json-schema/resources/schema.json');
+const form = JSON.parse(require('fs').readFileSync(process.argv[2], 'utf8'));
+const ajv = new Ajv({ allErrors: true, strict: false });
+addErrors(ajv);
+const validate = ajv.compile(schema);
+if (!validate(form)) { console.error(ajv.errorsText(validate.errors)); process.exit(1); }
+console.log('Valid ✓');
+EOF
+
+# NODE_PATH points to the project's node_modules so the script can find the packages
+NODE_PATH=$(pwd)/node_modules node /tmp/validate-form.cjs path/to/form.form
 ```
 
-For multiple forms, run the same command per file (or script over `*.form`) and keep fixing until all files validate cleanly.
+For multiple forms, loop over each file and keep fixing until all validate cleanly:
+
+```bash
+for f in *.form; do NODE_PATH=$(pwd)/node_modules node /tmp/validate-form.cjs "$f" || echo "FAILED: $f"; done
+```
 
 Common schema keywords and fixes:
 

--- a/skills/camunda-forms/SKILL.md
+++ b/skills/camunda-forms/SKILL.md
@@ -190,12 +190,12 @@ Generate complete `.form` JSON files. Ensure:
 
 ### Schema Validation Loop (Lint Before Deploy)
 
-After creating or editing `.form` files, validate them against the official Camunda form schema before deployment. Use `ajv` with the `ajv-errors` plugin directly — `ajv-cli` cannot be used because the schema uses the `errorMessage` keyword that `ajv-cli` does not support:
+After creating or editing `.form` files, validate them against the official Camunda form schema before deployment. Use `ajv` with the `ajv-errors` plugin directly — `ajv-cli` cannot be used because the schema uses the `errorMessage` keyword that `ajv-cli` does not support. Run all commands from the **project root**:
 
 ```bash
 npm install --save-dev ajv ajv-errors @bpmn-io/form-json-schema
 
-cat > /tmp/validate-form.cjs << 'EOF'
+cat > validate-form.cjs << 'EOF'
 const Ajv = require('ajv');
 const addErrors = require('ajv-errors');
 const schema = require('@bpmn-io/form-json-schema/resources/schema.json');
@@ -207,14 +207,13 @@ if (!validate(form)) { console.error(ajv.errorsText(validate.errors)); process.e
 console.log('Valid ✓');
 EOF
 
-# NODE_PATH points to the project's node_modules so the script can find the packages
-NODE_PATH=$(pwd)/node_modules node /tmp/validate-form.cjs path/to/form.form
+node validate-form.cjs path/to/form.form
 ```
 
 For multiple forms, loop over each file and keep fixing until all validate cleanly:
 
 ```bash
-for f in *.form; do NODE_PATH=$(pwd)/node_modules node /tmp/validate-form.cjs "$f" || echo "FAILED: $f"; done
+for f in *.form; do node validate-form.cjs "$f" || echo "FAILED: $f"; done
 ```
 
 Common schema keywords and fixes:

--- a/skills/camunda-forms/SKILL.md
+++ b/skills/camunda-forms/SKILL.md
@@ -190,7 +190,7 @@ Generate complete `.form` JSON files. Ensure:
 
 ### Schema Validation Loop (Lint Before Deploy)
 
-After creating or editing `.form` files, validate them against the official Camunda form schema before deployment. Use `ajv` with the `ajv-errors` plugin directly — `ajv-cli` cannot be used because the schema uses the `errorMessage` keyword that `ajv-cli` does not support. Run all commands from the **project root**:
+After creating or editing `.form` files, validate them against the official Camunda form schema before deployment. Use `ajv` with the `ajv-errors` plugin directly. A plain `ajv-cli` invocation fails on this schema because it uses the `errorMessage` keyword; if you use `ajv-cli`, load `ajv-errors` via `--require`. Run all commands from the **project root**:
 
 ```bash
 npm install --save-dev ajv ajv-errors @bpmn-io/form-json-schema


### PR DESCRIPTION
## Summary
This PR migrates the public-safe forms linting capability from ProcessOS into `camunda-forms`.

## Source skill reference
Extracted from ProcessOS skill:
- `process-os-forms-linting` (`process-os/skills/process-os-forms-linting/SKILL.md`)

## What changed
Added a **Schema Validation Loop (Lint Before Deploy)** section to `skills/camunda-forms/SKILL.md` with:
- validation against the official `@bpmn-io/form-json-schema`
- a repeat-until-clean fix loop
- common JSON-schema keyword diagnostics (`required`, `additionalProperties`, `type`, `enum`/`const`, `pattern`) and concrete fix directions

## Public-safe boundary
Included only generic schema-validation guidance for `.form` files.
Excluded ProcessOS-specific validator scripts, internal folder assumptions, and lifecycle orchestration context.

## Issue
Refs #62

closes #62
