### PR TITLE
Add CPT environment readiness preflight

### DIFF
--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -51,7 +51,7 @@ Check `pom.xml` (or `test/pom.xml`) for `camunda-process-test-spring`. If missin
 
 ### 2. Setup (only if missing)
 
-Follow [references/setup.md](references/setup.md): verify Java 21+, Maven, Docker; add the CPT dependency; scaffold `src/test/java/io/camunda/tests/ProcessTest.java` and `src/test/resources/scenarios/`. Confirm with `mvn test-compile`.
+Follow [references/setup.md](references/setup.md): run the readiness preflight (Java, Maven/wrapper, Docker), add the CPT dependency, scaffold `src/test/java/io/camunda/tests/ProcessTest.java` and `src/test/resources/scenarios/`. Confirm with `mvn test-compile`.
 
 ### 3. Plan segments (set-cover, not per-element)
 

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -24,10 +24,10 @@ java -version
 ./mvnw -version 2>/dev/null || mvn -version
 
 # Docker runtime
-docker info
+docker info --format '{{.ServerVersion}}'
 ```
 
-If Docker is not running, start your runtime (Docker Desktop, OrbStack, or Rancher Desktop) and re-run `docker info`.
+If Docker is not running, start your runtime (Docker Desktop, OrbStack, or Rancher Desktop) and re-run `docker info --format '{{.ServerVersion}}'`.
 
 If Java or Maven resolves in an interactive shell but fails in non-interactive runs, check tool-manager shims (`asdf`/`mise`) and set the project toolchain explicitly (for example via `.tool-versions`) before running CPT.
 

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -12,6 +12,25 @@ See **camunda-development** for installing these locally.
 
 > Testcontainers pulls the matching Zeebe image automatically on first run (~500MB). Do not pre-pull `camunda/zeebe:latest` — the tag may not match the CPT version on the classpath.
 
+## Readiness preflight (first run)
+
+Run this quick check before scaffolding:
+
+```bash
+# Java runtime
+java -version
+
+# Maven (prefer wrapper when present)
+./mvnw -version 2>/dev/null || mvn -version
+
+# Docker runtime
+docker info
+```
+
+If Docker is not running, start your runtime (Docker Desktop, OrbStack, or Rancher Desktop) and re-run `docker info`.
+
+If Java or Maven resolves in an interactive shell but fails in non-interactive runs, check tool-manager shims (`asdf`/`mise`) and set the project toolchain explicitly (for example via `.tool-versions`) before running CPT.
+
 ## CPT dependency
 
 Required entry in the project (or test harness) `pom.xml`:


### PR DESCRIPTION
## Summary
This PR migrates public-safe CPT environment setup guidance from ProcessOS into `camunda-process-test`.

## Source skill reference
Extracted from ProcessOS skill:
- `process-os-test-environment-setup` (`process-os/skills/process-os-test-environment-setup/SKILL.md`)

## What changed
- Added a **Readiness preflight (first run)** section to `skills/camunda-process-test/references/setup.md` with explicit checks for:
  - Java runtime
  - Maven (preferring wrapper)
  - Docker runtime
- Added troubleshooting note for tool-manager shim mismatches (`asdf`/`mise`) in non-interactive runs.
- Updated the setup step in `skills/camunda-process-test/SKILL.md` to explicitly call out the readiness preflight.

## Public-safe boundary
Included only generic CPT environment readiness guidance.
Excluded ProcessOS-specific local state files, lifecycle mechanics, and SaaS/test-orchestration internals.

## Issue
Refs #62

closes #62
