### PR TITLE
feat(camunda-process-mgmt): clarify process start verb selection

### DIFF
--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -140,7 +140,7 @@ c8ctl await pi --id MyProcess --requestTimeout 60000
 
 **Not for long-running activities.** `await pi` uses the cluster's start-and-wait REST endpoint, which times out before any single activity that runs longer than the request timeout (LLM agents, slow HTTP calls, user tasks). The timed-out response carries no instance key, so you can't follow up on the partial run. For those processes, use `c8ctl create pi` and poll `c8ctl get pi <key>` until terminal state, or fall back to `c8ctl search pi --state=ACTIVE` to recover the orphaned instance after a failed `await`.
 
-For scripting, run `create pi` with `--json`, capture the `processInstanceKey` field, then use it for follow-up operations (`c8ctl get pi <key>`, `c8ctl cancel pi <key>`, incident lookups by process-instance key).
+For scripting, run `create pi` with `--json`, capture the returned `key` field (the process-instance key), then use it for follow-up operations (`c8ctl get pi <key>`, `c8ctl cancel pi <key>`, incident lookups by process-instance key).
 
 ### Watch Mode (Development)
 

--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -102,9 +102,9 @@ Pick the start verb by intent:
 
 | Need | Command |
 |---|---|
-| Start and return immediately (default) | `c8ctl create pi` |
-| Deploy + start in one shot | `c8ctl run` |
-| Start and block until completion | `c8ctl await pi` |
+| Start and return immediately (default) | `c8ctl create pi --id <bpmnProcessId> [--variables '{...}']` |
+| Deploy + start in one shot | `c8ctl run <file.bpmn> [--variables '{...}']` |
+| Start and block until completion | `c8ctl await pi --id <bpmnProcessId> [--variables '{...}']` |
 
 Create an instance for a deployed process:
 
@@ -140,7 +140,7 @@ c8ctl await pi --id MyProcess --requestTimeout 60000
 
 **Not for long-running activities.** `await pi` uses the cluster's start-and-wait REST endpoint, which times out before any single activity that runs longer than the request timeout (LLM agents, slow HTTP calls, user tasks). The timed-out response carries no instance key, so you can't follow up on the partial run. For those processes, use `c8ctl create pi` and poll `c8ctl get pi <key>` until terminal state, or fall back to `c8ctl search pi --state=ACTIVE` to recover the orphaned instance after a failed `await`.
 
-For `create pi`, capture the returned `processInstanceKey` and use it for follow-up operations (`c8ctl get pi <key>`, `c8ctl cancel pi <key>`, incident lookups by process-instance key).
+For scripting, run `create pi` with `--json`, capture the `processInstanceKey` field, then use it for follow-up operations (`c8ctl get pi <key>`, `c8ctl cancel pi <key>`, incident lookups by process-instance key).
 
 ### Watch Mode (Development)
 

--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -104,7 +104,7 @@ Pick the start verb by intent:
 |---|---|
 | Start and return immediately (default) | `c8ctl create pi` |
 | Deploy + start in one shot | `c8ctl run` |
-| Start and block until terminal state | `c8ctl await pi` |
+| Start and block until completion | `c8ctl await pi` |
 
 Create an instance for a deployed process:
 

--- a/skills/camunda-process-mgmt/SKILL.md
+++ b/skills/camunda-process-mgmt/SKILL.md
@@ -98,6 +98,14 @@ Each deployment creates a new version of any resource it contains. Use `c8ctl li
 
 ### Starting Process Instances
 
+Pick the start verb by intent:
+
+| Need | Command |
+|---|---|
+| Start and return immediately (default) | `c8ctl create pi` |
+| Deploy + start in one shot | `c8ctl run` |
+| Start and block until terminal state | `c8ctl await pi` |
+
 Create an instance for a deployed process:
 
 ```bash
@@ -109,6 +117,8 @@ With input variables:
 ```bash
 c8ctl create pi --id MyProcess --variables '{"orderId": "ORD-123", "amount": 1500}'
 ```
+
+`--id` maps to `<bpmn:process id="...">` (the BPMN process ID), not the numeric process-definition key.
 
 Deploy and start in one step:
 
@@ -129,6 +139,8 @@ c8ctl await pi --id MyProcess --requestTimeout 60000
 ```
 
 **Not for long-running activities.** `await pi` uses the cluster's start-and-wait REST endpoint, which times out before any single activity that runs longer than the request timeout (LLM agents, slow HTTP calls, user tasks). The timed-out response carries no instance key, so you can't follow up on the partial run. For those processes, use `c8ctl create pi` and poll `c8ctl get pi <key>` until terminal state, or fall back to `c8ctl search pi --state=ACTIVE` to recover the orphaned instance after a failed `await`.
+
+For `create pi`, capture the returned `processInstanceKey` and use it for follow-up operations (`c8ctl get pi <key>`, `c8ctl cancel pi <key>`, incident lookups by process-instance key).
 
 ### Watch Mode (Development)
 


### PR DESCRIPTION
## Summary
- generalize ProcessOS process-instance-start guidance into camunda-process-mgmt
- add a create/run/await verb-selection table for fast command choice
- clarify --id semantics and follow-up usage of returned processInstanceKey

related to #62

## Notes
- make lint SKILL=camunda-process-mgmt could not run locally because waza is not installed in this environment.

closes #62
