### PR TITLE
Improve deploy preflight guidance in camunda-process-mgmt

### DIFF
--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -83,8 +83,8 @@ Example:
 c8ctl deploy \
   src/main/resources/processes \
   src/main/resources/decisions \
-  src/main/resources/forms
-```
+  src/main/resources/forms \
+  --profile=local
 
 After deploying, verify:
 

--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -62,6 +62,30 @@ Deploy an entire directory (recursive):
 c8ctl deploy ./my-project
 ```
 
+Pre-deploy checks (recommended):
+
+1. Lint BPMN before deployment:
+
+   ```bash
+   c8ctl bpmn lint process.bpmn
+   ```
+
+2. Validate DMN and form files if present (see **camunda-dmn** and **camunda-forms** workflows), then deploy only the resources that are ready.
+
+Spring Boot resource-tree tip:
+
+- In projects that keep deployables under `src/main/resources/`, prefer deploying `processes/`, `decisions/`, and `forms/` paths explicitly.
+- Avoid deploying the parent `src/main/resources` directory wholesale when it contains non-deployable files (`application.yaml`, `application.properties`, etc.).
+
+Example:
+
+```bash
+c8ctl deploy \
+  src/main/resources/processes \
+  src/main/resources/decisions \
+  src/main/resources/forms
+```
+
 After deploying, verify:
 
 ```bash

--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -85,6 +85,7 @@ c8ctl deploy \
   src/main/resources/decisions \
   src/main/resources/forms \
   --profile=local
+```
 
 After deploying, verify:
 


### PR DESCRIPTION
## Summary
This PR migrates the public-safe deployment improvements from ProcessOS into `camunda-process-mgmt`.

## Source skill reference
Extracted from ProcessOS skill:
- `process-os-deployment` (`process-os/skills/process-os-deployment/SKILL.md`)

## What changed
Enhanced the **Deploying Resources** section in `skills/camunda-process-mgmt/SKILL.md` with:
- a recommended pre-deploy lint/validation pass
- guidance to deploy only deploy-ready categories
- explicit Spring resource-tree deployment guidance to target `processes/`, `decisions/`, and `forms/` subdirectories
- warning against deploying parent directories that include non-resource files (for example `application.yaml`)

## Public-safe boundary
Included only generic deploy runbook guidance.
Excluded ProcessOS lifecycle state updates, governance gating, and internal directory conventions.

## Issue
Refs #62

closes #62
