### PR TITLE
feat(camunda-branch-code-review): add branch code-review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These skills follow the [Agent Skills](https://agentskills.io) open standard and
 | **camunda-connectors-development** | Build custom Camunda 8 connectors — JSON-only template on a protocol connector, or custom Java connector via the Connectors SDK (outbound + inbound) |
 | **camunda-process-mgmt** | Deploy resources, start/inspect instances, resolve incidents, complete tasks — via c8ctl |
 | **camunda-ai-agents** | Build AI agents in BPMN — AI Agent connector on an ad-hoc subprocess, tools, `fromAi()`, prompts |
-| **camunda-branch-code-review** | Review the current branch of the camunda/camunda monorepo — SpotBugs static analysis plus a manual SOLID/DRY/KISS/clean-code pass |
+| **camunda-branch-code-review** | Explicitly invoked ("review this branch using the skill") to review the current branch of the camunda/camunda monorepo — SpotBugs static analysis plus a manual SOLID/DRY/KISS/clean-code pass |
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ These skills follow the [Agent Skills](https://agentskills.io) open standard and
 | **camunda-connectors-development** | Build custom Camunda 8 connectors — JSON-only template on a protocol connector, or custom Java connector via the Connectors SDK (outbound + inbound) |
 | **camunda-process-mgmt** | Deploy resources, start/inspect instances, resolve incidents, complete tasks — via c8ctl |
 | **camunda-ai-agents** | Build AI agents in BPMN — AI Agent connector on an ad-hoc subprocess, tools, `fromAi()`, prompts |
+| **camunda-branch-code-review** | Review the current branch of the camunda/camunda monorepo — SpotBugs static analysis plus a manual SOLID/DRY/KISS/clean-code pass |
 
 ## Prerequisites
 

--- a/skills/camunda-branch-code-review/SKILL.md
+++ b/skills/camunda-branch-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: camunda-branch-code-review
-description: Reviews the code introduced/changed on the current git branch of the camunda/camunda monorepo against SOLID, DRY, KISS, clean-code principles and the refactoring.guru code-smell & design-pattern catalogs, combined with a SpotBugs static-analysis pass. Use when asked to review a branch/PR, do a code review, check a diff for design or correctness issues, or before opening a pull request in the camunda/camunda monorepo.
+description: Reviews the code introduced/changed on the current git branch of the camunda/camunda monorepo against SOLID, DRY, KISS, clean-code principles and the refactoring.guru code-smell & design-pattern catalogs, combined with a SpotBugs static-analysis pass. Use ONLY when the user explicitly asks to run this skill/review by name (e.g. "review this branch using the skill", "run the branch code-review skill", "do a branch review with the camunda-branch-code-review skill"). Do NOT trigger on a generic, unqualified "review my code / this PR / this diff" request.
 ---
 
 # Branch Code Review
@@ -16,9 +16,15 @@ references and severity tags.
 
 ## When to use
 
-- "Review this branch / PR / my changes"
-- "Code review before I open the PR"
-- "Check this diff for design / correctness issues"
+Trigger **only on an explicit, by-name request to run this skill** — not on a
+generic "review my code" ask. Examples that should invoke it:
+
+- "Review this branch using the skill"
+- "Run the branch code-review skill (before I open the PR)"
+- "Do a branch review with the camunda-branch-code-review skill on this diff"
+
+A bare "review my changes / this PR / this diff", with no reference to this
+skill, should **not** auto-trigger it.
 
 ## Tooling prerequisite
 

--- a/skills/camunda-branch-code-review/SKILL.md
+++ b/skills/camunda-branch-code-review/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: camunda-branch-code-review
+description: Reviews the code introduced/changed on the current git branch of the camunda/camunda monorepo against SOLID, DRY, KISS, clean-code principles and the refactoring.guru code-smell & design-pattern catalogs, combined with a SpotBugs static-analysis pass. Use when asked to review a branch/PR, do a code review, check a diff for design or correctness issues, or before opening a pull request in the camunda/camunda monorepo.
+---
+
+# Branch Code Review
+
+Review the code **introduced or changed on the current branch** of the
+camunda/camunda monorepo. Combines an automated SpotBugs pass (high-signal
+review profile) with a manual SOLID / DRY / KISS / clean-code analysis backed by
+the refactoring.guru code-smell & design-pattern catalogs
+(`references/refactoring-guru-checks.md`). The review **fans out to one parallel
+agent per topic/tool** — led by an adversarial **logic-correctness** pass — then
+merges everything into one consolidated findings list with `file:line`
+references and severity tags.
+
+## When to use
+
+- "Review this branch / PR / my changes"
+- "Code review before I open the PR"
+- "Check this diff for design / correctness issues"
+
+## Tooling prerequisite
+
+The SpotBugs runner ships with this skill under `scripts/`:
+
+- `scripts/camunda-static-analysis.sh` — the runner
+- `scripts/spotbugs-review-include.xml` — curated high-signal filter (`-p review`)
+- `scripts/spotbugs-all-include.xml` — every category (`-p all`)
+
+The runner resolves the two include filters relative to itself, so the whole
+`scripts/` directory is self-contained. It must run against a **camunda/camunda
+checkout** and needs the repo's Maven wrapper (`./mvnw`) plus `python3` (used to
+parse the SpotBugs XML report). If `python3` or a usable checkout is
+unavailable, **do not launch the `spotbugs` agent** (Phase 2); say so in the
+output and run only the manual review agents.
+
+## Severity tags
+
+Use exactly these tags. Every finding carries one; order the final report
+**correctness > SOLID > DRY > KISS > clean > hygiene**.
+
+- **correctness** — bugs / provably-wrong logic (most SpotBugs HIGH/MED; leaked
+  secrets; a dead path that hides real intent; an untested branch where a bug
+  would most likely hide).
+- **SOLID** — single-responsibility / OO-design violations (god classes,
+  switch-on-type, leaky abstractions, concrete deps that should be injected).
+- **DRY** — duplicated logic/constants/branches that should share a helper.
+- **KISS** — unnecessary complexity, over-abstraction, speculative generality,
+  misapplied/over-engineered patterns.
+- **clean** — naming, function length, nesting, magic values, comments that
+  explain *what* not *why*, harmless unused code, weak assertions.
+- **hygiene** — build/format/test/doc gaps, stray files, missing `@Nullable`,
+  leftover TODOs/scaffolding, scope creep.
+
+## Procedure
+
+The review runs in three phases: **(1) Setup** — the orchestrator establishes
+shared context once; **(2) Fan-out** — one parallel agent per topic/tool, each
+returning findings in the standard format; **(3) Consolidate** — the orchestrator
+merges them into a single report.
+
+### Phase 1 — Setup (orchestrator, run once)
+
+Determine the branch base and the exact changed files. Prefer the merge-base so
+only this branch's commits are reviewed (not changes already on main), and
+capture the **stated goal** from commit messages / PR title:
+
+```bash
+cd <repo-root>
+git fetch origin --quiet 2>/dev/null || true
+BASE=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main)
+echo "base=$BASE"
+git --no-pager diff --stat "$BASE"...HEAD
+git --no-pager diff --name-only "$BASE"...HEAD
+git --no-pager log --oneline "$BASE"..HEAD
+```
+
+Map the changed files to the distinct top-level Maven module(s) touched (e.g.
+`zeebe/engine`, `optimize/backend`, `service`) — these scope the SpotBugs pass
+and the scope judgement.
+
+**New module check:** if the branch adds a brand-new Maven module (a new
+`pom.xml`) that ships with no public/protected classes yet (e.g. only
+`package-info.java`), it needs the `maven.javadoc.skip=true` + empty-javadoc-jar
+placeholder or the release javadoc build fails; flag `[hygiene]` if missing, and
+also flag `[hygiene]` if the placeholder lingers after real classes land. See
+`references/review-heuristics.md` → "New-module javadoc placeholder".
+
+Assemble a **shared review context block** to paste verbatim into every fan-out
+agent (each agent is stateless — this is its only context):
+
+```
+REPO_ROOT: <abs path>
+BASE: <short-sha>            (diff range: BASE...HEAD)
+GOAL: <one-line stated goal from commit/PR>
+JAVA MODULES: <list>
+SKILL_DIR: <abs path to this skill dir; reference files live under references/
+            (refactoring-guru-checks.md, review-heuristics.md), the SpotBugs
+            runner under scripts/>
+CHANGED FILES:
+<paste `git --no-pager diff --name-only BASE...HEAD`>
+
+Read the diff you need with: git --no-pager diff <BASE>...HEAD -- <file>
+Never review from the file list alone.
+Conventions: obey AGENTS.md / module docs over generic ideals (e.g. Optimize C7
+Id/Key naming per optimize/docs/adr/001-c7-naming-conventions.md — do NOT flag a
+`...Key` holding a String or `...Id` holding a Long; JSpecify migration lands in
+separate commits).
+Severity tags (use exactly these, one per finding): correctness, SOLID, DRY,
+KISS, clean, hygiene — as defined in the skill's Severity tags section.
+OUTPUT: only finding lines, one per line, no preamble:
+  `path/File.java:NN [tag] message`
+Cite file:line for every finding; suffix SpotBugs hits with "(SpotBugs)".
+High signal only — "No findings" is a valid result; do not invent issues.
+```
+
+### Phase 2 — Fan out to parallel review agents
+
+**When to fan out vs run inline.** Parallel agents pay off on larger diffs; for
+a tiny change the orchestration overhead outweighs it. Decide from the Phase-1
+diff:
+
+- **Small diff** — ≲ 3 changed files **and** ≲ ~150 changed lines **and** a
+  single module: skip the fan-out. The orchestrator runs every topic itself
+  inline (still run the `spotbugs` pass if the runner is usable), applying the
+  same per-agent task specs below as a checklist — but still give the
+  `logic-correctness` adversarial trace its full treatment (it's the pass most
+  likely to catch a serious bug), not a skim.
+- **Otherwise** — fan out. Launch **all applicable agents in a single message**
+  so they run in parallel.
+
+Paste the shared review context block into each agent, followed by its task spec.
+The **correctness-critical** agents — `logic-correctness` and `sensitive-data` —
+run on a **high-capability reasoning model at high effort** (use the
+`general-purpose` agent type, not the lightweight `explore`): logic-bug recall is
+model-bound, so under-powering these is the main reason serious bugs slip
+through. The remaining design/hygiene agents use `explore`; the `spotbugs` agent
+uses `task` (heavier — it builds). All are read-only reviewers: none modify code.
+
+| Agent | Type | Owns | Reads |
+|-------|------|------|-------|
+| `logic-correctness` | general-purpose | **Adversarial semantic trace of every changed function** — wrong conditions, off-by-one, null, error handling — **plus sibling-path invariant completeness** | `references/review-heuristics.md` |
+| `spotbugs` | task | SpotBugs pass across **all** touched Java modules | — |
+| `principles` | explore | SOLID / DRY / KISS / clean-code + refactoring.guru smells & patterns | `references/refactoring-guru-checks.md` |
+| `goal-scope` | explore | Goal completeness; scope correctness; agnostic/extensible/reusable | — |
+| `docs-accuracy` | explore | Javadoc/comment claims vs implementation | `references/review-heuristics.md` |
+| `sensitive-data` | general-purpose | Secret/PII leaks via exceptions & logs | `references/review-heuristics.md` |
+| `test-quality` | explore | Branch coverage, assertion strength, boundaries, per-unit | `references/review-heuristics.md` |
+| `dead-code` | explore | Unused members, unreachable/vacuous code, dead API, scaffolding | `references/review-heuristics.md` |
+| `third-party` | explore | Deprecated SDK calls; unnormalized external values | `references/review-heuristics.md` |
+
+Per-agent task specs (append to the shared context block):
+
+- **`logic-correctness`** — the **highest-priority** pass and the one most likely
+  to catch a serious bug. Do **not** scan for smells: for every changed function
+  and branch, read it in full context, state its contract, then **simulate it
+  against edge/hostile inputs** (null, empty, 0, negative, boundary ± 1, max,
+  duplicates, wrong-case) and verify each branch's result. Flag every input that
+  yields wrong behaviour as `[correctness]`, citing `file:line` **and the
+  triggering input**. Then, for any changed side effect tied to a lifecycle/state
+  transition, run the **sibling-path completeness** check — enumerate *every*
+  path that reaches the same state (grep the underlying state mutation and all
+  sibling intents/appliers, not just the ones in the diff) and confirm each
+  performs the equivalent step or provably cannot reach that state. Never dismiss
+  a sibling path by asserting an invariant — verify it in code. Run on a
+  high-capability model at high reasoning effort.
+  See `references/review-heuristics.md` → "Logic correctness — adversarial trace"
+  and "Sibling-path / invariant completeness".
+- **`spotbugs`** — run the curated review profile scoped to the branch diff, once
+  per touched Java module. This catches logic smells the repo/CI filter omits
+  (vacuous `instanceof`, useless/dead code, `==` on Strings, redundant
+  null-checks, swallowed exceptions, security):
+  ```bash
+  scripts/camunda-static-analysis.sh -a spotbugs -p review \
+    --changed-base "$BASE" <module>
+  ```
+  - Pass **only Java modules**. Skip `*/client` (frontend) and pure-resource changes.
+  - If an upstream module changed (e.g. `optimize-commons` feeding
+    `optimize/backend`), add `-i` so its JAR is reinstalled, else compilation
+    resolves against a stale dependency.
+  - Optimize modules are auto-handled (`include-optimize`). For a deep pass on a
+    small change use `-p all`.
+  - **This single agent handles every module sequentially** — do not split
+    SpotBugs across parallel agents, because `-i` runs `mvn install` and
+    concurrent installs corrupt the local repo.
+  - Map priority to severity: HIGH/MED correctness-class → `correctness`;
+    STYLE/dead-code → `clean`. Record type, category, `file:line`, message.
+- **`principles`** — read `references/refactoring-guru-checks.md`; scan each
+  changed hunk against the smell catalog (Bloaters, OO Abusers, Change
+  Preventers, Dispensables, Couplers) and assess SOLID / DRY / KISS / clean-code.
+  For every real hit, name the matching refactoring technique and/or design
+  pattern as the remedy; flag misapplied/over-engineered patterns as speculative
+  generality `[KISS]`. Honor KISS/YAGNI — do not demand patterns.
+- **`goal-scope`** — Does the change **fully** address GOAL? Is it scoped to the
+  right module(s) with no drive-by edits, unrelated refactors, or formatting
+  churn? Are the changes agnostic/extensible/reusable where reasonable (flag
+  hard-coded assumptions / one-off logic that should be shared — respect
+  YAGNI/KISS)? If GOAL is to maintain an invariant on a state transition (add
+  cleanup / a step when an entity reaches some state), confirm the change covers
+  **all** paths to that state, not only the ones named in the commit — apply the
+  "Sibling-path / invariant completeness" check in `references/review-heuristics.md`
+  and flag any uncovered sibling path (`[correctness]` if it leaks the invariant,
+  `[hygiene]` if the fix is deliberately scoped but the boundary is left implicit).
+- **`docs-accuracy`** — see `references/review-heuristics.md` → "Documentation accuracy".
+- **`sensitive-data`** — see `references/review-heuristics.md` → "Sensitive-data hygiene".
+- **`test-quality`** — see `references/review-heuristics.md` → "Test quality, not just presence".
+- **`dead-code`** — see `references/review-heuristics.md` → "Dead / unused code".
+- **`third-party`** — see `references/review-heuristics.md` → "Third-party API usage".
+
+### Phase 3 — Consolidate (orchestrator)
+
+Collect every agent's finding lines and merge into one report:
+
+- **Dedupe overlaps** — the same `file:line` issue can surface from multiple
+  agents (e.g. `spotbugs` and `dead-code` both flag an unused private). Keep one
+  line, preferring the SpotBugs-attributed wording when they coincide.
+- Normalise tags and order by severity per the Severity tags section.
+- If an agent returned nothing, that's fine ("no findings" is valid). If one
+  failed, note it and re-run just that topic yourself — don't block the report.
+- Emit the single report below.
+
+## Output format
+
+Produce a single consolidated report:
+
+```
+## Branch Code Review
+
+**Goal:** <one line>  | **Base:** <short-sha>  | **Modules:** <list>
+
+### Goal & scope
+- Fully addresses goal: yes/partial/no — <why>
+- Scoped correctly: yes/no — <unrelated files, if any>
+- Agnostic/extensible/reusable: <assessment>
+
+### Findings
+- `path/File.java:120` [correctness] BC_VACUOUS_INSTANCEOF — instanceof always
+  true; the guarded early-return branch is dead code. (SpotBugs)
+- `path/File.java:88` [DRY] Two variants duplicate the same aggregation logic;
+  extract a shared helper.
+- `path/Other.java:42` [clean] Magic string literal — replace with the existing
+  named constant.
+- `path/Helper.java:67` [clean] Unused private method added on this branch but no
+  caller; remove or wire it up.
+...
+
+### Summary
+<counts by severity; top 1-3 things to fix before merge; note any agent that was
+skipped (e.g. spotbugs runner unavailable) or failed>
+```
+
+Tag and order findings per the **Severity tags** section above
+(correctness > SOLID > DRY > KISS > clean > hygiene).
+
+## Rules
+
+- Every finding **must** cite `file:line`. No vague or whole-file findings.
+- High signal-to-noise: report real issues only. Do not invent problems to fill
+  the list; "no findings in category X" is a valid result.
+- Each fan-out agent owns exactly its topic/tool and returns only finding lines;
+  the orchestrator does setup and consolidation. On larger diffs launch the
+  agents in parallel (one message, multiple task calls) — they are read-only and
+  independent; on a small diff (Phase 2 threshold) run the same checks inline.
+- Do **not** modify code being reviewed — review only. Offer fixes only if asked.
+- Attribute SpotBugs findings with "(SpotBugs)"; everything else is manual.
+- Respect repo conventions in `AGENTS.md` and module docs over generic ideals
+  (e.g. Optimize C7 naming, JSpecify nullness migration done in separate commits).

--- a/skills/camunda-branch-code-review/SKILL.md
+++ b/skills/camunda-branch-code-review/SKILL.md
@@ -112,7 +112,8 @@ KISS, clean, hygiene — as defined in the skill's Severity tags section.
 OUTPUT: only finding lines, one per line, no preamble:
   `path/File.java:NN [tag] message`
 Cite file:line for every finding; suffix SpotBugs hits with "(SpotBugs)".
-High signal only — "No findings" is a valid result; do not invent issues.
+High signal only — do not invent issues. If you have nothing to report, output
+the single literal line `No findings` (exactly that, no file:line, nothing else).
 ```
 
 ### Phase 2 — Fan out to parallel review agents
@@ -216,7 +217,7 @@ Collect every agent's finding lines and merge into one report:
   agents (e.g. `spotbugs` and `dead-code` both flag an unused private). Keep one
   line, preferring the SpotBugs-attributed wording when they coincide.
 - Normalise tags and order by severity per the Severity tags section.
-- If an agent returned nothing, that's fine ("no findings" is valid). If one
+- If an agent returned nothing (the literal `No findings`), that's fine. If one
   failed, note it and re-run just that topic yourself — don't block the report.
 - Emit the single report below.
 

--- a/skills/camunda-branch-code-review/references/refactoring-guru-checks.md
+++ b/skills/camunda-branch-code-review/references/refactoring-guru-checks.md
@@ -1,0 +1,95 @@
+# Refactoring.guru checks reference
+
+Catalog used by the **camunda-branch-code-review** skill as an additional source of
+review checks, derived from:
+
+- Code smells & refactoring techniques — <https://refactoring.guru/refactoring>
+- Design patterns — <https://refactoring.guru/design-patterns>
+
+Use these as a **checklist to detect problems and recommend remedies** — not as
+a mandate to introduce patterns. Respect KISS/YAGNI: only suggest a refactoring
+or pattern when it removes a concrete smell in the changed code. Every finding
+must still cite `file:line`.
+
+Map findings to the skill's severity tags as noted per group (most smells →
+`DRY`/`KISS`/`clean`/`SOLID`; provably-dead/broken → `correctness`).
+
+---
+
+## 1. Code smells (detect these)
+
+### Bloaters — code/methods/classes grown too large
+- **Long Method** — method > ~10 lines doing too much. → *Extract Method*. `[KISS/clean]`
+- **Large Class** — too many fields/methods/responsibilities. → *Extract Class/Subclass*, *Extract Interface*. `[SOLID]`
+- **Primitive Obsession** — primitives/constants/strings instead of small types; constants encoding info (e.g. `ROLE=1`); string keys for pseudo-fields. → *Replace Data Value with Object*, *Replace Type Code with Class/Enum*. `[clean]`
+- **Long Parameter List** — > ~3-4 params. → *Introduce Parameter Object*, *Preserve Whole Object*. `[clean]`
+- **Data Clumps** — same group of fields/params recurring together. → *Extract Class*, *Introduce Parameter Object*. `[DRY]`
+
+### Object-Orientation Abusers — incomplete/incorrect use of OO
+- **Switch Statements / type-dispatch** — `switch`/`if-else` on a type code, repeated. → *Replace Conditional with Polymorphism*, *Strategy/State*. `[SOLID]`
+- **Temporary Field** — field set only in some circumstances; empty otherwise. → *Extract Class*, *Introduce Null Object*. `[clean]`
+- **Refused Bequest** — subclass uses little of its inherited API, or overrides to no-op/throw. → *Replace Inheritance with Delegation*, *Extract Superclass*. `[SOLID]`
+- **Alternative Classes with Different Interfaces** — two classes do the same job with different method names. → *Rename/Move Method*, unify interface. `[DRY/SOLID]`
+
+### Change Preventers — one change forces many edits
+- **Divergent Change** — one class changed for many unrelated reasons. → *Extract Class* (SRP). `[SOLID]`
+- **Shotgun Surgery** — one logical change requires edits scattered across many classes. → *Move Method/Field*, *Inline Class*. `[SOLID]`
+- **Parallel Inheritance Hierarchies** — every subclass of A forces a subclass of B (a special Shotgun Surgery). → collapse/merge hierarchies. `[SOLID]`
+
+### Dispensables — pointless things to remove
+- **Duplicate Code** — identical/near-identical fragments (incl. copy-pasted ES/OS or per-DB variants beyond the established dual-stack split). → *Extract Method*, *Pull Up Method*, *Form Template Method*. `[DRY]`
+  - **Verify against existing code, not just within the diff.** New duplication is often a copy of a block that *already exists elsewhere in the codebase* — so it won't show up by eyeballing the hunk alone. When a hunk adds a non-trivial loop/helper (e.g. a "collect entries into a list, then act on each" visit pattern, or a specific query-and-filter sequence), grep the touched package/module for the same shape (the same state API call, the same visitor lambda) before accepting it. A small shared state helper often removes both copies. `[DRY]`
+- **Dead Code** — unreachable branch, unused var/param/field/method, vacuous condition. → delete. `[correctness]` if provably unreachable, else `[clean]`
+- **Lazy Class** — class doing too little to justify its existence. → *Inline Class*, *Collapse Hierarchy*. `[clean]`
+- **Speculative Generality** — unused abstraction/hook/param "for the future" (YAGNI). → *Collapse Hierarchy*, *Inline Class*, *Remove Parameter*. `[KISS]`
+- **Data Class** — class with only fields + getters/setters and no behavior, while logic lives elsewhere. → *Move Method* behavior in. `[SOLID]` (note: DTOs/records are legitimate; only flag when behavior is misplaced).
+- **Comments (as deodorant)** — comments explaining *what* obscure code does instead of *why*. → *Extract Method* with intention-revealing name, *Rename*. `[clean]`
+- **Misleading / imprecise name** — a method/field/variable name that implies something the code doesn't do (wrong cardinality, wrong subject, wrong action). Check every new public API name against what it *actually* operates on. → *Rename Method/Field*. `[clean]`.
+
+### Couplers — excessive coupling
+- **Feature Envy** — method more interested in another class's data than its own. → *Move Method*, *Extract Method*. `[SOLID]`
+- **Inappropriate Intimacy** — classes reach into each other's internals / mutable shared state / hidden side-channels (temporal coupling). → *Move Method/Field*, *Hide Delegate*, pass data explicitly. `[SOLID]`
+- **Message Chains** — `a.getB().getC().getD()`. → *Hide Delegate*. `[clean]`
+- **Middle Man** — class that only delegates to another. → *Remove Middle Man*. `[clean]` (note: Facade/delegation can be intentional — don't over-flag).
+- **Incomplete Library Class** — library missing needed methods. → *Introduce Foreign Method / Local Extension*. `[clean]`
+
+---
+
+## 2. Refactoring techniques (recommend these as remedies)
+
+Cite the technique by name when proposing a fix.
+
+- **Composing Methods:** Extract Method, Inline Method, Extract Variable, Inline Temp, Replace Temp with Query, Split Temporary Variable, Remove Assignments to Parameters, Replace Method with Method Object, Substitute Algorithm.
+- **Moving Features between Objects:** Move Method, Move Field, Extract Class, Inline Class, Hide Delegate, Remove Middle Man, Introduce Foreign Method, Introduce Local Extension.
+- **Organizing Data:** Encapsulate Field/Collection, Replace Data Value with Object, Replace Type Code with Class/Subclasses/State-Strategy, Replace Array with Object, Replace Magic Number with Symbolic Constant.
+- **Simplifying Conditionals:** Decompose Conditional, Consolidate Conditional Expression, Consolidate Duplicate Conditional Fragments, Remove Control Flag, Replace Nested Conditional with Guard Clauses, Replace Conditional with Polymorphism, Introduce Null Object, Introduce Assertion.
+- **Simplifying Method Calls:** Rename Method, Add/Remove Parameter, Introduce Parameter Object, Preserve Whole Object, Separate Query from Modifier, Replace Parameter with Explicit Methods, Replace Error Code with Exception.
+- **Dealing with Generalization:** Pull Up / Push Down Field & Method, Extract Subclass/Superclass/Interface, Collapse Hierarchy, Form Template Method, Replace Inheritance with Delegation (and vice versa).
+
+---
+
+## 3. Design patterns (recognize fit & misuse)
+
+Use to (a) suggest a pattern when it cleanly removes a smell, and (b) flag a
+**misapplied/over-engineered** pattern (itself a Speculative Generality smell).
+Tag pattern-fit findings `[SOLID]` (or `[KISS]` when the pattern is overkill).
+
+- **Creational:** Factory Method, Abstract Factory, Builder, Prototype, Singleton.
+  - Cues: sprawling `new`/switch-on-type construction → Factory; telescoping constructors / Long Parameter List on build → Builder; global mutable singletons → review for testability.
+- **Structural:** Adapter, Bridge, Composite, Decorator, Facade, Flyweight, Proxy.
+  - Cues: Alternative Classes w/ Different Interfaces → Adapter; tree of part/whole → Composite; wrapping to add behavior → Decorator; subsystem entry point → Facade (legitimate Middle Man).
+- **Behavioral:** Chain of Responsibility, Command, Iterator, Mediator, Memento, Observer, State, Strategy, Template Method, Visitor.
+  - Cues: Switch/type-dispatch → Strategy/State/Polymorphism; duplicated algorithm skeleton across ES/OS or sub-types → Template Method; many-to-many object refs → Mediator; behavior varying by lifecycle status flag → State.
+
+### Pattern anti-checks (flag as `[KISS]`)
+- Pattern introduced with a single implementation and no second caller (Speculative Generality).
+- Indirection that adds layers without removing duplication or coupling.
+- A "manager/util" Facade that only forwards calls (Middle Man) with no cohesion gain.
+
+---
+
+## How to apply during review (Step 5 of SKILL.md)
+1. For each changed hunk, scan the smell list above; record concrete hits with `file:line`.
+2. Name the matching **refactoring technique** and/or **pattern** as the suggested remedy.
+3. Keep high signal: report a smell only if it's real in the changed code, not theoretical. "No smells in category X" is fine.
+4. Honor repo conventions (e.g. Optimize's intentional ES/OS dual stack, C7 `Id`/`Key` naming, JSpecify migration in separate commits) over generic catalog advice.

--- a/skills/camunda-branch-code-review/references/review-heuristics.md
+++ b/skills/camunda-branch-code-review/references/review-heuristics.md
@@ -1,0 +1,226 @@
+# Review heuristics — detailed guidance
+
+Depth reference for the **camunda-branch-code-review** skill. `SKILL.md` keeps
+the checklist scannable; this file holds the rationale and edge cases behind each
+check. Consult the relevant section when a checklist item fires and you need the
+full reasoning.
+
+---
+
+## Logic correctness — adversarial trace (`logic-correctness` agent)
+
+The highest-recall correctness check, and the one a checklist alone misses. Do
+**not** skim the hunk for smells — **simulate the changed code against hostile
+inputs** and confirm each branch produces the right result. Run this on a
+high-capability reasoning model, not a lightweight one.
+
+Method — for every changed or added function/method (and every changed branch):
+
+1. **Read it in full context**, not just the diff hunk — open the file so you
+   see the surrounding method, the fields it touches, and what its callers
+   expect back.
+2. **State its intended contract** in one line (what it must return / do for
+   which inputs). If the diff changed that contract, note who relies on the old one.
+3. **Enumerate every branch** (`if`/`else`, `switch` arm, ternary, `catch`, loop
+   entry/exit, early return) and pick **concrete edge inputs** for each: `null`,
+   empty, `0`, negative, `1`, the exact boundary and boundary ± 1, max,
+   duplicates, unsorted, wrong-case, and the "impossible" value.
+4. **Mentally execute** each input and check the actual output / side effect /
+   thrown exception is correct. Any input that yields wrong behaviour is a
+   `[correctness]` finding — cite `file:line` **and the triggering input**.
+
+Scan specifically for these bug classes — this is where real logic bugs hide:
+
+- **Conditions & booleans** — wrong comparison (`<` vs `<=`, `>` vs `>=`),
+  inverted/negated logic, `&&` vs `||`, De Morgan mistakes, operator precedence,
+  a guard that is always true / always false, a condition testing the wrong
+  variable (copy-paste).
+- **Off-by-one & ranges** — loop bounds, index arithmetic, `substring`/slice
+  ranges, inclusive-vs-exclusive limits, `size` vs `size - 1`, `<= limit` vs
+  `< limit` on a max-size check.
+- **Null / empty / Optional** — unchecked dereference of a value that can be null
+  (map `get`, first element, injected field, method return), `Optional.get`
+  without `isPresent`, empty-collection access, autoboxing NPE (`int` from a
+  nullable `Integer`), a new branch that skips the null-handling done elsewhere.
+- **Error / exception handling** — swallowed or too-broadly-caught exception,
+  wrong exception type, control flow that depends on an exception that won't
+  fire, missing rollback/cleanup/resource-close on the error path, returning
+  `null`/empty/partial (or a success code) on failure, not restoring state after
+  a caught error, ignoring a return/status code that signals failure.
+- **Arithmetic** — integer overflow/underflow, `int` division truncation,
+  division/modulo by zero, sign errors, rounding, `int` where a `long` is needed.
+- **Equality & identity** — `==` on objects/boxed types instead of `equals`, an
+  enum compared by its value string, broken `equals`/`hashCode`, case/whitespace
+  sensitivity on external strings.
+- **State & ordering** — a value read before it is set, mutation of a shared or
+  argument object, an operation whose correctness depends on order, a field
+  updated without its parallel field, a stale cached value.
+- **Collections & streams** — concurrent modification during iteration, wrong
+  default from `getOrDefault`, a filter/`distinct` that drops or keeps the wrong
+  elements, `findFirst` on an unordered stream.
+- **Data flow** — a value computed but never used or returned, the wrong
+  variable used (copy-paste), swapped arguments, a unit/type mismatch.
+
+Do not stop at the first bug in a method — trace the whole thing. "No
+correctness issues after tracing X inputs" is a valid, useful result.
+
+---
+
+## Sibling-path / invariant completeness (`logic-correctness` + `goal-scope` agents)
+
+The highest-value *whole-diff* check, and the one this skill has actually missed
+in practice. When a change adds a step to **one** code path that maintains an
+invariant, verify **every sibling path that reaches the same state also performs
+that step** — a maintained invariant must hold on *all* paths, not just the one
+or two named in the commit message. Partial coverage of a set of equivalent
+paths is a real `[correctness]` defect (a leaked/inconsistent invariant), not a
+nitpick.
+
+**Do not reason your way out of this by asserting an invariant — verify it in
+code.** If you find yourself thinking "path X can't happen because Y", that "Y"
+is a claim you must confirm by *reading the code for path X*, not a licence to
+skip it. Abstract reasoning ("a parked job can't be completed, so I don't need
+to check completion") is exactly how a leaked invariant on an unenumerated
+sibling path slips through.
+
+Method — when the diff adds/removes a side effect tied to a lifecycle or state
+transition (cleanup, index update, metric, counter, notification, resource
+release, cache invalidation, parallel-field update):
+
+1. **Name the invariant** the new step maintains (e.g. "no waiting-secret-index
+   rows survive once a job leaves `JobState`").
+2. **Enumerate every path that reaches the same terminal state / does the same
+   trigger action** — don't trust the commit message's list. Grep for the
+   underlying operation, not just the intent named in the diff. Concretely:
+   - the state mutation the new step pairs with — e.g. grep every caller of
+     `jobState.delete` / `.remove` / `.cancel` / `.complete`, every writer of the
+     sibling intents (`grep "JobIntent.<X>"` for **all** terminal intents, not
+     just the changed one), every applier/processor for the same value type.
+   - **versioned appliers**: if the change adds behaviour to
+     `FooCompletedV4Applier`, list *all* `Foo*Applier` classes that delete/finish
+     the same entity (`FooCanceledV*`, `FooErrorThrownV*`, `FooTimedOutV*`, …) and
+     confirm each either performs the step or provably cannot reach the state.
+3. **For each sibling path, confirm** it either (a) performs the equivalent step,
+   or (b) provably cannot reach the state that needs it — and back (b) with the
+   specific code line that makes it impossible, not intuition.
+4. Flag every sibling path that drops the invariant as `[correctness]`, citing
+   its `file:line` and naming the leaked/inconsistent state. If the author
+   intends to scope the fix to a subset, that scoping must be stated as an
+   explicit invariant in the code/PR — flag `[hygiene]` if it is merely implicit.
+
+---
+
+## New-module javadoc placeholder (Phase 1 setup)
+
+When a branch adds a brand-new Maven module (a new `pom.xml` under a module
+directory), flag it if it ships with **no public/protected classes yet** (e.g.
+only `package-info.java`).
+
+Why: the release process attaches a javadoc jar to every Java module, and
+`javadoc` treats *"No public or protected classes found to document"* as a
+**hard build failure**, which breaks the scheduled release dry-run.
+
+- If the module is intentionally scaffolded ahead of its content, it must carry
+  the `maven.javadoc.skip=true` + empty-javadoc-jar placeholder — the existing
+  convention in `zeebe/protocol-asserts`, `zeebe/expression-language`,
+  `optimize`, `operate`, `tasklist`, `webapp`. Flag `[hygiene]` if it's missing.
+- Once real classes land (often in a later branch/PR building on the scaffold),
+  flag `[hygiene]` if the placeholder is still present but no longer needed —
+  leaving it in permanently just hides future javadoc regressions instead of
+  catching them.
+
+---
+
+## Documentation accuracy (`docs-accuracy` agent)
+
+For every Javadoc/comment claim about behavior (auth/permission model, which
+error/status a branch returns, mutual-exclusivity rules, thread-safety, ordering
+guarantees), grep the actual implementation and confirm it matches. Don't take a
+docstring's claim at face value — treat it as a **testable assertion about the
+code**, not background prose. Flag `[hygiene]` if stale/wrong.
+
+---
+
+## Sensitive-data hygiene (`sensitive-data` agent)
+
+In any code that handles secrets, credentials, tokens, personal data, or other
+data that must not be exposed: do thrown exceptions, wrapped causes, or log/error
+messages ever carry raw content derived from that value?
+
+Parser exceptions in particular (JSON/YAML/regex/XML) commonly embed a snippet
+of their input in `getMessage()` — if that input is (or contains) the sensitive
+value, it leaks into logs, error responses, or stack traces. Flag `[correctness]`
+(a real bug, not style) any exception path that propagates `e.getMessage()` or
+the exception itself from parsing/processing a value that must stay confidential.
+
+---
+
+## Test quality, not just presence (`test-quality` agent)
+
+Target: every changed/added line of production code in the diff is exercised by
+at least one test — every new method, every new/changed branch (`if`/`else`,
+`switch` arm, `catch` block, ternary), not just "the class has some tests." No
+automated diff-coverage tool is wired into this skill, so do this manually: for
+each changed/added non-test file, walk each new or modified conditional arm and
+confirm a test in the diff (or already in the suite) actually drives execution
+down that arm — don't infer coverage from a method merely being *called* by a
+test, confirm the specific branch is reached. Flag every uncovered branch/arm
+individually with `[hygiene]` (or `[correctness]` if the untested path is where a
+bug would most likely hide) — list each one by `file:line`, don't just note
+"coverage could be better." A green full suite proves nothing here: a whole new
+class, or one branch of an `if`/`switch` in an otherwise-tested method, can sit
+completely uncovered while every existing test keeps passing.
+
+- **Assertion strength** — a loose assertion (`contains`, `anyMatch`,
+  `isNotEmpty`) where a stronger one (`containsExactly`,
+  `containsExactlyInAnyOrder`, an exact equality check) would catch a missing or
+  unexpected-extra item that the loose form silently lets through. `[clean]` or
+  `[correctness]` if the looseness could actually mask a bug.
+- **Boundary/edge cases** — for any logic with a size limit, page/batch
+  boundary, min/max range, or empty/single/many cardinality, is there a test at
+  the boundary (exactly at the limit, one over it, empty), not just the
+  happy-path middle case? Flag `[hygiene]` if only the happy path is exercised.
+- **Per-unit coverage** — does every new class/function with non-trivial logic
+  have its own direct test, or is it only exercised incidentally as a side effect
+  of testing something else? Incidental-only coverage is fragile — flag
+  `[hygiene]`.
+
+---
+
+## Dead / unused code (`dead-code` agent)
+
+Scan every changed hunk for code that is added or left behind but never actually
+reached or used. Flag each occurrence individually by `file:line`:
+
+- **Unused members** — new `private` methods, fields, constants, parameters, or
+  local variables that nothing references (SpotBugs `UPM_*`/`URF_*`/`DLS_*` catch
+  some, but not all — confirm by grepping for each new private symbol's usages
+  within its scope).
+- **Unreachable / vacuous code** — statements after an unconditional
+  `return`/`throw`, branches whose condition is always true/false, `catch` blocks
+  for exceptions that can't be thrown, `default` arms that can't be hit, or
+  guards made redundant by an earlier check.
+- **Dead public API surface** — a new public/protected method or overload the
+  branch introduces but neither wires up nor tests, and that no caller exists for
+  (speculative generality — YAGNI). Distinguish from an intentionally-public
+  SPI/extension point.
+- **Leftover scaffolding** — commented-out code, `System.out`/debug prints,
+  unused imports, orphaned helper classes, or a feature flag/branch that is never
+  enabled.
+
+Tag `[clean]` for harmless-but-unused code, `[hygiene]` for leftover
+scaffolding/commented-out code, and `[correctness]` when the dead path hides a
+real intent (e.g. an always-false guard that was *meant* to protect something).
+Never silently accept "it'll be used in a later PR" — if there is no caller and
+no test on this branch, flag it and let the author confirm.
+
+---
+
+## Third-party API usage (`third-party` agent)
+
+When the diff calls into an external library/SDK: check for deprecated
+methods/fields (per that library's currently-pinned version) that have a
+documented non-deprecated replacement, and check whether the code trusts an
+external string/code/enum-like value verbatim in a `switch`/`equals`/comparison
+without normalizing case/whitespace first — external systems don't always
+guarantee exact formatting across versions.

--- a/skills/camunda-branch-code-review/scripts/camunda-static-analysis.sh
+++ b/skills/camunda-branch-code-review/scripts/camunda-static-analysis.sh
@@ -176,7 +176,11 @@ info "Analyzers: ${ANALYZERS}"
 has spotbugs && info "SpotBugs profile: ${BOLD}${SB_PROFILE}${RESET}$( [[ "$CHANGED_ONLY" -eq 1 ]] && echo " (changed files only)")"
 
 # Build the set of changed Java source files for --changed-only reporting.
+# Match on the package-relative source path (e.g. io/camunda/.../Foo.java) so
+# same-named files in different modules don't collide in a monorepo; keep a
+# basename set as a fallback for SpotBugs entries that lack a sourcepath.
 declare -A CHANGED_SET=()
+declare -A CHANGED_BASENAMES=()
 if [[ "$CHANGED_ONLY" -eq 1 ]]; then
   if [[ -n "$CHANGED_BASE" ]]; then
     mapfile -t _cf < <(git diff --name-only "$CHANGED_BASE" -- '*.java')
@@ -185,8 +189,19 @@ if [[ "$CHANGED_ONLY" -eq 1 ]]; then
                           git diff --cached --name-only -- '*.java'; \
                           git ls-files --others --exclude-standard -- '*.java'; } | sort -u )
   fi
-  for f in "${_cf[@]}"; do [[ -n "$f" ]] && CHANGED_SET["$(basename "$f")"]=1; done
-  info "Changed Java files: ${#CHANGED_SET[@]}"
+  for f in "${_cf[@]}"; do
+    [[ -z "$f" ]] && continue
+    rel="$f"
+    case "$f" in
+      */src/main/java/*) rel="${f#*/src/main/java/}" ;;
+      */src/test/java/*) rel="${f#*/src/test/java/}" ;;
+      src/main/java/*)   rel="${f#src/main/java/}" ;;
+      src/test/java/*)   rel="${f#src/test/java/}" ;;
+    esac
+    CHANGED_SET["$rel"]=1
+    CHANGED_BASENAMES["$(basename "$f")"]=1
+  done
+  info "Changed Java files: ${#CHANGED_BASENAMES[@]}"
 fi
 
 # Optimize lives behind the `include-optimize` profile, which is auto-disabled
@@ -226,14 +241,18 @@ run_step() {
 #             spotbugs:spotbugs goal, then parse + print findings ourselves
 #             (optionally scoped to changed files).
 print_spotbugs_findings() {
+  command -v python3 >/dev/null 2>&1 \
+    || die "python3 is required to parse SpotBugs findings but was not found on PATH."
   CHANGED_ONLY="$CHANGED_ONLY" \
   CHANGED_LIST="$(printf '%s\n' "${!CHANGED_SET[@]}")" \
+  CHANGED_BASENAMES="$(printf '%s\n' "${!CHANGED_BASENAMES[@]}")" \
   python3 - "$@" <<'PY'
 import os, sys, glob
 import xml.etree.ElementTree as ET
 
 changed_only = os.environ.get("CHANGED_ONLY") == "1"
 changed = {l for l in os.environ.get("CHANGED_LIST", "").splitlines() if l}
+changed_basenames = {l for l in os.environ.get("CHANGED_BASENAMES", "").splitlines() if l}
 RED, YEL, GRN, BOLD, RST = "\033[31m", "\033[33m", "\033[32m", "\033[1m", "\033[0m"
 prio = {"1": f"{RED}HIGH{RST}", "2": f"{YEL}MED {RST}", "3": f"{GRN}LOW {RST}"}
 
@@ -245,15 +264,23 @@ for module in sys.argv[1:]:
     root = ET.parse(xml).getroot()
     for b in root.iter("BugInstance"):
         sl = b.find("SourceLine")
+        # Prefer the package-relative sourcepath (unique across modules); fall
+        # back to the bare sourcefile only when sourcepath is unavailable.
+        sp = sl.get("sourcepath") if sl is not None else None
         src = sl.get("sourcefile") if sl is not None else None
-        if changed_only and (src is None or src not in changed):
-            continue
+        if changed_only:
+            if sp is not None:
+                if sp not in changed:
+                    continue
+            elif src is None or src not in changed_basenames:
+                continue
         cls = next((c.get("classname", "") for c in b.findall("Class")), "")
         line = sl.get("start") if sl is not None else "?"
+        loc = sp or src or "?"
         msg = b.findtext("LongMessage") or b.findtext("ShortMessage") or ""
         p = prio.get(b.get("priority", "2"), "    ")
         print(f"  [{p}] {BOLD}{b.get('type')}{RST} ({b.get('category')})")
-        print(f"        {src}:{line}  {cls}")
+        print(f"        {loc}:{line}  {cls}")
         print(f"        {msg}")
         total += 1
 
@@ -308,8 +335,6 @@ if has sonar; then
         key="${PROJECT_KEY}"
         [[ ${#MODULES[@]} -gt 1 ]] && key="${PROJECT_KEY}-$(echo "$m" | tr '/' '-')"
         info "Sonar scan: ${BOLD}${m}${RESET} (key=${key})"
-        bin="$m/target/classes"; tbin="$m/target/test-classes"
-        binaries="$bin"; [[ -d "$tbin" ]] && binaries="$bin,$tbin"
         org_arg=(); [[ -n "$SONAR_ORG" ]] && org_arg=(-Dsonar.organization="$SONAR_ORG")
         ( cd "$m" && sonar-scanner \
             -Dsonar.host.url="$SONAR_HOST_URL" \

--- a/skills/camunda-branch-code-review/scripts/camunda-static-analysis.sh
+++ b/skills/camunda-branch-code-review/scripts/camunda-static-analysis.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+#
+# camunda-static-analysis.sh
+# -------------------------------------------------------------------------
+# Standalone static-analysis runner for the camunda/camunda monorepo.
+#
+# Runs two analyzers, on demand, against one or more Maven modules:
+#   * SpotBugs     - via the repo's `-Pspotbugs` profile (effort=Max, Low
+#                    threshold) with the project's include/exclude filters.
+#   * SonarQube    - via the standalone SonarScanner CLI (`sonar-scanner`).
+#
+# This script ships INSIDE the camunda-branch-code-review skill and runs
+# AGAINST a separate camunda/camunda checkout - it is a review tool, not part
+# of the project build. Point it at a checkout with --repo or the CAMUNDA_REPO
+# env var (defaults to the current git repo). The SpotBugs include filters
+# (spotbugs-review-include.xml, spotbugs-all-include.xml) live next to it in
+# this scripts/ directory and are resolved relative to the script.
+#
+# -------------------------------------------------------------------------
+# Requirements
+#   * The camunda/camunda checkout (Maven wrapper `./mvnw`).
+#   * SonarScanner CLI on PATH (`sonar-scanner`) - only for the sonar step.
+#       brew install sonar-scanner
+#   * A reachable SonarQube/SonarCloud server for the sonar step:
+#       SONAR_HOST_URL   (default: http://localhost:9000)
+#       SONAR_TOKEN      (required for sonar; user/analysis token)
+#       SONAR_ORG        (optional; required for SonarCloud)
+#
+# -------------------------------------------------------------------------
+# Usage
+#   camunda-static-analysis.sh [options] [<module>...]
+#
+#   <module>...   One or more Maven module paths relative to the repo root
+#                 (e.g. zeebe/engine service). If omitted, modules are
+#                 auto-detected from your uncommitted git changes.
+#
+# Options
+#   -a, --analyzer <list>  Comma list of: spotbugs,sonar (default: both)
+#   -p, --profile <name>   SpotBugs rule set: repo|review|all (default: repo)
+#                            repo   - CORRECTNESS+MT_CORRECTNESS, fails like CI
+#                            review - curated high-signal set (catches vacuous
+#                                     instanceof, useless/dead code, == on
+#                                     Strings, security, ...); prints findings
+#                            all    - every category (noisy; use --changed-only)
+#       --changed-only     Report only findings in changed Java files
+#       --changed-base <r> Diff base ref for --changed-only (implies it)
+#   -r, --repo <path>      Path to the camunda checkout (default: cwd's repo)
+#   -k, --key <projectKey> Sonar project key (default: camunda-local)
+#   -i, --install-deps     Build/install module deps first (install -am -Dquickly)
+#   -o, --offline          Run Maven offline (-o)
+#   -h, --help             Show this help.
+#
+# Examples
+#   camunda-static-analysis.sh zeebe/engine
+#   camunda-static-analysis.sh -a spotbugs service search/search-client
+#   camunda-static-analysis.sh -a spotbugs -p review optimize/backend   # PR review
+#   camunda-static-analysis.sh -a spotbugs -p review --changed-only      # changed code
+#   camunda-static-analysis.sh -a spotbugs -p all --changed-base origin/main zeebe/engine
+#   SONAR_TOKEN=xxx camunda-static-analysis.sh -a sonar -k zeebe-engine zeebe/engine
+#   camunda-static-analysis.sh -i            # analyze changed modules, build deps
+#   camunda-static-analysis.sh -i -a spotbugs optimize/backend  # Optimize submodule
+#
+# Note on Optimize: target a submodule (optimize/backend|util|upgrade), not
+# `optimize`. The script auto-enables the `include-optimize` profile. If you
+# changed an upstream module (e.g. optimize-commons), pass -i so its JAR is
+# reinstalled - otherwise compilation resolves against a stale dependency.
+# -------------------------------------------------------------------------
+
+set -uo pipefail
+
+# Directory of this script (filters live next to it). Capture before any cd.
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Defaults -----------------------------------------------------------
+ANALYZERS="spotbugs,sonar"
+REPO="${CAMUNDA_REPO:-}"
+PROJECT_KEY="camunda-local"
+INSTALL_DEPS=0
+OFFLINE=""
+SB_PROFILE="repo"          # repo | review | all
+CHANGED_ONLY=0
+CHANGED_BASE=""            # git ref; empty = uncommitted working-tree changes
+MODULES=()
+SONAR_HOST_URL="${SONAR_HOST_URL:-http://localhost:9000}"
+SONAR_TOKEN="${SONAR_TOKEN:-}"
+SONAR_ORG="${SONAR_ORG:-}"
+
+# --- Colors -------------------------------------------------------------
+if [[ -t 1 ]]; then
+  RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+else
+  RED=""; GREEN=""; YELLOW=""; BOLD=""; RESET=""
+fi
+log()  { printf '%s\n' "$*"; }
+info() { printf '%s==>%s %s\n' "$BOLD" "$RESET" "$*"; }
+warn() { printf '%s[warn]%s %s\n' "$YELLOW" "$RESET" "$*" >&2; }
+die()  { printf '%s[error]%s %s\n' "$RED" "$RESET" "$*" >&2; exit 1; }
+usage() { sed -n '2,66p' "$0" | sed 's/^# \{0,1\}//'; }
+
+# --- Parse args ---------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -a|--analyzer)     ANALYZERS="$2"; shift 2 ;;
+    -r|--repo)         REPO="$2"; shift 2 ;;
+    -k|--key)          PROJECT_KEY="$2"; shift 2 ;;
+    -p|--profile)      SB_PROFILE="$2"; shift 2 ;;
+    --changed-only)    CHANGED_ONLY=1; shift ;;
+    --changed-base)    CHANGED_BASE="$2"; CHANGED_ONLY=1; shift 2 ;;
+    -i|--install-deps) INSTALL_DEPS=1; shift ;;
+    -o|--offline)      OFFLINE="-o"; shift ;;
+    -h|--help)         usage; exit 0 ;;
+    --)                shift; while [[ $# -gt 0 ]]; do MODULES+=("$1"); shift; done ;;
+    -*)                die "Unknown option: $1 (use -h for help)" ;;
+    *)                 MODULES+=("$1"); shift ;;
+  esac
+done
+
+has() { [[ ",$ANALYZERS," == *",$1,"* ]]; }
+
+# --- Resolve SpotBugs profile -> include filter -------------------------
+# repo   : use the repo's own filter (CORRECTNESS + MT_CORRECTNESS), run
+#          spotbugs:check (fails on findings) - matches CI exactly.
+# review : curated high-signal filter (adds BC_VACUOUS_INSTANCEOF, useless
+#          code, self-compares, == on Strings, security...).
+# all    : every category (noisy; pair with --changed-only).
+SB_INCLUDE=""
+case "$SB_PROFILE" in
+  repo)   ;;
+  review) SB_INCLUDE="$SELF_DIR/spotbugs-review-include.xml" ;;
+  all)    SB_INCLUDE="$SELF_DIR/spotbugs-all-include.xml" ;;
+  *)      die "Unknown --profile '$SB_PROFILE' (expected: repo|review|all)" ;;
+esac
+[[ -n "$SB_INCLUDE" && ! -f "$SB_INCLUDE" ]] && die "Missing filter file: $SB_INCLUDE"
+
+# --- Locate repo --------------------------------------------------------
+if [[ -z "$REPO" ]]; then
+  REPO="$(git rev-parse --show-toplevel 2>/dev/null)" \
+    || die "Not inside a git repo and --repo/CAMUNDA_REPO not set."
+fi
+[[ -f "$REPO/pom.xml" ]] || die "Repo has no pom.xml: $REPO"
+cd "$REPO"
+MVN="./mvnw"; [[ -x "$MVN" ]] || MVN="mvn"
+info "Repo: ${BOLD}${REPO}${RESET}"
+
+# --- Auto-detect modules from git changes -------------------------------
+find_module_for_path() {
+  local p="$1" candidate=""
+  p="$(dirname "$p")"
+  while [[ "$p" != "." && -n "$p" ]]; do
+    [[ -f "$p/pom.xml" ]] && candidate="$p"
+    p="$(dirname "$p")"
+  done
+  [[ -n "$candidate" ]] && printf '%s\n' "$candidate"
+}
+
+if [[ ${#MODULES[@]} -eq 0 ]]; then
+  info "No modules given - detecting from uncommitted git changes..."
+  mapfile -t CHANGED < <( { git diff --name-only -- '*.java'; \
+                            git diff --cached --name-only -- '*.java'; \
+                            git ls-files --others --exclude-standard -- '*.java'; } | sort -u )
+  declare -A SEEN=()
+  for f in "${CHANGED[@]}"; do
+    [[ -z "$f" || ! -e "$f" ]] && continue
+    m="$(find_module_for_path "$f")"
+    [[ -n "$m" && -z "${SEEN[$m]:-}" ]] && { SEEN[$m]=1; MODULES+=("$m"); }
+  done
+  [[ ${#MODULES[@]} -eq 0 ]] && die "No changed Java modules detected. Pass module path(s) explicitly."
+fi
+
+for m in "${MODULES[@]}"; do
+  [[ -f "$m/pom.xml" ]] || die "Not a Maven module (no pom.xml): $m"
+done
+PL="$(IFS=,; echo "${MODULES[*]}")"
+info "Modules:   ${BOLD}${PL}${RESET}"
+info "Analyzers: ${ANALYZERS}"
+has spotbugs && info "SpotBugs profile: ${BOLD}${SB_PROFILE}${RESET}$( [[ "$CHANGED_ONLY" -eq 1 ]] && echo " (changed files only)")"
+
+# Build the set of changed Java source files for --changed-only reporting.
+declare -A CHANGED_SET=()
+if [[ "$CHANGED_ONLY" -eq 1 ]]; then
+  if [[ -n "$CHANGED_BASE" ]]; then
+    mapfile -t _cf < <(git diff --name-only "$CHANGED_BASE" -- '*.java')
+  else
+    mapfile -t _cf < <( { git diff --name-only -- '*.java'; \
+                          git diff --cached --name-only -- '*.java'; \
+                          git ls-files --others --exclude-standard -- '*.java'; } | sort -u )
+  fi
+  for f in "${_cf[@]}"; do [[ -n "$f" ]] && CHANGED_SET["$(basename "$f")"]=1; done
+  info "Changed Java files: ${#CHANGED_SET[@]}"
+fi
+
+# Optimize lives behind the `include-optimize` profile, which is auto-disabled
+# by -Dquickly. If any target is an Optimize module, force the profile on (it
+# overrides the activation condition) so `-pl optimize/...` resolves in the
+# reactor even with -Dquickly.
+OPT_PROFILE=""
+for m in "${MODULES[@]}"; do
+  if [[ "$m" == optimize || "$m" == optimize/* ]]; then
+    OPT_PROFILE="-P include-optimize"
+    info "Detected Optimize module(s) - enabling ${BOLD}include-optimize${RESET} profile."
+    break
+  fi
+done
+
+# --- Optionally install dependencies ------------------------------------
+if [[ "$INSTALL_DEPS" -eq 1 ]]; then
+  info "Installing module dependencies (quickly)..."
+  $MVN $OFFLINE $OPT_PROFILE install -pl "$PL" -am -Dquickly -T1C \
+    || die "Dependency install failed; cannot analyze."
+fi
+
+declare -A RESULT=()
+run_step() {
+  local name="$1"; shift
+  info "Running ${BOLD}${name}${RESET} ..."
+  if "$@"; then RESULT[$name]="PASS"; else RESULT[$name]="FAIL"; fi
+}
+
+# --- SpotBugs -----------------------------------------------------------
+# The -Pspotbugs profile wires the repo's exclude filters and the
+# zeebe-build-tools dependency. Report is written to <m>/target/spotbugsXml.xml.
+#
+#   repo   -> spotbugs:check with the repo include filter (fails on findings,
+#             matches CI).
+#   review/all -> override the include filter, run the non-failing
+#             spotbugs:spotbugs goal, then parse + print findings ourselves
+#             (optionally scoped to changed files).
+print_spotbugs_findings() {
+  CHANGED_ONLY="$CHANGED_ONLY" \
+  CHANGED_LIST="$(printf '%s\n' "${!CHANGED_SET[@]}")" \
+  python3 - "$@" <<'PY'
+import os, sys, glob
+import xml.etree.ElementTree as ET
+
+changed_only = os.environ.get("CHANGED_ONLY") == "1"
+changed = {l for l in os.environ.get("CHANGED_LIST", "").splitlines() if l}
+RED, YEL, GRN, BOLD, RST = "\033[31m", "\033[33m", "\033[32m", "\033[1m", "\033[0m"
+prio = {"1": f"{RED}HIGH{RST}", "2": f"{YEL}MED {RST}", "3": f"{GRN}LOW {RST}"}
+
+total = 0
+for module in sys.argv[1:]:
+    xml = os.path.join(module, "target", "spotbugsXml.xml")
+    if not os.path.isfile(xml):
+        continue
+    root = ET.parse(xml).getroot()
+    for b in root.iter("BugInstance"):
+        sl = b.find("SourceLine")
+        src = sl.get("sourcefile") if sl is not None else None
+        if changed_only and (src is None or src not in changed):
+            continue
+        cls = next((c.get("classname", "") for c in b.findall("Class")), "")
+        line = sl.get("start") if sl is not None else "?"
+        msg = b.findtext("LongMessage") or b.findtext("ShortMessage") or ""
+        p = prio.get(b.get("priority", "2"), "    ")
+        print(f"  [{p}] {BOLD}{b.get('type')}{RST} ({b.get('category')})")
+        print(f"        {src}:{line}  {cls}")
+        print(f"        {msg}")
+        total += 1
+
+print()
+if total:
+    print(f"{RED}{BOLD}SpotBugs: {total} finding(s).{RST}")
+else:
+    scope = " in changed files" if changed_only else ""
+    print(f"{GRN}SpotBugs: no findings{scope}.{RST}")
+sys.exit(1 if total else 0)
+PY
+}
+
+if has spotbugs; then
+  if [[ "$SB_PROFILE" == "repo" ]]; then
+    run_step "spotbugs" \
+      $MVN $OFFLINE -Pspotbugs $OPT_PROFILE test-compile spotbugs:check -pl "$PL" -DskipTests
+  else
+    info "Running ${BOLD}spotbugs${RESET} (profile=${SB_PROFILE}) ..."
+    if $MVN $OFFLINE -Pspotbugs $OPT_PROFILE test-compile spotbugs:spotbugs \
+         -pl "$PL" -DskipTests -Dspotbugs.include="$SB_INCLUDE"; then
+      echo
+      info "SpotBugs findings (${SB_PROFILE}):"
+      if print_spotbugs_findings "${MODULES[@]}"; then
+        RESULT["spotbugs"]="PASS"
+      else
+        RESULT["spotbugs"]="FAIL"
+      fi
+    else
+      RESULT["spotbugs"]="FAIL"
+    fi
+  fi
+fi
+
+# --- SonarQube (standalone SonarScanner CLI) ----------------------------
+# Compiles classes (needed for sonar.java.binaries) then runs sonar-scanner
+# per module. Requires a reachable SonarQube server + token.
+if has sonar; then
+  if ! command -v sonar-scanner >/dev/null 2>&1; then
+    warn "sonar-scanner not found on PATH - skipping sonar (brew install sonar-scanner)."
+    RESULT["sonar"]="SKIP"
+  elif [[ -z "$SONAR_TOKEN" ]]; then
+    warn "SONAR_TOKEN not set - skipping sonar."
+    RESULT["sonar"]="SKIP"
+  else
+    info "Compiling modules for Sonar (sonar.java.binaries)..."
+    if ! $MVN $OFFLINE $OPT_PROFILE test-compile -pl "$PL" -Dquickly; then
+      RESULT["sonar"]="FAIL"
+    else
+      sonar_ok=1
+      for m in "${MODULES[@]}"; do
+        key="${PROJECT_KEY}"
+        [[ ${#MODULES[@]} -gt 1 ]] && key="${PROJECT_KEY}-$(echo "$m" | tr '/' '-')"
+        info "Sonar scan: ${BOLD}${m}${RESET} (key=${key})"
+        bin="$m/target/classes"; tbin="$m/target/test-classes"
+        binaries="$bin"; [[ -d "$tbin" ]] && binaries="$bin,$tbin"
+        org_arg=(); [[ -n "$SONAR_ORG" ]] && org_arg=(-Dsonar.organization="$SONAR_ORG")
+        ( cd "$m" && sonar-scanner \
+            -Dsonar.host.url="$SONAR_HOST_URL" \
+            -Dsonar.token="$SONAR_TOKEN" \
+            -Dsonar.projectKey="$key" \
+            -Dsonar.projectName="$key" \
+            -Dsonar.sources=src/main/java \
+            -Dsonar.tests=src/test/java \
+            -Dsonar.java.binaries=target/classes \
+            -Dsonar.java.test.binaries=target/test-classes \
+            -Dsonar.java.source=21 \
+            "${org_arg[@]}" ) || sonar_ok=0
+      done
+      [[ "$sonar_ok" -eq 1 ]] && RESULT["sonar"]="PASS" || RESULT["sonar"]="FAIL"
+    fi
+  fi
+fi
+
+# --- Summary ------------------------------------------------------------
+echo
+info "${BOLD}Static analysis summary${RESET}"
+fail=0
+for name in spotbugs sonar; do
+  status="${RESULT[$name]:-}"
+  [[ -z "$status" ]] && continue
+  case "$status" in
+    PASS) printf '  %s%-10s PASS%s\n' "$GREEN" "$name" "$RESET" ;;
+    SKIP) printf '  %s%-10s SKIP%s\n' "$YELLOW" "$name" "$RESET" ;;
+    *)    printf '  %s%-10s FAIL%s\n' "$RED" "$name" "$RESET"; fail=1 ;;
+  esac
+done
+
+if has spotbugs; then
+  echo
+  log "SpotBugs reports:"
+  for m in "${MODULES[@]}"; do log "  $m/target/spotbugsXml.xml"; done
+fi
+if has sonar && [[ "${RESULT[sonar]:-}" == "PASS" ]]; then
+  log "Sonar results: ${SONAR_HOST_URL}/dashboard?id=${PROJECT_KEY}"
+fi
+
+[[ "$fail" -eq 1 ]] && { echo; warn "One or more analyzers reported issues."; exit 1; }
+echo
+info "${GREEN}Done.${RESET}"

--- a/skills/camunda-branch-code-review/scripts/spotbugs-all-include.xml
+++ b/skills/camunda-branch-code-review/scripts/spotbugs-all-include.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SpotBugs "everything" include filter. Used by camunda-static-analysis.sh with
+  `-p all`. Maximum recall (all categories, run at effort=Max / threshold=Low).
+  Noisy - intended for a deep, focused review of a small changeset, ideally
+  combined with --changed-only.
+-->
+<FindBugsFilter
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Bug category="CORRECTNESS"/>
+  <Bug category="MT_CORRECTNESS"/>
+  <Bug category="SECURITY"/>
+  <Bug category="BAD_PRACTICE"/>
+  <Bug category="STYLE"/>
+  <Bug category="PERFORMANCE"/>
+  <Bug category="MALICIOUS_CODE"/>
+  <Bug category="I18N"/>
+  <Bug category="EXPERIMENTAL"/>
+</FindBugsFilter>

--- a/skills/camunda-branch-code-review/scripts/spotbugs-review-include.xml
+++ b/skills/camunda-branch-code-review/scripts/spotbugs-review-include.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SpotBugs "PR review" include filter (high signal, low noise).
+
+  Used by camunda-static-analysis.sh with `-p review`. It is INTENTIONALLY
+  broader than the repo/CI filter (which only enables CORRECTNESS +
+  MT_CORRECTNESS) so it also catches logic smells that the CI scan ignores -
+  most notably BC_VACUOUS_INSTANCEOF ("instanceof always true"), dead/useless
+  code, self-comparisons and == on Strings.
+
+  Each <Match> is OR'd. Full high-value categories are enabled wholesale;
+  individually-listed patterns pull in only the high-signal members of noisier
+  categories (STYLE / BAD_PRACTICE) so we don't drown in dead-store noise.
+-->
+<FindBugsFilter
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <!-- Whole categories that are almost always worth reviewing. -->
+  <Bug category="CORRECTNESS"/>
+  <Bug category="MT_CORRECTNESS"/>
+  <Bug category="SECURITY"/>
+
+  <!-- High-signal STYLE patterns: logic that is provably useless/wrong. -->
+  <Bug pattern="BC_VACUOUS_INSTANCEOF"/>          <!-- instanceof always true -->
+  <Bug pattern="UC_USELESS_CONDITION"/>
+  <Bug pattern="UC_USELESS_CONDITION_TYPE"/>
+  <Bug pattern="UC_USELESS_OBJECT"/>
+  <Bug pattern="UC_USELESS_OBJECT_STACK"/>
+  <Bug pattern="UC_USELESS_VOID_METHOD"/>
+  <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
+  <Bug pattern="UCF_USELESS_CONTROL_FLOW_NEXT_LINE"/>
+  <Bug pattern="RpC_REPEATED_CONDITIONAL_TEST"/>
+  <Bug pattern="SA_LOCAL_SELF_ASSIGNMENT"/>
+  <Bug pattern="SA_LOCAL_SELF_COMPUTATION"/>
+  <Bug pattern="SA_LOCAL_SELF_COMPARISON"/>
+  <Bug pattern="SA_FIELD_SELF_ASSIGNMENT"/>
+  <Bug pattern="SA_FIELD_SELF_COMPARISON"/>
+  <Bug pattern="SA_FIELD_SELF_COMPUTATION"/>
+  <Bug pattern="INT_BAD_COMPARISON_WITH_NONNEGATIVE_VALUE"/>
+  <Bug pattern="INT_VACUOUS_COMPARISON"/>
+  <Bug pattern="INT_VACUOUS_BIT_OPERATION"/>
+  <Bug pattern="SF_SWITCH_FALLTHROUGH"/>
+  <Bug pattern="SF_SWITCH_NO_DEFAULT"/>
+  <Bug pattern="REC_CATCH_EXCEPTION"/>
+  <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+  <Bug pattern="RCN_REDUNDANT_COMPARISON_TO_NULL"/>
+  <Bug pattern="RCN_REDUNDANT_COMPARISON_OF_NULL_AND_NONNULL_VALUE"/>
+  <Bug pattern="DLS_DEAD_LOCAL_STORE_IN_RETURN"/>
+  <Bug pattern="DLS_DEAD_STORE_OF_CLASS_LITERAL"/>
+
+  <!-- High-signal BAD_PRACTICE patterns. -->
+  <Bug pattern="ES_COMPARING_STRINGS_WITH_EQ"/>
+  <Bug pattern="ES_COMPARING_PARAMETER_STRING_WITH_EQ"/>
+  <Bug pattern="EQ_COMPARETO_USE_OBJECT_EQUALS"/>
+  <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+  <Bug pattern="RV_EXCEPTION_NOT_THROWN"/>
+  <Bug pattern="NP_BOOLEAN_RETURN_NULL"/>
+  <Bug pattern="DE_MIGHT_IGNORE"/>
+  <Bug pattern="ODR_OPEN_DATABASE_RESOURCE"/>
+  <Bug pattern="OS_OPEN_STREAM"/>
+  <Bug pattern="OS_OPEN_STREAM_EXCEPTION_PATH"/>
+</FindBugsFilter>


### PR DESCRIPTION
## Goal

Add a **branch code-review** skill that reviews the code introduced or changed on the current git branch of the `camunda/camunda` monorepo.

## What it does

Combines an automated **SpotBugs** pass (curated high-signal profile) with a manual **SOLID / DRY / KISS / clean-code** analysis backed by the refactoring.guru code-smell & design-pattern catalogs, plus dedicated **logic-correctness**, **sensitive-data**, **docs-accuracy**, **test-quality**, **dead-code**, and **third-party** passes.

The review runs in three phases:

1. **Setup** — the orchestrator establishes shared context once (diff scope, goal, touched modules).
2. **Fan-out** — one parallel read-only agent per topic/tool, led by an adversarial logic-correctness pass.
3. **Consolidate** — merge into a single findings report with `file:line` references and severity tags (`correctness > SOLID > DRY > KISS > clean > hygiene`).

## Contents

- `SKILL.md` — orchestration, phases, per-agent task specs, output format.
- `scripts/` — SpotBugs runner + curated/all include filters (self-contained).
- `references/review-heuristics.md`, `references/refactoring-guru-checks.md` — depth guidance.

## Notes

Guidance is intentionally **generic**: no specific PR-incident references or invented sample identifiers — only reusable heuristics and camunda convention notes.