### PR TITLE
Only evaluate changed skills for PRs

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -57,25 +57,42 @@ jobs:
 
       - run: uv sync --frozen
 
-      - name: Compute changed skills
+      - name: Compute changed scope
         env:
           RUN_ALL: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'evals:run-all') }}
         run: |
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
-          # run-all (or a dispatch with no PR) → every skill. A change to the
-          # harness itself (evals/ tree or the Python project) also runs all.
+          : > changed-targets.txt
+          # run-all (or a dispatch with no PR) → every skill.
           if [ "$RUN_ALL" = "true" ] || [ -z "$base" ]; then
             ls skills > changed-skills.txt
           else
-            git diff --name-only "$base..$head" \
-              | awk -F/ '$1=="skills" && NF>1 {print $2}' | sort -u > changed-skills.txt
-            if git diff --name-only "$base..$head" \
-                 | grep -qE '^evals/|^pyproject\.toml$|^uv\.lock$|^\.python-version$'; then
+            git diff --name-only "$base..$head" > changed-files.txt
+            awk -F/ '$1=="skills" && NF>1 {print $2}' changed-files.txt | sort -u > changed-skills.txt
+
+            # Map changed eval target files to exact target paths so a PR that
+            # updates one eval runs that eval only.
+            awk -F/ '
+              $1=="evals" && $2=="skills" && NF>=4 && $4=="triggers.py" {
+                print "skills/" $3 "/triggers.py"
+              }
+              $1=="evals" && $2=="skills" && NF>=4 && $4!="triggers.py" {
+                print "skills/" $3 "/outcomes.py"
+              }
+              $1=="evals" && $2=="scenarios" && NF>=4 {
+                print "scenarios/" $3 "/outcomes.py"
+              }
+            ' changed-files.txt | sort -u > changed-targets.txt
+
+            # Harness/framework changes still require full-suite-by-skill.
+            if grep -qE '^evals/src/|^evals/sandboxes/|^evals/docs/|^evals/README\.md$|^pyproject\.toml$|^uv\.lock$|^\.python-version$|^\.github/workflows/eval(-nightly|-baseline)?\.yml$' changed-files.txt; then
               ls skills > changed-skills.txt
+              : > changed-targets.txt
             fi
           fi
           echo "Changed skills:"; cat changed-skills.txt
+          echo "Changed eval targets:"; cat changed-targets.txt
 
       - name: Build run matrix
         id: matrix
@@ -83,10 +100,36 @@ jobs:
           COMPARE: ${{ contains(github.event.pull_request.labels.*.name, 'evals:compare') || github.event.inputs.compare == 'true' }}
           TARGET: ${{ github.event.inputs.target }}
         run: |
-          changed=$(tr '\n' ' ' < changed-skills.txt)
           compare_flag=""; [ "$COMPARE" = "true" ] && compare_flag="--compare"
-          # shellcheck disable=SC2086  # word-splitting is intended: one arg per skill
-          uv run evals-build-matrix --changed-skills $changed --target "$TARGET" $compare_flag > specs.json
+          echo '[]' > specs.json
+
+          merge_specs() {
+            tmp=$(mktemp)
+            jq -s 'add | unique_by(.slug)' specs.json "$1" > "$tmp"
+            mv "$tmp" specs.json
+          }
+
+          if [ -s changed-skills.txt ]; then
+            changed=$(tr '\n' ' ' < changed-skills.txt)
+            # shellcheck disable=SC2086  # word-splitting is intended: one arg per skill
+            uv run evals-build-matrix --changed-skills $changed --target "$TARGET" $compare_flag > specs-skill.json
+            merge_specs specs-skill.json
+          fi
+
+          if [ -s changed-targets.txt ]; then
+            while IFS= read -r target; do
+              [ -n "$target" ] || continue
+              uv run evals-build-matrix --target "$target" $compare_flag > specs-target.json
+              merge_specs specs-target.json
+            done < changed-targets.txt
+          fi
+
+          # workflow_dispatch with explicit target and no changed-skill context
+          if [ -n "$TARGET" ] && [ ! -s changed-skills.txt ] && [ ! -s changed-targets.txt ]; then
+            uv run evals-build-matrix --target "$TARGET" $compare_flag > specs-target.json
+            merge_specs specs-target.json
+          fi
+
           specs=$(cat specs.json)
           echo "$specs"
           echo "specs=$specs" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -3,9 +3,7 @@ name: 🧪 Run skill evals
 # Non-blocking PR eval signal — posts outcome + token-budget vs baseline as a
 # PR comment. Does NOT gate merge (keep out of required status checks).
 #
-# Maintainer-gated by labels (only triage+ can label; fork PRs never get the
-# secrets — this is `pull_request`, not `pull_request_target`):
-#   - evals:run       → targets whose skills ∩ changed skills
+# Auto-runs on PRs that touch skills/evals paths; labels refine scope:
 #   - evals:run-all   → every target (suite integration check)
 #   - evals:compare   → also run the without-skill arm of outcome evals
 # workflow_dispatch (requires write access) can run a single target and toggle
@@ -24,7 +22,16 @@ on:
         type: boolean
         default: false
   pull_request:
-    types: [labeled, synchronize, reopened]
+    types: [opened, reopened, synchronize, labeled]
+    paths:
+      - 'skills/**'
+      - 'evals/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.python-version'
+      - '.github/workflows/eval.yml'
+      - '.github/workflows/eval-nightly.yml'
+      - '.github/workflows/eval-baseline.yml'
 
 permissions:
   contents: read
@@ -37,10 +44,7 @@ concurrency:
 jobs:
   detect:
     name: Detect affected targets
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'evals:run') ||
-      contains(github.event.pull_request.labels.*.name, 'evals:run-all')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       specs: ${{ steps.matrix.outputs.specs }}

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -86,7 +86,7 @@ jobs:
             ' changed-files.txt | sort -u > changed-targets.txt
 
             # Harness/framework changes still require full-suite-by-skill.
-            if grep -qE '^evals/src/|^evals/sandboxes/|^evals/docs/|^evals/README\.md$|^pyproject\.toml$|^uv\.lock$|^\.python-version$|^\.github/workflows/eval(-nightly|-baseline)?\.yml$' changed-files.txt; then
+            if grep -qE '^evals/src/|^evals/sandboxes/|^evals/README\.md$|^pyproject\.toml$|^uv\.lock$|^\.python-version$|^\.github/workflows/eval\.yml$|^\.github/workflows/eval-(nightly|baseline)\.yml$' changed-files.txt; then
               ls skills > changed-skills.txt
               : > changed-targets.txt
             fi

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -136,7 +136,11 @@ jobs:
 
           specs=$(cat specs.json)
           echo "$specs"
-          echo "specs=$specs" >> "$GITHUB_OUTPUT"
+          {
+            echo "specs<<SPECS_EOF"
+            cat specs.json
+            echo "SPECS_EOF"
+          } >> "$GITHUB_OUTPUT"
           [ "$specs" = "[]" ] && echo "has=false" >> "$GITHUB_OUTPUT" || echo "has=true" >> "$GITHUB_OUTPUT"
           # Only build the sandbox images when an outcome target is in scope
           # (triggers run sandbox-free), so a triggers-only run skips the build.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,11 @@ on:
     branches: [main]
     paths:
       - 'skills/**'
+      - 'evals/**'
       - '.waza.yaml'
+      - '.github/workflows/eval.yml'
+      - '.github/workflows/eval-nightly.yml'
+      - '.github/workflows/eval-baseline.yml'
       - '.github/workflows/lint.yml'
 
 permissions:

--- a/evals/docs/ci.md
+++ b/evals/docs/ci.md
@@ -7,11 +7,9 @@ the local loop see [`runbook.md`](runbook.md); for the model see
 ## A skill-change PR, end to end
 
 1. **Iterate locally** (see [`runbook.md`](runbook.md)).
-2. **Open the PR.** Nothing runs automatically — evals are opt-in and
-   maintainer-gated by label.
-3. **A maintainer adds `evals:run`** — runs the targets your change can affect,
-   on the `with_skill` arm, gated against the committed baseline, and posts a
-   rolling comment.
+2. **Open the PR.** Evals auto-run for PRs that touch skill/eval/harness files.
+3. **Default run scope** is targets your change can affect, on the `with_skill`
+   arm, gated against the committed baseline, with a rolling PR comment.
 4. **Read it** — the PR comment for the verdict, the run's job summary for token
    usage, the trajectory viewer for a failing sample.
 5. **Occasionally** add `evals:compare` (does the skill earn its keep — the
@@ -26,34 +24,31 @@ the local loop see [`runbook.md`](runbook.md); for the model see
 | Workflow | Trigger | Scope |
 |---|---|---|
 | `lint.yml` | PR touching `skills/**` or `.waza.yaml` | `waza check` only |
-| `eval.yml` | `evals:run` / `evals:run-all` / `evals:compare` label, or the Actions tab | Affected (or all) targets; posts the PR comment. **Non-blocking.** |
+| `eval.yml` | PR changes to skill/eval/harness paths, or the Actions tab (`evals:run-all` / `evals:compare` labels optional) | Affected (or all) targets; posts the PR comment. **Non-blocking.** |
 | `eval-nightly.yml` | `workflow_dispatch` only (cron re-enabled in a follow-up) | Every target; uploads logs as artifacts |
 | `eval-baseline.yml` | `evals:regenerate-baselines` label, or the Actions tab | Re-runs outcome evals, regenerates baselines, commits them to the branch |
 
-**Gating is the label.** Only collaborators with triage or higher can label a
-PR, and `workflow_dispatch` requires write access — so there's no separate
-authorization job. Because the workflows use `pull_request` (not
-`pull_request_target`), a fork PR never receives the model secret: model runs only
-happen on branches in this repo.
+Auto-runs come from `pull_request` path filters; labels are optional refinements
+for scope/arms. `workflow_dispatch` still requires write access. Because the
+workflow uses `pull_request` (not `pull_request_target`), fork PRs do not
+receive model secrets.
 
 ## Labels
 
-Labels make two **orthogonal** choices — *scope* and *arms* — and re-run on each
-push while present (remove to stop):
+Labels are optional refinements and re-run on each push while present (remove
+to stop):
 
-- **`evals:run`** — targets whose `metadata.skills` intersect the changed skills
-  (the everyday signal).
 - **`evals:run-all`** — every target (whole-suite / harness check).
 - **`evals:compare`** — *also* run the `without_skill` arm of outcome evals.
   Without it, outcome evals run `with_skill` only.
 
 | You want to… | Label(s) | Runs | Gated vs baseline? |
 |---|---|---|---|
-| Check the skills your PR touched | `evals:run` | affected, `with_skill` | ✅ |
+| Check the skills your PR touched | none (default) | affected, `with_skill` | ✅ |
 | Check the whole suite | `evals:run-all` | every target, `with_skill` | ✅ |
-| See what a skill *adds* | either + `evals:compare` | adds `without_skill` | `with_skill` ✅ · `without_skill` ❌ |
+| See what a skill *adds* | optional `evals:compare` | adds `without_skill` | `with_skill` ✅ · `without_skill` ❌ |
 
-`workflow_dispatch` accepts `target` (substring filter over target ids) and
+`workflow_dispatch` accepts `target` (substring filter over target paths) and
 `compare` (run the second arm).
 
 ## Target selection

--- a/evals/docs/ci.md
+++ b/evals/docs/ci.md
@@ -61,8 +61,16 @@ push while present (remove to stop):
 No tiers. `evals-list --json` emits one entry per target —
 `{id, kind, skills, path, task, args, max_sandboxes}` — where `id` is e.g.
 `trigger:camunda-feel`, `skill:camunda-feel`, or `scenario:rocket-launch`, and
-`kind` is `trigger | outcome`. PR runs intersect `metadata.skills` with the
-changed skills; nightly runs everything. Adding a target needs no workflow change.
+`kind` is `trigger | outcome`.
+
+PR target selection is a union:
+
+- skill-driven selection (`metadata.skills ∩ changed_skills`) for product-skill edits
+- exact eval-path selection for changed eval files (so an edit to
+  `evals/skills/<skill>/outcomes.py` runs that target only)
+
+Harness/framework edits (`evals/src`, sandboxes, workflow plumbing, Python
+project files) still widen to all skills. Nightly runs everything.
 
 ## Jobs and what goes red
 


### PR DESCRIPTION
Summary:
- auto-run evals on PRs that change skills/evals/harness paths (no label required)
- stop widening every evals change to all skills
- detect changed eval targets by path and include those targets directly in the run matrix
- keep full-skill widening for harness/framework changes
- update CI docs for the new default behavior

Why:
Outcome PRs should run only the relevant targets by default, without manual labeling.

Part of #71