### PR TITLE
feat(camunda-process-test): add drift-aware suite maintenance guidance

### DIFF
--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -52,8 +52,10 @@ Check `pom.xml` (or `test/pom.xml`) for `camunda-process-test-spring`. If missin
 If scenarios already exist, run a drift check before editing tests:
 
 ```bash
-git diff main...HEAD -- <bpmn-path>
+git diff <base-branch>...HEAD -- <bpmn-path>
 ```
+
+Use the PR base branch or repository default branch as `<base-branch>` (often `main`).
 
 Then classify current suite gaps:
 

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -49,6 +49,20 @@ Skip `target/`, `node_modules/`, `.git/`, `build/`. If multiple files match, lis
 
 Check `pom.xml` (or `test/pom.xml`) for `camunda-process-test-spring`. If missing, go to step 2.
 
+If scenarios already exist, run a drift check before editing tests:
+
+```bash
+git diff HEAD -- <bpmn-path>
+```
+
+Then classify current suite gaps:
+
+- **Broken**: scenario references an `elementId` or `processDefinitionId` that no longer exists.
+- **Stale**: IDs still exist, but branch-driving variables or assumptions no longer match gateway/DMN behavior.
+- **Missing**: new branches, boundary events, or end events have no segment coverage.
+
+Fix in this order: broken → stale → missing, then run `mvn test` and continue with coverage verification.
+
 ### 2. Setup (only if missing)
 
 Follow [references/setup.md](references/setup.md): run the readiness preflight (Java, Maven/wrapper, Docker), add the CPT dependency, scaffold `src/test/java/io/camunda/tests/ProcessTest.java` and `src/test/resources/scenarios/`. Confirm with `mvn test-compile`.

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -52,7 +52,7 @@ Check `pom.xml` (or `test/pom.xml`) for `camunda-process-test-spring`. If missin
 If scenarios already exist, run a drift check before editing tests:
 
 ```bash
-git diff HEAD -- <bpmn-path>
+git diff main...HEAD -- <bpmn-path>
 ```
 
 Then classify current suite gaps:

--- a/skills/camunda-process-test/references/troubleshooting.md
+++ b/skills/camunda-process-test/references/troubleshooting.md
@@ -27,6 +27,15 @@ Diagnose `mvn test` failures. Each row classifies the failure as a **test proble
 | DMN behaves wrong but no incident; process completes normally with wrong outputs | BPMN-completes tests can't catch wrong DMN outputs unless a downstream gateway consumes them | Test | Add `ASSERT_DECISION` (JSON) or `CamundaAssert.assertThatDecision(...)` (Java) — see authoring.md § Instructions for DMN, and **camunda-dmn** § testing-decisions for what to assert per hit policy. |
 | `DECISION_EVALUATION_ERROR: expected '<typeRef>' but found '[...]'` | Decision-table `<variable typeRef="string"/>` declared but the hit policy returns a list (RULE ORDER / COLLECT without aggregator) | Process | Drop the decision-level `<variable>` element on the decision table, or remove its `typeRef`. See **camunda-dmn** § Decision-level `<variable>` declarations. |
 
+## BPMN drift sync checklist
+
+When BPMN changed since the last passing suite, sync tests before deep debugging:
+
+1. Diff BPMN changes: `git diff HEAD -- <bpmn-path>`.
+2. Re-read BPMN IDs and compare with scenario `elementId`/`processDefinitionId` references.
+3. Update broken IDs first, then variable-driven branch expectations, then add missing branch segments.
+4. Re-run `mvn test` and return to the quick-triage table for remaining failures.
+
 ## Repair discipline
 
 1. Diagnose **every** failure first. Do not start fixing until the full list is classified.

--- a/skills/camunda-process-test/references/troubleshooting.md
+++ b/skills/camunda-process-test/references/troubleshooting.md
@@ -31,7 +31,7 @@ Diagnose `mvn test` failures. Each row classifies the failure as a **test proble
 
 When BPMN changed since the last passing suite, sync tests before deep debugging:
 
-1. Diff BPMN changes: `git diff main...HEAD -- <bpmn-path>`.
+1. Diff BPMN changes: `git diff <base-branch>...HEAD -- <bpmn-path>` (often `main`).
 2. Re-read BPMN IDs and compare with scenario `elementId`/`processDefinitionId` references.
 3. Update broken IDs first, then variable-driven branch expectations, then add missing branch segments.
 4. Re-run `mvn test` and return to the quick-triage table for remaining failures.

--- a/skills/camunda-process-test/references/troubleshooting.md
+++ b/skills/camunda-process-test/references/troubleshooting.md
@@ -31,7 +31,7 @@ Diagnose `mvn test` failures. Each row classifies the failure as a **test proble
 
 When BPMN changed since the last passing suite, sync tests before deep debugging:
 
-1. Diff BPMN changes: `git diff HEAD -- <bpmn-path>`.
+1. Diff BPMN changes: `git diff main...HEAD -- <bpmn-path>`.
 2. Re-read BPMN IDs and compare with scenario `elementId`/`processDefinitionId` references.
 3. Update broken IDs first, then variable-driven branch expectations, then add missing branch segments.
 4. Re-run `mvn test` and return to the quick-triage table for remaining failures.


### PR DESCRIPTION
## Summary
- generalize ProcessOS test-suite maintenance flow into camunda-process-test
- add BPMN drift check and broken/stale/missing classification before repair
- add troubleshooting checklist for syncing tests after BPMN changes

related to #62

## Notes
- make lint SKILL=camunda-process-test could not run locally because waza is not installed in this environment.

closes #62
