### PR TITLE
feat(camunda-process-test): add run, evaluation, and CI workflows

### DIFF
--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -180,6 +180,16 @@ Segments: 1 happy path + 5 secondary
 Duplicates flagged: 0
 ```
 
+## Maintenance workflows for existing suites
+
+When tests already exist and the user asks to run, diagnose, or improve them (without generating a brand-new suite), use these focused workflows:
+
+1. **Run and diagnose failures** — execute `mvn test`, classify each failure as infrastructure/test/process, then fix in batches. Use [references/troubleshooting.md](references/troubleshooting.md) plus [references/run-and-diagnose.md](references/run-and-diagnose.md).
+2. **Evaluate coverage gaps before writing new tests** — explain current suite coverage in business terms, list uncovered branches/boundaries/rules, and recommend the smallest next set of scenarios. See [references/evaluation.md](references/evaluation.md).
+3. **Wire tests into CI** — configure CI to run CPT reliably and publish JUnit artifacts, with optional integration profile runs gated to trusted branches. See [references/ci.md](references/ci.md).
+
+These workflows are complementary: evaluate gaps first, implement new scenarios, then run/diagnose locally and in CI.
+
 ## References
 
 - [setup.md](references/setup.md) — Java, Maven, Docker prereqs; CPT dependency; test scaffold layout; Spring Boot 4.x pin
@@ -188,3 +198,6 @@ Duplicates flagged: 0
 - [test-context.md](references/test-context.md) — `CamundaProcessTestContext` Java API surface (job/decision/child-process mocking, time control, conditional behavior)
 - [connectors-runtime.md](references/connectors-runtime.md) — enabling the Connectors runtime alongside Zeebe; WireMock pattern; inbound webhooks
 - [troubleshooting.md](references/troubleshooting.md) — failure diagnosis table (test problem vs. process problem)
+- [run-and-diagnose.md](references/run-and-diagnose.md) — test-run execution loop and failure-batch repair strategy
+- [evaluation.md](references/evaluation.md) — coverage-gap assessment and recommendation workflow
+- [ci.md](references/ci.md) — CI pipeline patterns for CPT execution and test-report publishing

--- a/skills/camunda-process-test/references/ci.md
+++ b/skills/camunda-process-test/references/ci.md
@@ -7,7 +7,7 @@ Run CPT suites in CI as a quality gate and publish test artifacts.
 - Java toolchain compatible with project build
 - Maven cache enabled where possible
 - Docker available to the test job (CPT/Testcontainers requirement)
-- JUnit XML artifact upload from `target/surefire-reports/*.xml`
+- JUnit XML artifact upload from `**/target/surefire-reports/*.xml` (glob covers multi-module layouts)
 
 ## GitHub Actions baseline
 
@@ -36,13 +36,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: surefire-reports
-          path: target/surefire-reports/*.xml
+          path: "**/target/surefire-reports/*.xml"
 ```
 
 ## Optional split: process vs integration profile
 
 - Keep `mvn test` on pull requests for fast feedback.
-- Run integration profile jobs (`mvn test -P integration-test`) on protected branches or scheduled runs.
+- Run integration profile jobs (`mvn verify -P integration-test`) on protected branches or scheduled runs.
 - Store required cluster credentials in CI secrets, never in repo files.
 
 ## Common CI failure causes

--- a/skills/camunda-process-test/references/ci.md
+++ b/skills/camunda-process-test/references/ci.md
@@ -1,0 +1,54 @@
+# CPT CI setup patterns
+
+Run CPT suites in CI as a quality gate and publish test artifacts.
+
+## Baseline requirements
+
+- Java toolchain compatible with project build
+- Maven cache enabled where possible
+- Docker available to the test job (CPT/Testcontainers requirement)
+- JUnit XML artifact upload from `target/surefire-reports/*.xml`
+
+## GitHub Actions baseline
+
+```yaml
+name: process-tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  cpt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Run CPT tests
+        run: mvn test
+      - name: Upload Surefire reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: target/surefire-reports/*.xml
+```
+
+## Optional split: process vs integration profile
+
+- Keep `mvn test` on pull requests for fast feedback.
+- Run integration profile jobs (`mvn test -P integration-test`) on protected branches or scheduled runs.
+- Store required cluster credentials in CI secrets, never in repo files.
+
+## Common CI failure causes
+
+- Docker unavailable on runner
+- Missing test resources in `@TestDeployment`
+- Branch-specific test data assumptions not mirrored in CI environment
+
+When failures are recurrent, feed them back into [run-and-diagnose.md](run-and-diagnose.md) and harden the suite.

--- a/skills/camunda-process-test/references/evaluation.md
+++ b/skills/camunda-process-test/references/evaluation.md
@@ -1,0 +1,35 @@
+# Evaluate coverage gaps in an existing suite
+
+Use this before adding more scenarios to avoid random test growth.
+
+## Inputs
+
+- Target BPMN file(s)
+- Existing `.test.json` scenarios and/or Java CPT tests
+
+## Evaluation steps
+
+1. Parse BPMN decisions: gateways, boundary events, end events, called DMN decisions.
+2. Map each existing scenario to the path it covers.
+3. Explain current coverage in plain business language (what situations are tested, what are not).
+4. Classify gaps:
+   - Missing gateway branches
+   - Missing boundary-event/error paths
+   - Missing alternate end states
+   - Missing DMN rule paths that affect routing
+5. Recommend the **smallest additional scenario set** that closes the biggest gaps first.
+
+## Recommendation format
+
+For each proposed scenario:
+
+- **Name** (`<who/what> — <outcome>`)
+- **Business description**
+- **Type** (JSON process test or Java fallback)
+- **Gap covered** (specific branch/boundary/rule)
+
+Then suggest a coverage level target:
+
+- **Quick**: happy path + one critical exception path
+- **Standard**: all gateway branches and key boundaries
+- **Thorough**: full branch/boundary/rule coverage + stability-focused integration checks

--- a/skills/camunda-process-test/references/run-and-diagnose.md
+++ b/skills/camunda-process-test/references/run-and-diagnose.md
@@ -16,7 +16,7 @@ mvn test
    - **Test defect** (wrong IDs, missing instruction, stale variable names)
    - **Process defect** (gateway logic, DMN rule behavior, BPMN error code mismatch)
 4. Apply fixes in batches by class (not one-by-one churn), then re-run `mvn test`.
-5. Stop after 3 no-progress cycles and surface blockers explicitly.
+5. Stop after 3 no-progress cycles — defined as a re-run producing no reduction in failing tests and no new diagnostic signal — and surface blockers explicitly.
 
 ## Failure-class defaults
 

--- a/skills/camunda-process-test/references/run-and-diagnose.md
+++ b/skills/camunda-process-test/references/run-and-diagnose.md
@@ -1,0 +1,27 @@
+# Run and diagnose CPT suites
+
+Use this when tests already exist and the user asks to run/fix them.
+
+## Execution loop
+
+1. Ensure Docker runtime is available (see [setup.md](setup.md)).
+2. Run:
+
+```bash
+mvn test
+```
+
+3. If tests fail, classify each failure:
+   - **Infrastructure** (Docker down, deployment parse failure, missing resources)
+   - **Test defect** (wrong IDs, missing instruction, stale variable names)
+   - **Process defect** (gateway logic, DMN rule behavior, BPMN error code mismatch)
+4. Apply fixes in batches by class (not one-by-one churn), then re-run `mvn test`.
+5. Stop after 3 no-progress cycles and surface blockers explicitly.
+
+## Failure-class defaults
+
+- Prefer fixing **test defects** in the suite directly.
+- For ambiguous routing mismatches, verify BPMN/FEEL intent first, then decide whether test data or model logic is wrong.
+- Do not mask process defects by weakening assertions.
+
+Use [troubleshooting.md](troubleshooting.md) for detailed failure signatures and exact repair actions.


### PR DESCRIPTION
## Summary
- generalize public-safe guidance from process-os-test-run, process-os-test-evaluation, and process-os-ci-setup
- add maintenance workflows for existing suites (run/diagnose, coverage-gap evaluation, CI wiring)
- add new references: run-and-diagnose.md, evaluation.md, and ci.md

related to #62

## Notes
- make lint SKILL=camunda-process-test is blocked locally because waza is not installed in this environment.

closes #62
