### PR TITLE
feat(camunda-bpmn): add runtime compatibility validation workflow

### DIFF
--- a/skills/camunda-bpmn/SKILL.md
+++ b/skills/camunda-bpmn/SKILL.md
@@ -146,7 +146,7 @@ Lint catches structure, not runtime behaviour (FEEL errors, missing workers, unr
 
 ### Runtime compatibility gate
 
-Before a BPMN change is considered deployment-ready, run a compatibility pass with `c8ctl bpmn lint` against the exact files you intend to deploy (single file or full directory set). This catches Camunda-runtime constraints that may still pass generic XML checks.
+Before a BPMN change moves to deployment/testing, run a compatibility pass with `c8ctl bpmn lint` against the exact files you intend to deploy (single file or full directory set). This is a required runtime-compatibility check, but it is not by itself a deployment-success guarantee.
 
 Use this troubleshooting mapping when lint flags compatibility issues:
 

--- a/skills/camunda-bpmn/SKILL.md
+++ b/skills/camunda-bpmn/SKILL.md
@@ -144,6 +144,19 @@ When the task targets a directory (not a single file), use the directory workflo
 
 Lint catches structure, not runtime behaviour (FEEL errors, missing workers, unreachable end events). After lint is clean, validate by **running the process**: prefer **camunda-process-test** for embedded-engine feedback without a cluster, or fall back to **camunda-process-mgmt** to deploy and run an instance.
 
+### Runtime compatibility gate
+
+Before a BPMN change is considered deployment-ready, run a compatibility pass with `c8ctl bpmn lint` against the exact files you intend to deploy (single file or full directory set). This catches Camunda-runtime constraints that may still pass generic XML checks.
+
+Use this troubleshooting mapping when lint flags compatibility issues:
+
+- **implementation/task-definition** failures: task missing required Zeebe extension (`<zeebe:taskDefinition>`, `<zeebe:calledDecision>`, etc.) for its BPMN type.
+- **feel / io-mapping** failures: expressions are not valid FEEL for Camunda 8 (for example legacy `${...}` or non-FEEL mapping syntax). Cross-check with **camunda-feel**.
+- **element-type / gateway** failures: model uses unsupported or discouraged constructs for the target runtime profile.
+- **timer / event-definition** failures: timer or event configuration is structurally present but invalid for runtime execution.
+
+For a full compatibility workflow (target selection, directory runs, and fix loop), use [references/runtime-compatibility.md](references/runtime-compatibility.md).
+
 ## References
 
 For detailed reference material, read from `references/`:
@@ -152,3 +165,4 @@ For detailed reference material, read from `references/`:
 - [layout-rules.md](references/layout-rules.md) — DI coordinate management, element sizes, spacing rules for diagram layout
 - [canonical-style.md](references/canonical-style.md) — canonical bpmn-js XML style: tag layout, attribute order, self-closing form, why hand-formatting drifts
 - [bpmn-lint.md](references/bpmn-lint.md) — single-file vs directory lint workflow, output parsing, and recommended-rule fix mapping
+- [runtime-compatibility.md](references/runtime-compatibility.md) — deployment-readiness compatibility linting workflow and fix categories

--- a/skills/camunda-bpmn/references/runtime-compatibility.md
+++ b/skills/camunda-bpmn/references/runtime-compatibility.md
@@ -1,0 +1,45 @@
+# Runtime compatibility checklist
+
+Use this before deploy/test runs against a real Camunda 8 runtime.
+
+## When to run
+
+- After BPMN edits are structurally clean.
+- Before `c8ctl deploy`, smoke runs, or handing off for release.
+- On all changed `.bpmn` files, not just one representative file.
+
+## Targeting mode
+
+- **Single file**: run lint on the file directly.
+- **Directory**: discover `.bpmn` files recursively, skipping `.git`, `node_modules`, `target`, `build`, `.gradle`, `.mvn`, `.idea`, `.settings`, `.snapshots`.
+
+```bash
+find <target-dir> -type d \( -name .git -o -name node_modules -o -name target -o -name build -o -name .gradle -o -name .mvn -o -name .idea -o -name .settings -o -name .snapshots \) -prune -o -type f -name '*.bpmn' -print
+```
+
+Then run:
+
+```bash
+c8ctl bpmn lint <file.bpmn>
+```
+
+for each discovered file.
+
+## Fix loop
+
+1. Lint target files.
+2. Apply targeted BPMN XML fixes for each reported issue.
+3. Re-lint the same target set.
+4. Repeat until all files are clean.
+
+## Common compatibility categories
+
+| Category | What it usually means | Typical fix |
+|---|---|---|
+| Implementation extensions | Required Zeebe extension missing for the BPMN element type | Add missing `<zeebe:taskDefinition>`, `<zeebe:calledDecision>`, `<zeebe:userTask />`, etc. |
+| FEEL / expression parsing | Legacy or invalid expression syntax | Rewrite to Camunda 8 FEEL and validate with **camunda-feel**. |
+| I/O mapping | Mapping syntax not valid for runtime evaluation | Use valid FEEL in `source`/`target` mappings. |
+| Unsupported structure | BPMN construct is incompatible with runtime constraints | Remodel using supported gateways/events/tasks. |
+| Timer/event config | Event definition present but invalid at runtime | Correct timer/event definition shape and expression. |
+
+If a rule is unclear, inspect the exact lint message and map it back to the BPMN element first, then fix the smallest possible section.

--- a/skills/camunda-bpmn/references/runtime-compatibility.md
+++ b/skills/camunda-bpmn/references/runtime-compatibility.md
@@ -6,16 +6,12 @@ Use this before deploy/test runs against a real Camunda 8 runtime.
 
 - After BPMN edits are structurally clean.
 - Before `c8ctl deploy`, smoke runs, or handing off for release.
-- On all changed `.bpmn` files, not just one representative file.
+- On the full `.bpmn` target set for the intended deploy/test run (single file or directory set), not just one representative file.
 
 ## Targeting mode
 
 - **Single file**: run lint on the file directly.
-- **Directory**: discover `.bpmn` files recursively, skipping `.git`, `node_modules`, `target`, `build`, `.gradle`, `.mvn`, `.idea`, `.settings`, `.snapshots`.
-
-```bash
-find <target-dir> -type d \( -name .git -o -name node_modules -o -name target -o -name build -o -name .gradle -o -name .mvn -o -name .idea -o -name .settings -o -name .snapshots \) -prune -o -type f -name '*.bpmn' -print
-```
+- **Directory**: use the discovery workflow in [bpmn-lint.md](bpmn-lint.md) to recursively find target `.bpmn` files (including the shared skip-directory list), then lint each discovered file.
 
 Then run:
 


### PR DESCRIPTION
## Summary
- generalize public-safe parts of process-os-camunda-compatibility-check into camunda-bpmn
- add a runtime compatibility gate in the main skill flow
- add a dedicated runtime compatibility reference with directory targeting, fix loop, and troubleshooting categories

related to #62

## Notes
- make lint SKILL=camunda-bpmn is blocked locally because waza is not installed in this environment.

closes #62
