### PR TITLE
feat(camunda-dmn): add directory linting workflow guidance

### DIFF
--- a/skills/camunda-dmn/SKILL.md
+++ b/skills/camunda-dmn/SKILL.md
@@ -98,6 +98,8 @@ Two layers — run both before declaring a file done.
 npx --yes dmnlint path/to/decision.dmn
 ```
 
+For directory-wide work, discover `.dmn` files recursively first (skip `.git`, `node_modules`, `target`, `build`, `.gradle`, `.mvn`, `.idea`, `.settings`, `.snapshots`), then lint each discovered file. Keep a fix loop open: lint → targeted XML edits → re-lint until the set is clean.
+
 Common rules: `label-required` (add a `name`), `no-duplicate-requirements` (drop the duplicate `informationRequirement` edge). See [references/dmnlint.md](references/dmnlint.md) for the full rule → fix mapping.
 
 **2. Behaviour validation by execution.** `dmnlint` does not understand FEEL, hit-policy correctness, or type matches. Run the decision:

--- a/skills/camunda-dmn/references/dmnlint.md
+++ b/skills/camunda-dmn/references/dmnlint.md
@@ -24,6 +24,23 @@ Drop a `.dmnlintrc` at the project root:
 
 If the project already has a `.dmnlintrc` with a different `extends`, do not overwrite it — respect the project's choice and surface any rule disagreements in your final message.
 
+## Targeting modes
+
+- **Single file**: lint one `.dmn` file.
+- **Directory**: discover `.dmn` files recursively and lint each file.
+
+Skip these directories during discovery: `.git`, `node_modules`, `target`, `build`, `.gradle`, `.mvn`, `.idea`, `.settings`, `.snapshots`.
+
+```bash
+find <target-dir> -type d \( -name .git -o -name node_modules -o -name target -o -name build -o -name .gradle -o -name .mvn -o -name .idea -o -name .settings -o -name .snapshots \) -prune -o -type f -name '*.dmn' -print
+```
+
+Run lint on each discovered file and repeat the loop until clean:
+
+1. lint
+2. apply targeted XML fixes from the rule map below
+3. lint again
+
 ## Recommended rule set
 
 `dmnlint:recommended` enables these rules (both errors by default):

--- a/skills/camunda-dmn/references/dmnlint.md
+++ b/skills/camunda-dmn/references/dmnlint.md
@@ -32,7 +32,7 @@ If the project already has a `.dmnlintrc` with a different `extends`, do not ove
 Skip these directories during discovery: `.git`, `node_modules`, `target`, `build`, `.gradle`, `.mvn`, `.idea`, `.settings`, `.snapshots`.
 
 ```bash
-find path/to/dir -type d \( -name .git -o -name node_modules -o -name target -o -name build -o -name .gradle -o -name .mvn -o -name .idea -o -name .settings -o -name .snapshots \) -prune -o -type f -name '*.dmn' -print0 | while IFS= read -r -d '' file; do npx --yes dmnlint "$file"; done
+find path/to/dir -type d \( -name .git -o -name node_modules -o -name target -o -name build -o -name .gradle -o -name .mvn -o -name .idea -o -name .settings -o -name .snapshots \) -prune -o -type f -name '*.dmn' -print0 | xargs -0 -n1 npx --yes dmnlint
 ```
 
 Run lint on each discovered file and repeat the loop until clean:

--- a/skills/camunda-dmn/references/dmnlint.md
+++ b/skills/camunda-dmn/references/dmnlint.md
@@ -32,7 +32,7 @@ If the project already has a `.dmnlintrc` with a different `extends`, do not ove
 Skip these directories during discovery: `.git`, `node_modules`, `target`, `build`, `.gradle`, `.mvn`, `.idea`, `.settings`, `.snapshots`.
 
 ```bash
-find <target-dir> -type d \( -name .git -o -name node_modules -o -name target -o -name build -o -name .gradle -o -name .mvn -o -name .idea -o -name .settings -o -name .snapshots \) -prune -o -type f -name '*.dmn' -print
+find path/to/dir -type d \( -name .git -o -name node_modules -o -name target -o -name build -o -name .gradle -o -name .mvn -o -name .idea -o -name .settings -o -name .snapshots \) -prune -o -type f -name '*.dmn' -print0 | while IFS= read -r -d '' file; do npx --yes dmnlint "$file"; done
 ```
 
 Run lint on each discovered file and repeat the loop until clean:


### PR DESCRIPTION
## Summary
- generalize ProcessOS DMN linting approach into camunda-dmn
- document single-file and directory targeting modes for dmnlint
- add explicit lint to targeted fix to re-lint loop guidance

related to #62

## Notes
- make lint SKILL=camunda-dmn could not run locally because waza is not installed in this environment.

closes #62
