### PR TITLE
Add generic multi-artifact orchestration guidance to camunda-development

### DIFF
--- a/skills/camunda-development/SKILL.md
+++ b/skills/camunda-development/SKILL.md
@@ -95,10 +95,10 @@ When a process spans multiple service tasks, user tasks, and business-rule tasks
    - BPMN execution wiring updates
 4. Run domain validation loops:
    - BPMN: `c8ctl bpmn lint` (and compatibility checks as needed)
-   - DMN: `npx dmnlint` (structural) + FEEL/hit-policy test execution (see **camunda-dmn**)
+   - DMN: `npx --yes dmnlint` (structural) + FEEL/hit-policy test execution (see **camunda-dmn**)
    - Forms: JSON schema validity — required fields, `schemaVersion`, component `key` uniqueness (see **camunda-forms**)
 5. Run a cross-artifact wiring audit before deployment:
-   - every non-connector `taskDefinition type` is implemented by a worker
+   - every non-connector `taskDefinition type` (typically values **without** connector-style colons, e.g. `check-credit`) is implemented by a worker; connector runtime task types (for example `io.camunda:slack:1`) are resolved by connector templates/runtime, not custom workers
    - every referenced `formId` exists and matches form `id`
    - every referenced `decisionId` exists in deployed DMN resources
 6. Deploy only categories that are validation-clean; if a category is intentionally excluded, record that explicitly and keep release status as partial until fixed.

--- a/skills/camunda-development/SKILL.md
+++ b/skills/camunda-development/SKILL.md
@@ -95,8 +95,8 @@ When a process spans multiple service tasks, user tasks, and business-rule tasks
    - BPMN execution wiring updates
 4. Run domain validation loops:
    - BPMN: `c8ctl bpmn lint` (and compatibility checks as needed)
-   - DMN: decision/table linting and test execution
-   - Forms: JSON schema validation
+   - DMN: `npx dmnlint` (structural) + FEEL/hit-policy test execution (see **camunda-dmn**)
+   - Forms: JSON schema validity — required fields, `schemaVersion`, component `key` uniqueness (see **camunda-forms**)
 5. Run a cross-artifact wiring audit before deployment:
    - every non-connector `taskDefinition type` is implemented by a worker
    - every referenced `formId` exists and matches form `id`

--- a/skills/camunda-development/SKILL.md
+++ b/skills/camunda-development/SKILL.md
@@ -79,6 +79,32 @@ The table is the why behind the matrix: connectors trade language reach for reus
 
 Workers and connectors are a **per-task** choice, not a per-project one. A single Spring Boot application can host job workers (via the Camunda Spring Boot Starter) and an embedded connector runtime (via `spring-boot-starter-camunda-connectors`) side by side — the Connectors SDK itself builds on the Spring Boot Starter. Pick the right shape for each integration; you do not need to commit the whole project to one path.
 
+## Multi-artifact delivery orchestration (BPMN + workers + DMN + forms)
+
+When a process spans multiple service tasks, user tasks, and business-rule tasks, orchestrate implementation as a structured handoff instead of ad-hoc generation:
+
+1. Build an explicit implementation plan from the BPMN:
+   - service task / message event integration points → connector or worker path
+   - user tasks with `formId` → `.form` deliverables
+   - business-rule tasks with `decisionId` → `.dmn` deliverables
+2. Review and approve that plan before generating artifacts.
+3. Implement independent domains in parallel where safe:
+   - workers/connectors
+   - DMN decisions
+   - forms
+   - BPMN execution wiring updates
+4. Run domain validation loops:
+   - BPMN: `c8ctl bpmn lint` (and compatibility checks as needed)
+   - DMN: decision/table linting and test execution
+   - Forms: JSON schema validation
+5. Run a cross-artifact wiring audit before deployment:
+   - every non-connector `taskDefinition type` is implemented by a worker
+   - every referenced `formId` exists and matches form `id`
+   - every referenced `decisionId` exists in deployed DMN resources
+6. Deploy only categories that are validation-clean; if a category is intentionally excluded, record that explicitly and keep release status as partial until fixed.
+
+This keeps large Camunda deliveries deterministic, reviewable, and safe to iterate.
+
 ## Inbound is a connector concern
 
 Inbound triggers — events flowing *into* a process from an external system — are implemented only via the Connectors SDK. There is no job-worker path for inbound: job workers exclusively handle outbound jobs the engine has already activated.


### PR DESCRIPTION
## Summary
This PR migrates the public-safe orchestration patterns from ProcessOS artifact generation into `camunda-development`.

## Source skill reference
Extracted from ProcessOS skill:
- `process-os-artifact-generation` (`process-os/skills/process-os-artifact-generation/SKILL.md`)

## What changed
Added a new section to `skills/camunda-development/SKILL.md`:
- **Multi-artifact delivery orchestration (BPMN + workers + DMN + forms)**

The section covers generic orchestration guidance for larger deliveries:
- explicit implementation planning from BPMN
- review gate before generation
- safe parallelization by domain
- per-domain validation loops
- cross-artifact wiring audit before deployment
- partial-release discipline when categories are excluded

## Public-safe boundary
Included only generic orchestration mechanics.
Excluded ProcessOS-only internals (tier resolution, `.camunda/*` state handling, governance/lifecycle phase events, plugin/script internals, snapshot/memory conventions).

## Issue
Refs #62

closes #62
