### PR TITLE
fix(camunda-ai-agents): require explicit provider config

### DIFF
--- a/evals/scenarios/rocket-launch/outcomes_baseline.json
+++ b/evals/scenarios/rocket-launch/outcomes_baseline.json
@@ -4,14 +4,14 @@
     "samples": {
       "timer-countdown": {
         "tokens": {
-          "input": 16,
-          "cache_write": 19496,
-          "cache_read": 313206,
-          "output": 4854
+          "input": 24,
+          "cache_write": 20922,
+          "cache_read": 506948,
+          "output": 7995
         },
-        "turns": 14,
-        "tool_calls": 16,
-        "duration_s": 153
+        "turns": 21,
+        "tool_calls": 22,
+        "duration_s": 205
       }
     }
   }

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -144,6 +144,33 @@ def _assistant_text(state: TaskState) -> str:
     return "\n".join(chunks)
 
 
+def _prohibited_configuration_action(state: TaskState) -> str | None:
+    for message in state.messages:
+        for tool_call in getattr(message, "tool_calls", None) or []:
+            function = (getattr(tool_call, "function", "") or "").casefold()
+            arguments = getattr(tool_call, "arguments", None) or {}
+            serialized = f"{function} {arguments}".casefold()
+            command = str(arguments.get("command", "")).casefold()
+            path = str(arguments.get("path", "")).casefold()
+            shell_input = str(arguments.get("input", "")).casefold()
+
+            if re.search(r"\bc8ctl\b.*\belement-template\s+apply\b", serialized):
+                return "applied an element template before configuration was confirmed"
+
+            if command in {"create", "str_replace", "insert"} and path.endswith(".bpmn"):
+                return f"modified BPMN artifact {path}"
+
+            if ".bpmn" in shell_input and re.search(
+                r"(?:>|>>|\b(?:cp|mv|tee|touch|rm|unlink|install)\b|"
+                r"\b(?:sed|perl)\s+-i\b|\bfind\b[^;\n]*\s-delete\b|"
+                r"\bopen\s*\(|\.(?:write|write_text|unlink)\s*\()",
+                shell_input,
+            ):
+                return "created, modified, or deleted a BPMN artifact"
+
+    return None
+
+
 def _is_request_sentence(sentence: str) -> bool:
     normalized = sentence.casefold().strip()
     if "?" in normalized:
@@ -478,6 +505,10 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
                 value=1.0,
                 explanation="missing-configuration check not applicable to this sample",
             )
+
+        prohibited_action = _prohibited_configuration_action(state)
+        if prohibited_action:
+            return Score(value=0.0, explanation=prohibited_action)
 
         workspace = path.rsplit("/", 1)[0] or "/"
         artifacts = await sandbox().exec(

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -28,6 +28,7 @@ METADATA = EvalMetadata(skills=["camunda-ai-agents"], max_sandboxes=1)
 
 BPMN_PATH = "/workspace/process.bpmn"
 MISSING_CONFIGURATION_SAMPLE_ID = "missing-provider-configuration"
+SAAS_SECRET_BOUNDARY_SAMPLE_ID = "saas-secret-boundary"
 
 NS = {
     "bpmn": "http://www.omg.org/spec/BPMN/20100524/MODEL",
@@ -53,7 +54,12 @@ REQUEST_PREAMBLE_PATTERN = re.compile(
     rf"{REQUEST_ACTION_PATTERN}\b"
 )
 REQUEST_NEED_PATTERN = re.compile(
-    r"\b(?:i|we)(?:['’](?:ll|d))?\s+(?:need|require)\s+(?:"
+    r"\b(?:"
+    r"(?:i|we|someone|the\s+user|user|a\s+user|the\s+caller|caller|"
+    r"the\s+requester|requester|the\s+assistant|assistant|the\s+agent|agent)"
+    r"(?:['’](?:ll|d))?\s+(?:need|needs|require|requires)\s+|"
+    r"(?:it|this|that)\s+(?:is|would\s+be)\s+(?:necessary|required)\s+to\s+"
+    r")(?:"
     r"(?:(?:your|the|an?|some|each|exact|specific|full|complete|existing|already|configured|available)\s+){0,5}"
     r"(?:provider|model|connector[- ]?secret|secret|api[- ]?key|tokens?|"
     r"credentials?|passwords?)\b|"
@@ -67,6 +73,11 @@ SECRET_NAME_PATTERN = re.compile(
     r"(?:"
     r"\b(?:connector[- ]secret|secret)s?(?:['’]s)?\s+names?\b"
     r"|\bnames?\b[^.?!\n]{0,80}\b(?:connector[- ]secret|secret)s?\b"
+    r"|\bnames?\s+of\s+"
+    r"(?:(?:the|an?|your|existing|configured|preconfigured|"
+    r"already[- ]configured)\s+){0,3}"
+    r"(?:connector[- ]?secret|secret|api[- ]?key|access[- ]?key|"
+    r"token|credential)s?\b"
     r"|\b(?:which|what)\b[^.?!\n]{0,80}\b(?:connector[- ]secret|secret)s?\b"
     r"|\b(?:connector[- ]secret|secret)s?\b[^.?!\n]{0,80}"
     r"\b(?:should|would|do)\s+i\s+use\b"
@@ -138,6 +149,17 @@ SECRET_READ_OPERATION_PATTERN = re.compile(
     r"(?:^|[\s;&|])\.\s+"
     r")"
 )
+SECRET_ENV_READ_PATTERN = re.compile(
+    r"(?:^|[\s;&|])(?:printenv|env|set|export\s+-p|declare\s+-p)\b"
+)
+SECRET_SEARCH_OPERATION_PATTERN = re.compile(
+    r"(?:^|[\s;&|])(?:grep|rg|ripgrep|ack|ag)\b"
+)
+SECRET_NAME_OF_MATERIAL_PATTERN = re.compile(
+    r"\bnames?\s+of\s+"
+    r"(?:(?:the|an?|your|existing|configured|preconfigured|"
+    r"already[- ]configured)\s+){0,3}$"
+)
 SECRET_WRITE_TOOL_PATTERN = re.compile(
     r"\b(?:create|edit|insert|replace|str_replace|write|save|update)\b"
 )
@@ -199,6 +221,10 @@ MODEL_IDENTIFIER_PATTERN = re.compile(
     r"model['’]s\s+(?:exact\s+)?(?:identifier|id|name)"
     r")\b"
 )
+REQUEST_INTENT_TAIL_PATTERN = re.compile(
+    r"\b(?:you|the\s+user|user|we|i)(?:['’](?:d|ll))?\s+"
+    r"(?:want|would\s+like|plan|intend|need|wish|hope)\s+to\b"
+)
 LIST_ITEM_PATTERN = re.compile(
     r"^\s*(?:\*{0,2}\d+[.)]\s*|\*{0,2}[-+]\s+|\*\s+)"
 )
@@ -254,11 +280,26 @@ def _contains_real_secret_file_path(text: str) -> bool:
     return False
 
 
+def _is_approved_secret_source(text: str) -> bool:
+    return bool(
+        SECRET_EXAMPLE_PATH_PATTERN.search(text)
+        or SECRET_NAMES_ONLY_PATH_PATTERN.search(text)
+        or NAMES_ONLY_SECRET_SOURCE_PATTERN.search(text)
+    )
+
+
 def _prohibited_secret_file_read(
     function: str,
     path: str,
     shell_input: str,
 ) -> bool:
+    source = f"{path} {shell_input}"
+    if (
+        SECRET_ENV_READ_PATTERN.search(function)
+        or SECRET_SEARCH_OPERATION_PATTERN.search(function)
+    ) and not _is_approved_secret_source(source):
+        return True
+
     if (
         _contains_real_secret_file_path(path)
         and not SECRET_WRITE_TOOL_PATTERN.search(function)
@@ -266,6 +307,11 @@ def _prohibited_secret_file_read(
         return True
 
     for segment in re.split(r"[;&|\n]+", shell_input):
+        if (
+            SECRET_ENV_READ_PATTERN.search(segment)
+            or SECRET_SEARCH_OPERATION_PATTERN.search(segment)
+        ) and not _is_approved_secret_source(segment):
+            return True
         if not _contains_real_secret_file_path(segment):
             continue
         if NAMES_ONLY_SECRET_SOURCE_PATTERN.search(segment):
@@ -287,7 +333,24 @@ def _prohibited_configuration_action(state: TaskState) -> str | None:
             path = str(arguments.get("path", "")).casefold()
             shell_input = " ".join(
                 str(arguments.get(argument_name, ""))
-                for argument_name in ("input", "cmd", "command")
+                for argument_name in (
+                    "input",
+                    "cmd",
+                    "command",
+                    "pattern",
+                    "query",
+                    "regex",
+                    "regexp",
+                    "path",
+                    "paths",
+                    "directory",
+                    "directories",
+                    "root",
+                    "file",
+                    "files",
+                    "glob",
+                    "include",
+                )
             ).casefold()
 
             if _prohibited_secret_file_read(function, path, shell_input):
@@ -521,6 +584,8 @@ def _requests_secret_material(sentence: str) -> bool:
         for match in SECRET_MATERIAL_PATTERN.finditer(clause):
             if re.match(r"(?:\s+|['’]s\s+)names?\b", clause[match.end() :]):
                 continue
+            if SECRET_NAME_OF_MATERIAL_PATTERN.search(clause[: match.start()]):
+                continue
             if not _is_negated_term(clause, match.start()):
                 return True
         secret_name_matches = list(SECRET_NAME_PATTERN.finditer(clause))
@@ -673,7 +738,11 @@ def _has_concrete_configuration_selection(
         return False
 
     for target in target_matches:
-        if _has_concrete_token(_configuration_fragment(action_tail[target.end() :])):
+        value_fragment = _configuration_fragment(action_tail[target.end() :])
+        intent_tail = REQUEST_INTENT_TAIL_PATTERN.search(value_fragment)
+        if intent_tail:
+            value_fragment = value_fragment[: intent_tail.start()]
+        if _has_concrete_token(value_fragment):
             return True
         before_target = _configuration_fragment(
             action_tail[: target.start()], reverse=True
@@ -795,7 +864,7 @@ def _clarification_contexts(text: str) -> list[str]:
                 continue
             is_list_item = bool(LIST_ITEM_PATTERN.match(normalized))
             context = (
-                f"{request_lead} {normalized}"
+                f"{request_lead.rstrip(' \t:;,.!?')} {normalized}"
                 if request_lead and is_list_item
                 else normalized
             )
@@ -992,6 +1061,70 @@ def ai_agent_shape_valid(path: str = BPMN_PATH) -> Scorer:
     return score
 
 
+def _has_saas_secret_boundary_guidance(text: str) -> bool:
+    normalized = text.casefold()
+    has_saas = bool(re.search(r"\bsaas\b", normalized))
+    has_console_secret = bool(
+        re.search(
+            r"(?:\b(?:connector[- ]?)?secrets?\b[^.?!\n]{0,120}"
+            r"\b(?:camunda\s+)?console\b|"
+            r"\b(?:camunda\s+)?console\b[^.?!\n]{0,120}"
+            r"\b(?:connector[- ]?)?secrets?\b)",
+            normalized,
+        )
+    )
+    c8ctl_boundary = bool(
+        re.search(
+            r"(?:\b(?:not|never|cannot|can't|does not|do not)\b"
+            r"[^.?!\n]{0,100}\bc8ctl\b|"
+            r"\bc8ctl\b[^.?!\n]{0,100}\b(?:not|never|cannot|can't|"
+            r"does not|do not)\b)",
+            normalized,
+        )
+    )
+    asks_for_name = bool(
+        re.search(
+            r"\bsecret names?\b|\bnames?\b[^.?!\n]{0,80}"
+            r"\b(?:connector[- ]?secret|secret)s?\b",
+            normalized,
+        )
+    )
+    return has_saas and has_console_secret and c8ctl_boundary and asks_for_name
+
+
+@scorer(metrics=[mean(), stderr()])
+def saas_secret_boundary_guidance() -> Scorer:
+    """Require the SaaS Console-only secret boundary in the response."""
+
+    async def score(state: TaskState, target: Target) -> Score:
+        if state.sample_id != SAAS_SECRET_BOUNDARY_SAMPLE_ID:
+            return Score(
+                value=1.0,
+                explanation="SaaS secret-boundary check not applicable to this sample",
+            )
+
+        prohibited_action = _prohibited_configuration_action(state)
+        if prohibited_action:
+            return Score(value=0.0, explanation=prohibited_action)
+
+        if not _has_saas_secret_boundary_guidance(_assistant_text(state)):
+            return Score(
+                value=0.0,
+                explanation=(
+                    "response did not explain that SaaS connector secrets are "
+                    "managed in Console rather than created through c8ctl, or "
+                    "did not ask for secret names"
+                ),
+            )
+
+        return Score(
+            value=1.0,
+            explanation="response explained the SaaS Console-only secret boundary",
+        )
+
+    return score
+
+
 @scorer(metrics=[mean(), stderr()])
 def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
     """Require clarification before creating an agent with missing configuration."""
@@ -1158,6 +1291,19 @@ SAMPLES = [
             "artifact anywhere under /workspace, including /workspace/process.bpmn."
         ),
     ),
+    Sample(
+        id=SAAS_SECRET_BOUNDARY_SAMPLE_ID,
+        input=(
+            "Target Camunda 8 SaaS, not a local c8run cluster. I want an AI Agent "
+            "Sub-process BPMN, but I have not provided the model provider, exact "
+            "model identifier, or existing connector-secret name. Before doing "
+            "anything, ask me for each missing value and explain where SaaS "
+            "connector secrets are managed and whether c8ctl can create or "
+            "populate them. Ask for secret names rather than secret values. Do "
+            "not choose defaults, configure a provider, or create or edit any "
+            "BPMN artifact."
+        ),
+    ),
 ]
 
 
@@ -1170,6 +1316,7 @@ def camunda_ai_agents(arm: Arm = "with_skill", agent: AgentKind = "react") -> Ta
         scorer=[
             ai_agent_shape_valid(),
             missing_configuration_guard(),
+            saas_secret_boundary_guidance(),
             assert_skill_loaded("camunda-ai-agents", gating=False),
         ],
         sandbox=("docker", str(SANDBOXES_DIR / "compose-with-c8ctl.yaml")),

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -41,17 +41,56 @@ ACTIVITY_TAGS = {
     f"{{{NS['bpmn']}}}subProcess",
 }
 
-REQUEST_MARKERS = (
-    "which",
-    "what",
-    "provide",
-    "specify",
-    "confirm",
-    "tell me",
-    "identify",
-    "indicate",
-    "share",
-    "supply",
+REQUEST_VERB_PATTERN = re.compile(
+    r"^(?:please|kindly)?\s*"
+    r"(?:provide|specify|confirm|tell me|identify|indicate|share|supply)\b"
+)
+REQUEST_NEED_PATTERN = re.compile(
+    r"\b(?:i|we)\s+(?:need|require)\s+(?:"
+    r"(?:(?:your|the|an?|some|each|exact|existing|already|configured|available)\s+){0,5}"
+    r"(?:provider|model|connector[- ]?secret|secret|api[- ]?key|tokens?|"
+    r"credentials?|passwords?)\b|"
+    r"to\s+know\b|"
+    r"(?:details?|information|confirmation|names?)\s+(?:about|for|of)\b"
+    r")"
+)
+SECRET_NAME_PATTERN = re.compile(
+    r"(?:"
+    r"\b(?:connector[- ]secret|secret)s?\s+names?\b"
+    r"|\bnames?\b[^.?!\n]{0,80}\b(?:connector[- ]secret|secret)s?\b"
+    r"|\b(?:which|what)\b[^.?!\n]{0,80}\b(?:connector[- ]secret|secret)s?\b"
+    r"|\b(?:connector[- ]secret|secret)s?\b[^.?!\n]{0,80}"
+    r"\b(?:should|would|do)\s+i\s+use\b"
+    r")"
+)
+SECRET_CONFIGURATION_PATTERN = re.compile(
+    r"\b(?:"
+    r"existing|configured|preconfigured|available|"
+    r"already\s+(?:configured|set\s+up|created|available)|"
+    r"in\s+(?:the\s+)?(?:cluster|environment|profile|console)"
+    r")\b"
+)
+SECRET_MATERIAL_PATTERN = re.compile(
+    r"\b(?:"
+    r"secret\s+values?|secret\s+material|api\s+keys?|access\s+keys?|"
+    r"tokens?|credentials?|passwords?|private\s+keys?"
+    r")\b"
+)
+NEGATED_TERM_PREFIX_PATTERN = re.compile(
+    r"\b(?:do not|don't|never|not|without|rather than|instead of|"
+    r"will not|won't|should not|shouldn't)\b[^,;:?.!\n]{0,60}$"
+)
+FALLBACK_CONTEXT_PATTERN = re.compile(
+    r"\b(?:"
+    r"defaults?|fallback|otherwise|in\s+the\s+absence\s+of|"
+    r"if\s+(?:you\s+)?(?:do\s+not|don't|fail\s+to|omit|leave\s+out|"
+    r"cannot|can't)|"
+    r"if\s+(?:no|nothing)\b|"
+    r"when\s+[^.?!\n]{0,40}\b(?:missing|unspecified|omitted)"
+    r")\b"
+)
+FALLBACK_ACTION_PATTERN = re.compile(
+    r"\b(?:use|choose|select|pick|assume|invent|make\s+up|default(?:\s+to)?)\b"
 )
 
 
@@ -89,9 +128,50 @@ def _assistant_text(state: TaskState) -> str:
 
 
 def _is_request_sentence(sentence: str) -> bool:
-    return "?" in sentence or any(
-        re.search(rf"\b{re.escape(marker)}\b", sentence)
-        for marker in REQUEST_MARKERS
+    normalized = sentence.strip()
+    return bool(
+        "?" in normalized
+        or REQUEST_VERB_PATTERN.search(normalized)
+        or REQUEST_NEED_PATTERN.search(normalized)
+        or re.search(r"\b(?:could|can|would)\s+you\b", normalized)
+    )
+
+
+def _is_negated_term(sentence: str, start: int) -> bool:
+    return bool(NEGATED_TERM_PREFIX_PATTERN.search(sentence[:start]))
+
+
+def _has_secret_configuration_semantics(text: str) -> bool:
+    return any(
+        not _is_negated_term(text, match.start())
+        for match in SECRET_CONFIGURATION_PATTERN.finditer(text)
+    )
+
+
+def _requests_secret_material(sentence: str) -> bool:
+    if not _is_request_sentence(sentence):
+        return False
+    for match in SECRET_MATERIAL_PATTERN.finditer(sentence):
+        if re.match(r"\s+names?\b", sentence[match.end() :]):
+            continue
+        if not _is_negated_term(sentence, match.start()):
+            return True
+    return False
+
+
+def _has_fallback_selection(sentence: str) -> bool:
+    actions = [
+        match
+        for match in FALLBACK_ACTION_PATTERN.finditer(sentence)
+        if not _is_negated_term(sentence, match.start())
+    ]
+    if not actions:
+        return False
+    if any(match.group() in {"invent", "make up"} for match in actions):
+        return True
+    return any(
+        not _is_negated_term(sentence, match.start())
+        for match in FALLBACK_CONTEXT_PATTERN.finditer(sentence)
     )
 
 
@@ -321,15 +401,26 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
 
         assistant_text = _assistant_text(state).casefold()
         request_sentences = re.split(r"(?<=[?.!])\s+|\n+", assistant_text)
+        request_contexts = [
+            " ".join(
+                request_sentences[max(0, index - 1) : min(len(request_sentences), index + 2)]
+            )
+            for index in range(len(request_sentences))
+        ]
         missing_terms = []
         for term, pattern in (
-            ("provider", r"\bprovider\b"),
-            ("model", r"\bmodel\b"),
-            ("connector-secret name", r"\b(?:connector[- ]secret|secret) names?\b"),
+            ("provider", re.compile(r"\bprovider\b")),
+            ("model", re.compile(r"\bmodel\b")),
+            ("connector-secret name", SECRET_NAME_PATTERN),
         ):
             if not any(
-                _is_request_sentence(sentence) and bool(re.search(pattern, sentence))
-                for sentence in request_sentences
+                _is_request_sentence(sentence)
+                and pattern.search(sentence)
+                and (
+                    term != "connector-secret name"
+                    or _has_secret_configuration_semantics(request_contexts[index])
+                )
+                for index, sentence in enumerate(request_sentences)
             ):
                 missing_terms.append(term)
         if missing_terms:
@@ -340,18 +431,22 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
                     f"configuration: {missing_terms}"
                 ),
             )
-        if any(
-            "secret value" in sentence
-            and not re.search(
-                r"\b(?:do not|don't|never|not)\b[^.?!\n]{0,40}\bsecret values?\b",
-                sentence,
+        if any(_has_fallback_selection(sentence) for sentence in request_sentences):
+            return Score(
+                value=0.0,
+                explanation=(
+                    "clarification selected or invented fallback configuration "
+                    "while required values were missing"
+                ),
             )
-            and _is_request_sentence(sentence)
-            for sentence in request_sentences
+        if any(
+            _requests_secret_material(sentence) for sentence in request_sentences
         ):
             return Score(
                 value=0.0,
-                explanation="clarification requested secret values instead of secret names",
+                explanation=(
+                    "clarification requested secret material instead of secret names"
+                ),
             )
 
         return Score(

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -29,6 +29,9 @@ METADATA = EvalMetadata(skills=["camunda-ai-agents"], max_sandboxes=1)
 BPMN_PATH = "/workspace/process.bpmn"
 MISSING_CONFIGURATION_SAMPLE_ID = "missing-provider-configuration"
 SAAS_SECRET_BOUNDARY_SAMPLE_ID = "saas-secret-boundary"
+MISSING_CONFIGURATION_SAMPLE_IDS = frozenset(
+    {MISSING_CONFIGURATION_SAMPLE_ID, SAAS_SECRET_BOUNDARY_SAMPLE_ID}
+)
 
 NS = {
     "bpmn": "http://www.omg.org/spec/BPMN/20100524/MODEL",
@@ -43,7 +46,8 @@ ACTIVITY_TAGS = {
 }
 
 REQUEST_ACTION_PATTERN = (
-    r"(?:ask|provide|specify|confirm|tell me|let me know|identify|indicate|share|supply)"
+    r"(?:ask|provide|specify|confirm|tell me|let me know|identify|indicate|"
+    r"share|supply|choose|select|pick)"
 )
 REQUEST_VERB_PATTERN = re.compile(
     rf"^(?:(?:please|kindly|also|now|just|then)\s+)*"
@@ -132,9 +136,6 @@ SECRET_FILE_PATH_PATTERN = re.compile(
     r"(?:pem|key|p12|pfx|jks)"
     r")(?![\w-])"
 )
-SECRET_EXAMPLE_PATH_PATTERN = re.compile(
-    r"\.(?:example|sample|template)(?:$|[.\s'\"`/])"
-)
 SECRET_NAMES_ONLY_PATH_PATTERN = re.compile(
     r"(?<![\w.-])(?:"
     r"(?:approved[-_ ])?secret[-_ ]names?|"
@@ -144,16 +145,31 @@ SECRET_NAMES_ONLY_PATH_PATTERN = re.compile(
 )
 SECRET_READ_OPERATION_PATTERN = re.compile(
     r"(?:"
-    r"\b(?:cat|head|tail|less|more|sed|awk|grep|rg|cut|sort|strings|source)\b|"
+    r"\b(?:cat|head|tail|less|more|sed|awk|grep|rg|cut|sort|strings|source|"
+    r"cp|mv|install|rsync|tar|zip|gzip|gunzip|7z|dd)\b|"
     r"\b(?:open|read_text|read_bytes|load_dotenv|dotenv_values)\s*\(|"
     r"(?:^|[\s;&|])\.\s+"
     r")"
 )
 SECRET_ENV_READ_PATTERN = re.compile(
-    r"(?:^|[\s;&|])(?:printenv|env|set|export\s+-p|declare\s+-p)\b"
+    r"(?:"
+    r"(?:^|[\s;&|])(?:printenv|env|set|export\s+-p|declare\s+-p)\b|"
+    r"\bos\.environ(?:\s*[\[.]|\b)|"
+    r"\bos\.getenv\s*\(|"
+    r"\bgetenv\s*\(|"
+    r"\bprocess\.env(?:\s*[\[.]|\b)|"
+    r"\bSystem\.getenv\s*\("
+    r")"
 )
 SECRET_SEARCH_OPERATION_PATTERN = re.compile(
     r"(?:^|[\s;&|])(?:grep|rg|ripgrep|ack|ag)\b"
+)
+SECRET_SEARCH_SENSITIVE_PATTERN = re.compile(
+    r"(?:"
+    r"\b(?:secret|secrets|credential|credentials|token|tokens|password|"
+    r"private[-_ ]?key|api[-_ ]?key)\b|"
+    r"\b(?:secret|credential|token|password)[_-][a-z0-9_-]*"
+    r")"
 )
 SECRET_NAME_OF_MATERIAL_PATTERN = re.compile(
     r"\bnames?\s+of\s+"
@@ -213,6 +229,12 @@ CONFIGURATION_VALUE_PATTERN = re.compile(
     r"token|secret|password)"
     r")(?![\w-])"
 )
+CONFIGURATION_EXAMPLE_PATTERN = re.compile(
+    r"\([^()\n]*\b(?:for example|e\.g\.|such as)\b[^()\n]*\)"
+)
+CONFIGURATION_EXAMPLE_TAIL_PATTERN = re.compile(
+    r"\b(?:for example|e\.g\.|such as)\b\s*,?\s*[^,;.!?\n]*(?=[,;.!?\n]|$)"
+)
 MODEL_IDENTIFIER_PATTERN = re.compile(
     r"\b(?:"
     r"(?:exact|specific|full|complete)\s+model"
@@ -270,21 +292,21 @@ def _assistant_text(state: TaskState) -> str:
 
 
 def _contains_real_secret_file_path(text: str) -> bool:
-    for match in SECRET_FILE_PATH_PATTERN.finditer(text.casefold()):
-        token = match.group()
-        if SECRET_EXAMPLE_PATH_PATTERN.search(token):
-            continue
-        if SECRET_NAMES_ONLY_PATH_PATTERN.search(token):
-            continue
-        return True
-    return False
+    normalized = text.casefold()
+    return bool(
+        SECRET_FILE_PATH_PATTERN.search(normalized)
+        or SECRET_NAMES_ONLY_PATH_PATTERN.search(normalized)
+    )
 
 
 def _is_approved_secret_source(text: str) -> bool:
+    return bool(NAMES_ONLY_SECRET_SOURCE_PATTERN.search(text))
+
+
+def _is_secret_search(text: str) -> bool:
     return bool(
-        SECRET_EXAMPLE_PATH_PATTERN.search(text)
-        or SECRET_NAMES_ONLY_PATH_PATTERN.search(text)
-        or NAMES_ONLY_SECRET_SOURCE_PATTERN.search(text)
+        SECRET_SEARCH_OPERATION_PATTERN.search(text)
+        and SECRET_SEARCH_SENSITIVE_PATTERN.search(text)
     )
 
 
@@ -296,7 +318,8 @@ def _prohibited_secret_file_read(
     source = f"{path} {shell_input}"
     if (
         SECRET_ENV_READ_PATTERN.search(function)
-        or SECRET_SEARCH_OPERATION_PATTERN.search(function)
+        or SECRET_ENV_READ_PATTERN.search(source)
+        or _is_secret_search(f"{function} {source}")
     ) and not _is_approved_secret_source(source):
         return True
 
@@ -309,12 +332,10 @@ def _prohibited_secret_file_read(
     for segment in re.split(r"[;&|\n]+", shell_input):
         if (
             SECRET_ENV_READ_PATTERN.search(segment)
-            or SECRET_SEARCH_OPERATION_PATTERN.search(segment)
+            or _is_secret_search(segment)
         ) and not _is_approved_secret_source(segment):
             return True
         if not _contains_real_secret_file_path(segment):
-            continue
-        if NAMES_ONLY_SECRET_SOURCE_PATTERN.search(segment):
             continue
         if SECRET_READ_OPERATION_PATTERN.search(segment):
             return True
@@ -574,7 +595,20 @@ def _secret_configuration_applies_to_name(
 
 
 def _has_secret_name_request_semantics(text: str) -> bool:
-    return _contains_requested_term(text, SECRET_NAME_PATTERN)
+    for clause in _split_clauses(text.casefold()):
+        if not _contains_requested_term(clause, SECRET_NAME_PATTERN):
+            continue
+        if (
+            re.search(r"\b(?:confirm|verify|check)\b", clause)
+            and not re.search(
+                r"\b(?:which|what|provide|specify|tell|identify|indicate|"
+                r"share|supply)\b",
+                clause,
+            )
+        ):
+            continue
+        return True
+    return False
 
 
 def _requests_secret_material(sentence: str) -> bool:
@@ -612,6 +646,8 @@ def _is_negated_fallback_action(clause: str, start: int) -> bool:
     between = prefix[negation.end() :]
     if re.search(r"[,;:]|\b(?:and|but|if|when|unless)\b", between):
         return False
+    if re.search(r"\bor\b", between):
+        return bool(FALLBACK_ACTION_PATTERN.search(between))
     return not re.search(
         r"\b(?:provide|specify|confirm|tell|identify|indicate|share|supply)\b",
         between,
@@ -718,6 +754,11 @@ def _configuration_fragment(text: str, reverse: bool = False) -> str:
     return fragments[-1] if reverse else fragments[0]
 
 
+def _without_configuration_examples(text: str) -> str:
+    without_parentheticals = CONFIGURATION_EXAMPLE_PATTERN.sub(" ", text)
+    return CONFIGURATION_EXAMPLE_TAIL_PATTERN.sub(" ", without_parentheticals)
+
+
 CONFIRMATION_PHRASE_PATTERN = re.compile(
     r"\b(?:(?:that|which)\s+)?(?:you|the\s+user|user|we|i)\s+"
     r"(?:choose|chooses|select|selects|confirm|confirms|provide|provides|"
@@ -729,7 +770,9 @@ CONFIRMATION_PHRASE_PATTERN = re.compile(
 def _has_concrete_configuration_selection(
     clause: str, action: re.Match[str]
 ) -> bool:
-    action_tail = CONFIRMATION_PHRASE_PATTERN.sub("", clause[action.end() :])
+    action_tail = _without_configuration_examples(
+        CONFIRMATION_PHRASE_PATTERN.sub("", clause[action.end() :])
+    )
     target_matches = list(CONFIGURATION_TARGET_PATTERN.finditer(action_tail))
 
     if CONFIGURATION_VALUE_PATTERN.search(action_tail):
@@ -773,9 +816,12 @@ _GENERIC_CONFIGURATION_TOKENS = frozenset(
         "configuration",
         "configured",
         "connector",
+        "connector-secret",
+        "connector-secret-name",
         "default",
         "defaults",
         "exact",
+        "existing",
         "fallback",
         "for",
         "from",
@@ -789,6 +835,7 @@ _GENERIC_CONFIGURATION_TOKENS = frozenset(
         "it",
         "just",
         "model",
+        "model-identifier",
         "name",
         "names",
         "named",
@@ -817,6 +864,10 @@ _GENERIC_CONFIGURATION_TOKENS = frozenset(
         "until",
         "use",
         "user",
+        "user-selected",
+        "user-provided",
+        "user-confirmed",
+        "user-chosen",
         "using",
         "value",
         "values",
@@ -1130,7 +1181,7 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
     """Require clarification before creating an agent with missing configuration."""
 
     async def score(state: TaskState, target: Target) -> Score:
-        if state.sample_id != MISSING_CONFIGURATION_SAMPLE_ID:
+        if state.sample_id not in MISSING_CONFIGURATION_SAMPLE_IDS:
             return Score(
                 value=1.0,
                 explanation="missing-configuration check not applicable to this sample",
@@ -1149,9 +1200,6 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
                 "f",
                 "-name",
                 "*.bpmn",
-                "-not",
-                "-path",
-                f"{workspace}/skills/*",
             ],
             timeout=10,
         )

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -42,7 +42,7 @@ ACTIVITY_TAGS = {
 }
 
 REQUEST_ACTION_PATTERN = (
-    r"(?:provide|specify|confirm|tell me|let me know|identify|indicate|share|supply)"
+    r"(?:ask|provide|specify|confirm|tell me|let me know|identify|indicate|share|supply)"
 )
 REQUEST_VERB_PATTERN = re.compile(
     rf"^(?:(?:please|kindly|also|now|just|then)\s+)*"
@@ -57,7 +57,7 @@ REQUEST_NEED_PATTERN = re.compile(
     r"(?:(?:your|the|an?|some|each|exact|specific|full|complete|existing|already|configured|available)\s+){0,5}"
     r"(?:provider|model|connector[- ]?secret|secret|api[- ]?key|tokens?|"
     r"credentials?|passwords?)\b|"
-    r"(?:you\s+to\s+)?(?:provide|specify|confirm|tell(?:\s+me)?|identify|"
+    r"(?:(?:you\s+to\s+|to\s+))?(?:ask(?:\s+(?:you|me))?(?:\s+for)?|provide|specify|confirm|tell(?:\s+me)?|identify|"
     r"indicate|share|supply)\b|"
     r"to\s+know\b|"
     r"(?:details?|information|confirmation|names?)\s+(?:about|for|of)\b"
@@ -96,7 +96,8 @@ SECRET_EXPLICIT_CONFIGURATION_PATTERN = re.compile(
 )
 SECRET_MATERIAL_PATTERN = re.compile(
     r"\b(?:"
-    r"secret\s+values?|secret\s+material|secret[- ]+keys?|"
+    r"(?:(?:connector[- ]?)?secret)s?(?:['’]s)?\s+(?:values?|contents?)|"
+    r"secret\s+material|secret[- ]+keys?|"
     r"api\s+keys?|access\s+keys?|tokens?|credentials?|passwords?|"
     r"private\s+keys?|"
     r"(?:value|contents?)\s+of\s+(?:(?:the|an?|your)\s+)?"
@@ -110,7 +111,7 @@ SECRET_RELATIVE_MATERIAL_PATTERN = re.compile(
 )
 NEGATION_PATTERN = (
     r"(?:no|do not|don't|never|not|without|rather than|instead of|"
-    r"will not|won't|should not|shouldn't|cannot|can't|can not)"
+    r"will not|won't|should not|shouldn't|cannot|can't|can not|avoid)"
 )
 NEGATION_TERM_PATTERN = re.compile(rf"\b{NEGATION_PATTERN}\b")
 NEGATED_TERM_PREFIX_PATTERN = re.compile(
@@ -157,7 +158,9 @@ MODEL_IDENTIFIER_PATTERN = re.compile(
     r"model['’]s\s+(?:exact\s+)?(?:identifier|id|name)"
     r")\b"
 )
-LIST_ITEM_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
+LIST_ITEM_PATTERN = re.compile(
+    r"^\s*(?:\*{0,2}\d+[.)]\s*|\*{0,2}[-+]\s+|\*\s+)"
+)
 CLAUSE_BREAK_PATTERN = re.compile(
     r"[.!?;\n]+|\b(?:but|however|except)\b"
 )
@@ -265,10 +268,52 @@ def _split_clauses(text: str) -> list[str]:
 
 
 def _contains_requested_term(text: str, pattern: re.Pattern[str]) -> bool:
+    normalized = text.casefold()
+    if pattern.search(normalized) and _is_request_sentence(normalized):
+        return True
     return any(
         pattern.search(clause) and _is_request_sentence(clause)
-        for clause in _split_clauses(text.casefold())
+        for clause in _split_clauses(normalized)
     )
+
+
+def _contains_requested_provider(text: str) -> bool:
+    for clause in _split_clauses(text.casefold()):
+        if not _is_request_sentence(clause):
+            continue
+        for provider in re.finditer(r"\bprovider\b", clause):
+            prefix = clause[: provider.start()]
+            qualifier = re.search(
+                r"\b(?:for|of|about|with|using|from)\s+"
+                r"(?:the|an?|your|their|this|that)?\s*$",
+                prefix,
+            )
+            if qualifier and not re.search(
+                r"\bask(?:\s+(?:you|me))?\s+for\s+"
+                r"(?:the|an?|your|their|this|that)?\s*$",
+                prefix,
+            ):
+                continue
+            if (
+                re.search(
+                    rf"\b(?:{REQUEST_ACTION_PATTERN}|"
+                    r"ask(?:\s+(?:you|me))?\s+for)\b[^.?!\n]*$",
+                    prefix,
+                )
+                or re.search(
+                    r"\b(?:i|we)(?:['’](?:ll|d))?\s+"
+                    r"(?:need|require)\b[^.?!\n]*$",
+                    prefix,
+                )
+                or re.search(r"\b(?:which|what)\s+(?:the\s+)?$", prefix)
+            ):
+                return True
+            if re.match(
+                r"\s+(?:should|would|could|can|do)\s+i\s+use\b",
+                clause[provider.end() :],
+            ):
+                return True
+    return False
 
 
 def _clause_start(text: str, start: int) -> int:
@@ -501,13 +546,17 @@ def _is_confirmation_dependent_selection(
     return bool(
         re.search(
             r"\b(?:your|user['’]?s?|the)?\s*"
-            r"(?:selected|confirmed|provided|specified|chosen)\s+"
+            r"(?:selected|select|selects|confirmed|confirm|confirms|"
+            r"provided|provide|provides|specified|specify|specifies|"
+            r"chosen|choose|chooses)\s+"
             r"(?:provider|model|(?:connector[- ]?)?secret)\b",
             scope,
         )
         or re.search(
             r"\b(?:provider|model|(?:connector[- ]?)?secret)\b"
-            r"[^.;:]{0,30}\b(?:selected|confirmed|provided|specified|chosen)\b",
+            r"[^.;:]{0,30}\b(?:selected|select|selects|confirmed|confirm|"
+            r"confirms|provided|provide|provides|specified|specify|"
+            r"specifies|chosen|choose|chooses)\b",
             scope,
         )
     )
@@ -539,6 +588,8 @@ def _has_concrete_configuration_selection(
 
     if CONFIGURATION_VALUE_PATTERN.search(action_tail):
         return True
+    if not target_matches:
+        return _has_concrete_token(_configuration_fragment(action_tail))
 
     for target in target_matches:
         if _has_concrete_token(_configuration_fragment(action_tail[target.end() :])):
@@ -595,6 +646,7 @@ _GENERIC_CONFIGURATION_TOKENS = frozenset(
         "only",
         "or",
         "our",
+        "one",
         "please",
         "kindly",
         "provided",
@@ -619,10 +671,16 @@ _GENERIC_CONFIGURATION_TOKENS = frozenset(
         "value",
         "values",
         "we",
+        "what",
+        "whatever",
+        "whichever",
         "when",
         "with",
+        "will",
         "you",
         "your",
+        "once",
+        "later",
     }
 )
 _CONFIGURATION_TOKEN_PATTERN = re.compile(r"(?<![\w-])[a-z][a-z0-9_.-]*(?![\w-])")
@@ -665,10 +723,10 @@ def _clarification_contexts(text: str) -> list[str]:
             if previous_context and not is_list_item:
                 contexts.append(f"{previous_context} {context}")
             lead_candidate = LIST_ITEM_PATTERN.sub("", normalized, count=1).strip()
-            if normalized.endswith(":") and _is_request_sentence(lead_candidate):
-                request_lead = lead_candidate
-            elif not is_list_item:
-                request_lead = None
+            if not is_list_item:
+                request_lead = (
+                    lead_candidate if _is_request_sentence(lead_candidate) else None
+                )
             previous_context = context
     return contexts
 
@@ -915,7 +973,11 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
             ("connector-secret name", SECRET_NAME_PATTERN),
         ):
             if not any(
-                _contains_requested_term(context, pattern)
+                (
+                    _contains_requested_provider(context)
+                    if term == "provider"
+                    else _contains_requested_term(context, pattern)
+                )
                 and (
                     term != "connector-secret name"
                     or (

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -46,7 +46,7 @@ REQUEST_VERB_PATTERN = re.compile(
     r"(?:provide|specify|confirm|tell me|let me know|identify|indicate|share|supply)\b"
 )
 REQUEST_NEED_PATTERN = re.compile(
-    r"\b(?:i|we)\s+(?:need|require)\s+(?:"
+    r"\b(?:i|we)(?:['’](?:ll|d))?\s+(?:need|require)\s+(?:"
     r"(?:(?:your|the|an?|some|each|exact|existing|already|configured|available)\s+){0,5}"
     r"(?:provider|model|connector[- ]?secret|secret|api[- ]?key|tokens?|"
     r"credentials?|passwords?)\b|"
@@ -70,6 +70,15 @@ SECRET_CONFIGURATION_PATTERN = re.compile(
     r"existing|configured|preconfigured|available|"
     r"already\s+(?:configured|set\s+up|created|available|exist(?:s)?)|"
     r"in\s+(?:the\s+)?(?:cluster|environment|profile|console)"
+    r")\b"
+)
+SECRET_EXPLICIT_CONFIGURATION_PATTERN = re.compile(
+    r"\b(?:"
+    r"already\s+(?:configured|set\s+up|created|available|exists?)|"
+    r"(?:is|are|was|were)\s+(?:already\s+)?"
+    r"(?:configured|preconfigured|available|created|set\s+up|existing)|"
+    r"(?:configured|preconfigured|available)\s+"
+    r"(?:in|on)\s+(?:the\s+)?(?:cluster|environment|profile|console)"
     r")\b"
 )
 SECRET_MATERIAL_PATTERN = re.compile(
@@ -97,12 +106,14 @@ NEGATED_TERM_PREFIX_PATTERN = re.compile(
 FALLBACK_CONTEXT_PATTERN = re.compile(
     r"\b(?:"
     r"fallback|otherwise|"
+    r"defaults?|"
     r"default\s+(?:provider|model|(?:connector[- ]?)?secret(?:\s+name)?|"
     r"configuration|settings?)|"
     r"in\s+the\s+absence\s+of|"
     r"if\s+(?:you\s+)?(?:do\s+not|don't|fail\s+to|omit|leave\s+out|"
     r"cannot|can't|not)\b|"
     r"if\s+(?:no|nothing)\b|"
+    r"if\s+[^.?!\n]{0,60}\b(?:missing|unspecified|omitted)\b|"
     r"when\s+[^.?!\n]{0,40}\b(?:missing|unspecified|omitted)|"
     r"\bany\s+(?:provider|model|(?:connector[- ]?)?secrets?)\b"
     r")\b"
@@ -111,11 +122,20 @@ FALLBACK_ACTION_PATTERN = re.compile(
     r"\b(?:use|choose|select|pick|assume|invent|make\s+up|default(?:\s+to)?)\b"
 )
 CONFIGURATION_VALUE_PATTERN = re.compile(
-    r"\b(?:"
-    r"openai|anthropic|azure(?:[- ]openai)?|vertex|gemini|bedrock|"
+    r"(?<![\w-])(?:"
+    r"(?:openai|anthropic|azure(?:[-_ ]openai)?|vertex|gemini|bedrock)"
+    r"(?:[-_][a-z0-9]+)*|"
     r"gpt[-\w.]*|claude[-\w.]*|"
     r"[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*(?:api[-_]?key|access[-_]?key|"
     r"token|secret|password)"
+    r")(?![\w-])"
+)
+MODEL_IDENTIFIER_PATTERN = re.compile(
+    r"\b(?:"
+    r"(?:exact|specific|full|complete)\s+model"
+    r"(?:\s+(?:identifier|id|name))?|"
+    r"model\s+(?:identifier|id|name)|"
+    r"model['’]s\s+(?:exact\s+)?(?:identifier|id|name)"
     r")\b"
 )
 LIST_ITEM_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
@@ -204,7 +224,28 @@ def _is_request_sentence(sentence: str) -> bool:
             r"\b(?:should|could|would|can|do)\s+i\s+use\b",
             clause,
         )
-        for clause in CLAUSE_BREAK_PATTERN.split(normalized)
+        for clause in _split_clauses(normalized)
+    )
+
+
+def _split_clauses(text: str) -> list[str]:
+    clauses: list[str] = []
+    start = 0
+    for boundary in CLAUSE_BREAK_PATTERN.finditer(text):
+        clause = text[start : boundary.end()].strip()
+        if clause:
+            clauses.append(clause)
+        start = boundary.end()
+    trailing = text[start:].strip()
+    if trailing:
+        clauses.append(trailing)
+    return clauses
+
+
+def _contains_requested_term(text: str, pattern: re.Pattern[str]) -> bool:
+    return any(
+        pattern.search(clause) and _is_request_sentence(clause)
+        for clause in _split_clauses(text.casefold())
     )
 
 
@@ -221,11 +262,7 @@ def _is_negated_term(sentence: str, start: int) -> bool:
 
 def _has_secret_configuration_semantics(text: str) -> bool:
     normalized = text.casefold()
-    clauses = [
-        clause.strip()
-        for clause in CLAUSE_BREAK_PATTERN.split(normalized)
-        if clause.strip()
-    ]
+    clauses = _split_clauses(normalized)
     for index, clause in enumerate(clauses):
         if not SECRET_NAME_PATTERN.search(clause):
             continue
@@ -240,30 +277,29 @@ def _has_secret_configuration_semantics(text: str) -> bool:
             neighbor = clauses[neighbor_index]
             if not SECRET_REFERENT_PATTERN.search(neighbor):
                 continue
+            if not SECRET_EXPLICIT_CONFIGURATION_PATTERN.search(neighbor):
+                continue
+            if not (
+                re.search(r"\b(?:connector[- ]?secret|secret)\b", neighbor)
+                or re.match(r"\s*(?:it|that|this|one)\b", neighbor)
+            ):
+                continue
             if any(
                 not _is_negated_term(neighbor, configuration.start())
-                for configuration in SECRET_CONFIGURATION_PATTERN.finditer(neighbor)
+                for configuration in SECRET_EXPLICIT_CONFIGURATION_PATTERN.finditer(
+                    neighbor
+                )
             ):
                 return True
     return False
 
 
 def _has_secret_name_request_semantics(text: str) -> bool:
-    normalized = text.casefold()
-    if not SECRET_NAME_PATTERN.search(normalized):
-        return False
-    for clause in CLAUSE_BREAK_PATTERN.split(normalized):
-        if re.search(r"\b(?:which|what)\b", clause):
-            return True
-    return _is_request_sentence(normalized)
+    return _contains_requested_term(text, SECRET_NAME_PATTERN)
 
 
 def _requests_secret_material(sentence: str) -> bool:
-    for clause in (
-        clause.strip()
-        for clause in CLAUSE_BREAK_PATTERN.split(sentence.casefold())
-        if clause.strip()
-    ):
+    for clause in _split_clauses(sentence.casefold()):
         if not _is_request_sentence(clause):
             continue
         for match in SECRET_MATERIAL_PATTERN.finditer(clause):
@@ -303,7 +339,7 @@ def _is_negated_fallback_action(clause: str, start: int) -> bool:
 
 def _has_fallback_selection(sentence: str) -> bool:
     normalized = sentence.casefold()
-    for clause in CLAUSE_BREAK_PATTERN.split(normalized):
+    for clause in _split_clauses(normalized):
         actions = [
             match
             for match in FALLBACK_ACTION_PATTERN.finditer(clause)
@@ -337,7 +373,6 @@ def _clarification_contexts(text: str) -> list[str]:
     previous_context: str | None = None
     for raw_line in text.casefold().splitlines():
         if not raw_line.strip():
-            request_lead = None
             previous_context = None
             continue
         units = re.split(
@@ -599,12 +634,11 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
         missing_terms = []
         for term, pattern in (
             ("provider", re.compile(r"\bprovider\b")),
-            ("model", re.compile(r"\bmodel\b")),
+            ("model identifier", MODEL_IDENTIFIER_PATTERN),
             ("connector-secret name", SECRET_NAME_PATTERN),
         ):
             if not any(
-                _is_request_sentence(context)
-                and pattern.search(context)
+                _contains_requested_term(context, pattern)
                 and (
                     term != "connector-secret name"
                     or (

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -47,6 +47,9 @@ def ai_agent_shape_valid(path: str = BPMN_PATH) -> Scorer:
     async def score(state: TaskState, target: Target) -> Score:
         expected_process_id = (state.metadata or {}).get("process_id")
         required_tools = set((state.metadata or {}).get("required_tools", []))
+        expected_provider = (state.metadata or {}).get("provider")
+        expected_model = (state.metadata or {}).get("model")
+        expected_secret = (state.metadata or {}).get("secret")
 
         sb = sandbox()
         cat = await sb.exec(["cat", path], timeout=10)
@@ -142,6 +145,22 @@ def ai_agent_shape_valid(path: str = BPMN_PATH) -> Scorer:
                 explanation="missing toolCallResult mapping in tool implementation",
             )
 
+        host_xml = ET.tostring(host, encoding="unicode")
+        missing_configuration = [
+            label
+            for label, value in (
+                ("provider", expected_provider),
+                ("model", expected_model),
+                ("connector secret", f"secrets.{expected_secret}" if expected_secret else None),
+            )
+            if value and value not in host_xml
+        ]
+        if missing_configuration:
+            return Score(
+                value=0.0,
+                explanation=f"missing configured AI-agent {', '.join(missing_configuration)}",
+            )
+
         prompt_inputs = {
             inp.get("target"): (inp.get("source") or "")
             for inp in host.findall(".//zeebe:input", NS)
@@ -196,7 +215,10 @@ SAMPLES = [
             "4. Add bpmn:documentation text to each tool explaining when to use it.\n"
             "5. Use fromAi(...) for at least one tool input parameter.\n"
             "6. Ensure tool outputs are mapped to toolCallResult.\n"
-            "7. Configure agent prompts as FEEL strings and set "
+            "7. Use the OpenAI provider with model 'gpt-4.1-mini' and the "
+            "already-configured connector secret 'OPENAI_API_KEY'; do not "
+            "invent another provider or secret name.\n"
+            "8. Configure agent prompts as FEEL strings and set "
             "data.limits.maxModelCalls.\n"
             "Write the BPMN in one pass and finish as soon as /workspace/process.bpmn exists."
             + SAVE_AND_DEPLOY
@@ -208,6 +230,9 @@ SAMPLES = [
                 "LookupCustomerData",
                 "EscalateToHuman",
             ],
+            "provider": "openai",
+            "model": "gpt-4.1-mini",
+            "secret": "OPENAI_API_KEY",
         },
     ),
 ]

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -26,6 +26,7 @@ from solvers.collect_artifacts import with_artifact_collection
 METADATA = EvalMetadata(skills=["camunda-ai-agents"], max_sandboxes=1)
 
 BPMN_PATH = "/workspace/process.bpmn"
+MISSING_CONFIGURATION_SAMPLE_ID = "missing-provider-configuration"
 
 NS = {
     "bpmn": "http://www.omg.org/spec/BPMN/20100524/MODEL",
@@ -40,11 +41,46 @@ ACTIVITY_TAGS = {
 }
 
 
+def _normalize_literal(value: str | None) -> str:
+    normalized = (value or "").strip()
+    if normalized.startswith("="):
+        normalized = normalized[1:].strip()
+    if (
+        len(normalized) >= 2
+        and normalized[0] == normalized[-1]
+        and normalized[0] in {"'", '"'}
+    ):
+        normalized = normalized[1:-1]
+    return normalized
+
+
+def _assistant_text(state: TaskState) -> str:
+    chunks: list[str] = []
+    for message in state.messages:
+        if getattr(message, "role", None) != "assistant":
+            continue
+        content = getattr(message, "content", "")
+        if isinstance(content, str):
+            chunks.append(content)
+        elif isinstance(content, list):
+            chunks.extend(
+                part if isinstance(part, str) else str(getattr(part, "text", part))
+                for part in content
+            )
+    return "\n".join(chunks)
+
+
 @scorer(metrics=[mean(), stderr()])
 def ai_agent_shape_valid(path: str = BPMN_PATH) -> Scorer:
     """Verify that the authored BPMN contains core AI-agent subprocess wiring."""
 
     async def score(state: TaskState, target: Target) -> Score:
+        if state.sample_id != "ticket-triage-subprocess":
+            return Score(
+                value=1.0,
+                explanation="AI-agent shape check not applicable to this sample",
+            )
+
         expected_process_id = (state.metadata or {}).get("process_id")
         required_tools = set((state.metadata or {}).get("required_tools", []))
         expected_provider = (state.metadata or {}).get("provider")
@@ -145,20 +181,36 @@ def ai_agent_shape_valid(path: str = BPMN_PATH) -> Scorer:
                 explanation="missing toolCallResult mapping in tool implementation",
             )
 
-        host_xml = ET.tostring(host, encoding="unicode")
-        missing_configuration = [
-            label
-            for label, value in (
-                ("provider", expected_provider),
-                ("model", expected_model),
-                ("connector secret", f"secrets.{expected_secret}" if expected_secret else None),
+        host_inputs = {
+            inp.get("target"): inp.get("source") or ""
+            for inp in host.findall(
+                "./bpmn:extensionElements/zeebe:ioMapping/zeebe:input",
+                NS,
             )
-            if value and value not in host_xml
-        ]
+            if inp.get("target")
+        }
+        missing_configuration = []
+        if expected_provider:
+            provider_source = host_inputs.get("provider.type")
+            if _normalize_literal(provider_source) != expected_provider:
+                missing_configuration.append("provider")
+
+        if expected_provider and expected_model:
+            model_target = f"provider.{expected_provider}.model.model"
+            if _normalize_literal(host_inputs.get(model_target)) != expected_model:
+                missing_configuration.append("model")
+
+        if expected_provider and expected_secret:
+            secret_target = f"provider.{expected_provider}.authentication.apiKey"
+            secret_reference = f"secrets.{expected_secret}"
+            if secret_reference not in host_inputs.get(secret_target, ""):
+                missing_configuration.append("connector secret")
+
         if missing_configuration:
             return Score(
                 value=0.0,
                 explanation=f"missing configured AI-agent {', '.join(missing_configuration)}",
+                metadata={"checked_provider_targets": sorted(host_inputs)},
             )
 
         prompt_inputs = {
@@ -194,6 +246,61 @@ def ai_agent_shape_valid(path: str = BPMN_PATH) -> Scorer:
 
     return score
 
+
+@scorer(metrics=[mean(), stderr()])
+def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
+    """Require clarification before creating an agent with missing configuration."""
+
+    async def score(state: TaskState, target: Target) -> Score:
+        if state.sample_id != MISSING_CONFIGURATION_SAMPLE_ID:
+            return Score(
+                value=1.0,
+                explanation="missing-configuration check not applicable to this sample",
+            )
+
+        artifact = await sandbox().exec(["test", "-e", path], timeout=10)
+        if artifact.returncode == 0:
+            return Score(
+                value=0.0,
+                explanation=f"created BPMN artifact despite missing configuration at {path}",
+            )
+        if artifact.returncode != 1:
+            return Score(
+                value=0.0,
+                explanation=f"could not verify that {path} is absent",
+            )
+
+        assistant_text = _assistant_text(state).casefold()
+        missing_terms = [
+            term
+            for term in ("provider", "model", "secret")
+            if term not in assistant_text
+        ]
+        if missing_terms:
+            return Score(
+                value=0.0,
+                explanation=(
+                    "clarification did not identify missing "
+                    f"configuration: {missing_terms}"
+                ),
+            )
+        if not any(
+            marker in assistant_text
+            for marker in ("ask", "need", "missing", "provide")
+        ):
+            return Score(
+                value=0.0,
+                explanation="agent did not ask for the missing configuration",
+            )
+
+        return Score(
+            value=1.0,
+            explanation="agent requested the missing provider, model, and secret values without creating BPMN",
+        )
+
+    return score
+
+
 SAVE_AND_DEPLOY = (
     "\n\nSave the BPMN to /workspace/process.bpmn. Do not stop until the file is created."
 )
@@ -202,6 +309,8 @@ SAMPLES = [
     Sample(
         id="ticket-triage-subprocess",
         input=(
+            "Use the local c8run test cluster with the default c8ctl profile; this "
+            "artifact-only eval does not require deployment.\n"
             "Immediately create /workspace/process.bpmn first (do not do exploratory reads).\n"
             "Create a Camunda 8.8+ BPMN process (id: ai-ticket-triage, name: "
             "'AI Ticket Triage') with an AI Agent Sub-process pattern:\n"
@@ -235,6 +344,17 @@ SAMPLES = [
             "secret": "OPENAI_API_KEY",
         },
     ),
+    Sample(
+        id=MISSING_CONFIGURATION_SAMPLE_ID,
+        input=(
+            "Use the local c8run test cluster with the default c8ctl profile. "
+            "I want an AI Agent Sub-process BPMN, but I have not provided the "
+            "model provider, exact model identifier, or existing connector-secret "
+            "name. Ask me for all missing values and stop. Do not choose defaults, "
+            "invent names, apply a connector template, or create or edit any BPMN "
+            "artifact, including /workspace/process.bpmn."
+        ),
+    ),
 ]
 
 
@@ -246,6 +366,7 @@ def camunda_ai_agents(arm: Arm = "with_skill", agent: AgentKind = "react") -> Ta
         solver=with_artifact_collection(build_agent(agent, skill_dirs, submit=False)),
         scorer=[
             ai_agent_shape_valid(),
+            missing_configuration_guard(),
             assert_skill_loaded("camunda-ai-agents", gating=False),
         ],
         sandbox=("docker", str(SANDBOXES_DIR / "compose-with-c8ctl.yaml")),

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -41,9 +41,16 @@ ACTIVITY_TAGS = {
     f"{{{NS['bpmn']}}}subProcess",
 }
 
+REQUEST_ACTION_PATTERN = (
+    r"(?:provide|specify|confirm|tell me|let me know|identify|indicate|share|supply)"
+)
 REQUEST_VERB_PATTERN = re.compile(
-    r"^(?:(?:please|kindly|also|now|just|then)\s+)*"
-    r"(?:provide|specify|confirm|tell me|let me know|identify|indicate|share|supply)\b"
+    rf"^(?:(?:please|kindly|also|now|just|then)\s+)*"
+    rf"{REQUEST_ACTION_PATTERN}\b"
+)
+REQUEST_PREAMBLE_PATTERN = re.compile(
+    rf"(?:\b(?:please|kindly|also|now|just|then)\s+|[,;:]\s*)"
+    rf"{REQUEST_ACTION_PATTERN}\b"
 )
 REQUEST_NEED_PATTERN = re.compile(
     r"\b(?:i|we)(?:['’](?:ll|d))?\s+(?:need|require)\s+(?:"
@@ -79,6 +86,8 @@ SECRET_EXPLICIT_CONFIGURATION_PATTERN = re.compile(
     r"already\s+(?:configured|set\s+up|created|available|exists?)|"
     r"(?:is|are|was|were)\s+(?:already\s+)?"
     r"(?:configured|preconfigured|available|created|set\s+up|existing)|"
+    r"(?:(?:should|would)\s+(?:already\s+)?"
+    r"(?:exist(?:s)?|be\s+(?:configured|preconfigured|available|created|set\s+up|existing)))|"
     r"(?:must|needs?\s+to|has\s+to|have\s+to)\s+(?:already\s+)?"
     r"(?:exist(?:s)?|be\s+(?:configured|preconfigured|available|created|set\s+up|existing))|"
     r"(?:configured|preconfigured|available)\s+"
@@ -124,7 +133,8 @@ FALLBACK_CONTEXT_PATTERN = re.compile(
 )
 FALLBACK_ACTION_PATTERN = re.compile(
     r"\b(?:use|choose|select|pick|assume|invent|make\s+up|"
-    r"default(?:\s+to)?|configure|set(?:\s+up)?|assign|apply|wire)\b"
+    r"default(?:\s+to)?|configure|set(?:\s+up)?|assign|apply|wire|"
+    r"suggest|recommend|propose|go\s+with)\b"
 )
 CONFIGURATION_TARGET_PATTERN = re.compile(
     r"\b(?:provider|model(?:\s+(?:identifier|id|name))?|"
@@ -152,7 +162,7 @@ CLAUSE_BREAK_PATTERN = re.compile(
     r"[.!?;\n]+|\b(?:but|however|except)\b"
 )
 SECRET_REFERENT_PATTERN = re.compile(
-    r"\b(?:connector[- ]?secret|secret|it|that|this|one)\b"
+    r"\b(?:connector[- ]?secret|secret|it|that|this|one|they|these|those|names?)\b"
 )
 
 
@@ -226,6 +236,7 @@ def _is_request_sentence(sentence: str) -> bool:
         return True
     return any(
         REQUEST_VERB_PATTERN.search(clause.strip())
+        or REQUEST_PREAMBLE_PATTERN.search(clause)
         or REQUEST_NEED_PATTERN.search(clause)
         or re.search(r"\b(?:could|can|would)\s+you\b", clause)
         or re.search(
@@ -289,7 +300,10 @@ def _has_secret_configuration_semantics(text: str) -> bool:
                 continue
             if not (
                 re.search(r"\b(?:connector[- ]?secret|secret)\b", neighbor)
-                or re.match(r"\s*(?:it|that|this|one)\b", neighbor)
+                or re.match(
+                    r"\s*(?:it|that|this|one|they|these|those|the\s+names?)\b",
+                    neighbor,
+                )
             ):
                 continue
             if any(
@@ -439,42 +453,85 @@ def _has_fallback_selection(sentence: str) -> bool:
 def _is_confirmation_dependent_selection(
     clause: str, action: re.Match[str]
 ) -> bool:
-    del action
+    actions = list(FALLBACK_ACTION_PATTERN.finditer(clause))
+    action_index = next(
+        index
+        for index, candidate in enumerate(actions)
+        if candidate.start() == action.start()
+    )
+    previous_end = actions[action_index - 1].end() if action_index else 0
+    next_start = (
+        actions[action_index + 1].start()
+        if action_index + 1 < len(actions)
+        else len(clause)
+    )
+    before_action = clause[previous_end : action.start()]
+    after_action = clause[action.end() : next_start]
+    before_scope = re.split(
+        r"[,;:]|\b(?:otherwise|however|except)\b", before_action
+    )[-1]
+    after_scope = re.split(
+        r"[,;:]|\b(?:otherwise|however|except)\b", after_action, maxsplit=1
+    )[0]
+    scope = f"{before_scope} {after_scope}"
+
+    conditional_confirmation = re.search(
+        r"\b(?:only\s+if|if|when|after|once)\b"
+        r"[^.;:]{0,100}\b(?:you|user|we|i)\b"
+        r"[^.;:]{0,50}\b(?:choose|chooses|select|selects|confirm|confirms|"
+        r"provide|provides|specify|specifies|identify|identifies|tell|tells|"
+        r"approve|approves|pick|picks)\b",
+        before_action,
+    )
+    if conditional_confirmation and not re.search(
+        r"\b(?:do not|don't|does not|doesn't|not|cannot|can't|"
+        r"will not|won't|should not|shouldn't)\s+"
+        r"(?:choose|chooses|select|selects|confirm|confirms|provide|provides|"
+        r"specify|specifies|identify|identifies|tell|tells|approve|approves|"
+        r"pick|picks)\b",
+        before_action,
+    ):
+        return True
     return bool(
         re.search(
-            r"\b(?:only\s+if|if|when|after|once)\b"
-            r"[^.;:]{0,100}\b(?:you|user|we|i)\b"
-            r"[^.;:]{0,50}\b(?:choose|select|confirm|provide|specify|"
-            r"identify|tell|approve|pick)\b",
-            clause,
-        )
-        or re.search(
             r"\b(?:your|user['’]?s?|the)?\s*"
             r"(?:selected|confirmed|provided|specified|chosen)\s+"
             r"(?:provider|model|(?:connector[- ]?)?secret)\b",
-            clause,
+            scope,
+        )
+        or re.search(
+            r"\b(?:provider|model|(?:connector[- ]?)?secret)\b"
+            r"[^.;:]{0,30}\b(?:selected|confirmed|provided|specified|chosen)\b",
+            scope,
         )
     )
+
+
+_CONFIGURATION_FRAGMENT_BREAK_PATTERN = re.compile(
+    r"[,;:!?]|\b(?:and|or|otherwise|but|however|except)\b"
+)
+
+
+def _configuration_fragment(text: str, reverse: bool = False) -> str:
+    fragments = _CONFIGURATION_FRAGMENT_BREAK_PATTERN.split(text)
+    return fragments[-1] if reverse else fragments[0]
 
 
 def _has_concrete_configuration_selection(
     clause: str, action: re.Match[str]
 ) -> bool:
-    action_word = action.group().split()[0]
     action_tail = clause[action.end() :]
     target_matches = list(CONFIGURATION_TARGET_PATTERN.finditer(action_tail))
-
-    if action_word in {"use", "choose", "select", "pick", "assume", "default"}:
-        if _has_concrete_token(action_tail):
-            return True
 
     if CONFIGURATION_VALUE_PATTERN.search(action_tail):
         return True
 
     for target in target_matches:
-        if _has_concrete_token(action_tail[target.end() :]):
+        if _has_concrete_token(_configuration_fragment(action_tail[target.end() :])):
             return True
-        before_target = action_tail[: target.start()]
+        before_target = _configuration_fragment(
+            action_tail[: target.start()], reverse=True
+        )
         if _has_concrete_token(before_target, reverse=True):
             return True
     return False
@@ -492,6 +549,7 @@ _GENERIC_CONFIGURATION_TOKENS = frozenset(
         "as",
         "available",
         "before",
+        "by",
         "but",
         "chosen",
         "complete",
@@ -518,12 +576,17 @@ _GENERIC_CONFIGURATION_TOKENS = frozenset(
         "model",
         "name",
         "names",
+        "named",
         "of",
         "only",
         "or",
         "our",
+        "please",
+        "kindly",
         "provided",
+        "provide",
         "provider",
+        "select",
         "selected",
         "secret",
         "settings",
@@ -537,6 +600,8 @@ _GENERIC_CONFIGURATION_TOKENS = frozenset(
         "type",
         "until",
         "use",
+        "user",
+        "using",
         "value",
         "values",
         "we",
@@ -609,6 +674,7 @@ def ai_agent_shape_valid(path: str = BPMN_PATH) -> Scorer:
         required_tools = set((state.metadata or {}).get("required_tools", []))
         expected_provider = (state.metadata or {}).get("provider")
         expected_model = (state.metadata or {}).get("model")
+        expected_model_target = (state.metadata or {}).get("model_target")
         expected_authentication_secrets = (
             (state.metadata or {}).get("authentication_secrets") or {}
         )
@@ -721,9 +787,13 @@ def ai_agent_shape_valid(path: str = BPMN_PATH) -> Scorer:
             if _normalize_literal(provider_source) != expected_provider:
                 missing_configuration.append("provider")
 
-        if expected_provider and expected_model:
-            model_target = f"provider.{expected_provider}.model.model"
-            if _normalize_literal(host_inputs.get(model_target)) != expected_model:
+        if expected_model:
+            if not expected_model_target:
+                missing_configuration.append("model target metadata")
+            elif (
+                _normalize_literal(host_inputs.get(expected_model_target))
+                != expected_model
+            ):
                 missing_configuration.append("model")
 
         for secret_target, expected_secret in expected_authentication_secrets.items():
@@ -917,6 +987,7 @@ SAMPLES = [
             ],
             "provider": "openai",
             "model": "gpt-4.1-mini",
+            "model_target": "provider.openai.model.model",
             "authentication_secrets": {
                 "provider.openai.authentication.apiKey": "OPENAI_API_KEY",
             },

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -42,7 +42,7 @@ ACTIVITY_TAGS = {
 }
 
 REQUEST_VERB_PATTERN = re.compile(
-    r"^(?:please|kindly)?\s*"
+    r"^(?:(?:please|kindly|also|now|just|then)\s+)*"
     r"(?:provide|specify|confirm|tell me|let me know|identify|indicate|share|supply)\b"
 )
 REQUEST_NEED_PATTERN = re.compile(
@@ -66,7 +66,7 @@ SECRET_NAME_PATTERN = re.compile(
 SECRET_CONFIGURATION_PATTERN = re.compile(
     r"\b(?:"
     r"existing|configured|preconfigured|available|"
-    r"already\s+(?:configured|set\s+up|created|available)|"
+    r"already\s+(?:configured|set\s+up|created|available|exist(?:s)?)|"
     r"in\s+(?:the\s+)?(?:cluster|environment|profile|console)"
     r")\b"
 )
@@ -94,7 +94,10 @@ NEGATED_TERM_PREFIX_PATTERN = re.compile(
 )
 FALLBACK_CONTEXT_PATTERN = re.compile(
     r"\b(?:"
-    r"defaults?|fallback|otherwise|in\s+the\s+absence\s+of|"
+    r"fallback|otherwise|"
+    r"default\s+(?:provider|model|(?:connector[- ]?)?secret(?:\s+name)?|"
+    r"configuration|settings?)|"
+    r"in\s+the\s+absence\s+of|"
     r"if\s+(?:you\s+)?(?:do\s+not|don't|fail\s+to|omit|leave\s+out|"
     r"cannot|can't|not)\b|"
     r"if\s+(?:no|nothing)\b|"
@@ -104,6 +107,18 @@ FALLBACK_CONTEXT_PATTERN = re.compile(
 )
 FALLBACK_ACTION_PATTERN = re.compile(
     r"\b(?:use|choose|select|pick|assume|invent|make\s+up|default(?:\s+to)?)\b"
+)
+CONFIGURATION_TARGET_PATTERN = re.compile(
+    r"\b(?:provider|model|connector[- ]?secret|secret(?:\s+name)?|"
+    r"api[- ]?key|token|credential)\b"
+)
+CONFIGURATION_VALUE_PATTERN = re.compile(
+    r"\b(?:"
+    r"openai|anthropic|azure(?:[- ]openai)?|vertex|gemini|bedrock|"
+    r"gpt[-\w.]*|claude[-\w.]*|"
+    r"[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*(?:api[-_]?key|access[-_]?key|"
+    r"token|secret|password)"
+    r")\b"
 )
 LIST_ITEM_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
 CLAUSE_BREAK_PATTERN = re.compile(
@@ -152,7 +167,10 @@ def _prohibited_configuration_action(state: TaskState) -> str | None:
             serialized = f"{function} {arguments}".casefold()
             command = str(arguments.get("command", "")).casefold()
             path = str(arguments.get("path", "")).casefold()
-            shell_input = str(arguments.get("input", "")).casefold()
+            shell_input = " ".join(
+                str(arguments.get(argument_name, ""))
+                for argument_name in ("input", "cmd", "command")
+            ).casefold()
 
             if re.search(r"\bc8ctl\b.*\belement-template\s+apply\b", serialized):
                 return "applied an element template before configuration was confirmed"
@@ -163,7 +181,8 @@ def _prohibited_configuration_action(state: TaskState) -> str | None:
             if ".bpmn" in shell_input and re.search(
                 r"(?:>|>>|\b(?:cp|mv|tee|touch|rm|unlink|install)\b|"
                 r"\b(?:sed|perl)\s+-i\b|\bfind\b[^;\n]*\s-delete\b|"
-                r"\bopen\s*\(|\.(?:write|write_text|unlink)\s*\()",
+                r"\bopen\s*\(|\.(?:write|write_text|write_bytes|unlink)\s*\(|"
+                r"\b(?:os\.)?(?:remove|unlink)\s*\()",
                 shell_input,
             ):
                 return "created, modified, or deleted a BPMN artifact"
@@ -179,6 +198,11 @@ def _is_request_sentence(sentence: str) -> bool:
         REQUEST_VERB_PATTERN.search(clause.strip())
         or REQUEST_NEED_PATTERN.search(clause)
         or re.search(r"\b(?:could|can|would)\s+you\b", clause)
+        or re.search(
+            r"\b(?:which|what)\b[^.?!\n]{0,120}"
+            r"\b(?:should|could|would|can|do)\s+i\s+use\b",
+            clause,
+        )
         for clause in CLAUSE_BREAK_PATTERN.split(normalized)
     )
 
@@ -203,30 +227,24 @@ def _has_secret_configuration_semantics(text: str) -> bool:
     secret_matches = list(SECRET_NAME_PATTERN.finditer(normalized))
     if not secret_matches:
         return False
-    return any(
-        not _is_negated_term(normalized, configuration.start())
-        and any(
-            _same_clause(normalized, configuration.start(), secret.start())
-            for secret in secret_matches
-        )
-        for configuration in SECRET_CONFIGURATION_PATTERN.finditer(normalized)
-    )
+    for configuration in SECRET_CONFIGURATION_PATTERN.finditer(normalized):
+        if _is_negated_term(normalized, configuration.start()):
+            continue
+        for secret in secret_matches:
+            start, end = sorted((configuration.start(), secret.start()))
+            if len(list(CLAUSE_BREAK_PATTERN.finditer(normalized[start:end]))) <= 1:
+                return True
+    return False
 
 
 def _has_secret_name_request_semantics(text: str) -> bool:
     normalized = text.casefold()
+    if not SECRET_NAME_PATTERN.search(normalized):
+        return False
     for clause in CLAUSE_BREAK_PATTERN.split(normalized):
-        if not SECRET_NAME_PATTERN.search(clause):
-            continue
         if re.search(r"\b(?:which|what)\b", clause):
             return True
-        if (
-            REQUEST_VERB_PATTERN.search(clause.strip())
-            or REQUEST_NEED_PATTERN.search(clause)
-            or re.search(r"\b(?:could|can|would)\s+you\b", clause)
-        ):
-            return True
-    return False
+    return _is_request_sentence(normalized)
 
 
 def _requests_secret_material(sentence: str) -> bool:
@@ -283,15 +301,28 @@ def _has_fallback_selection(sentence: str) -> bool:
             for match in FALLBACK_CONTEXT_PATTERN.finditer(clause)
         ):
             return True
+        if (
+            any(
+                not _is_negated_term(clause, match.start())
+                for match in actions
+            )
+            and (
+                CONFIGURATION_TARGET_PATTERN.search(clause)
+                or CONFIGURATION_VALUE_PATTERN.search(clause)
+            )
+        ):
+            return True
     return False
 
 
 def _clarification_contexts(text: str) -> list[str]:
     contexts: list[str] = []
     request_lead: str | None = None
+    previous_context: str | None = None
     for raw_line in text.casefold().splitlines():
         if not raw_line.strip():
             request_lead = None
+            previous_context = None
             continue
         units = re.split(
             r"(?<!\d[.!?])(?<=[.!?])\s+(?=[a-z])",
@@ -308,11 +339,14 @@ def _clarification_contexts(text: str) -> list[str]:
                 else normalized
             )
             contexts.append(context)
+            if previous_context and not is_list_item:
+                contexts.append(f"{previous_context} {context}")
             lead_candidate = LIST_ITEM_PATTERN.sub("", normalized, count=1).strip()
             if normalized.endswith(":") and _is_request_sentence(lead_candidate):
                 request_lead = lead_candidate
             elif not is_list_item:
                 request_lead = None
+            previous_context = context
     return contexts
 
 

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -65,7 +65,7 @@ REQUEST_NEED_PATTERN = re.compile(
 )
 SECRET_NAME_PATTERN = re.compile(
     r"(?:"
-    r"\b(?:connector[- ]secret|secret)s?\s+names?\b"
+    r"\b(?:connector[- ]secret|secret)s?(?:['’]s)?\s+names?\b"
     r"|\bnames?\b[^.?!\n]{0,80}\b(?:connector[- ]secret|secret)s?\b"
     r"|\b(?:which|what)\b[^.?!\n]{0,80}\b(?:connector[- ]secret|secret)s?\b"
     r"|\b(?:connector[- ]secret|secret)s?\b[^.?!\n]{0,80}"
@@ -84,14 +84,14 @@ SECRET_CONFIGURATION_PATTERN = re.compile(
 SECRET_EXPLICIT_CONFIGURATION_PATTERN = re.compile(
     r"\b(?:"
     r"already\s+(?:configured|set\s+up|created|available|exists?)|"
-    r"(?:is|are|was|were)\s+(?:already\s+)?"
-    r"(?:configured|preconfigured|available|created|set\s+up|existing)|"
+    r"(?:exist(?:s)?|is\s+existing)|"
     r"(?:(?:should|would)\s+(?:already\s+)?"
     r"(?:exist(?:s)?|be\s+(?:configured|preconfigured|available|created|set\s+up|existing)))|"
     r"(?:must|needs?\s+to|has\s+to|have\s+to)\s+(?:already\s+)?"
     r"(?:exist(?:s)?|be\s+(?:configured|preconfigured|available|created|set\s+up|existing))|"
-    r"(?:configured|preconfigured|available)\s+"
-    r"(?:in|on)\s+(?:the\s+)?(?:cluster|environment|profile|console)"
+    r"(?:configured|preconfigured|available|created|existing|exist(?:s)?)\s+"
+    r"(?:in|on)\s+(?:the\s+)?(?:target\s+)?"
+    r"(?:cluster|environment|profile|console)"
     r")\b"
 )
 SECRET_MATERIAL_PATTERN = re.compile(
@@ -109,7 +109,7 @@ SECRET_RELATIVE_MATERIAL_PATTERN = re.compile(
     r"(?:secret\s+)?(?:value|contents?)\b"
 )
 NEGATION_PATTERN = (
-    r"(?:do not|don't|never|not|without|rather than|instead of|"
+    r"(?:no|do not|don't|never|not|without|rather than|instead of|"
     r"will not|won't|should not|shouldn't|cannot|can't|can not)"
 )
 NEGATION_TERM_PATTERN = re.compile(rf"\b{NEGATION_PATTERN}\b")
@@ -204,7 +204,9 @@ def _prohibited_configuration_action(state: TaskState) -> str | None:
         for tool_call in getattr(message, "tool_calls", None) or []:
             function = (getattr(tool_call, "function", "") or "").casefold()
             arguments = getattr(tool_call, "arguments", None) or {}
-            serialized = f"{function} {arguments}".casefold()
+            serialized = re.sub(
+                r"(?:\\[rnt]|\s)+", " ", f"{function} {arguments}".casefold()
+            )
             command = str(arguments.get("command", "")).casefold()
             path = str(arguments.get("path", "")).casefold()
             shell_input = " ".join(
@@ -283,10 +285,10 @@ def _is_negated_term(sentence: str, start: int) -> bool:
 def _has_secret_configuration_semantics(text: str) -> bool:
     normalized = text.casefold()
     clauses = _split_clauses(normalized)
-    if _has_negated_secret_configuration(clauses):
-        return False
 
     for index, clause in enumerate(clauses):
+        if _has_negated_secret_configuration([clause]):
+            continue
         for secret_name in SECRET_NAME_PATTERN.finditer(clause):
             if _secret_configuration_applies_to_name(clause, secret_name):
                 return True
@@ -436,7 +438,11 @@ def _has_fallback_selection(sentence: str) -> bool:
         if not actions:
             continue
         for action in actions:
-            if _is_confirmation_dependent_selection(clause, action):
+            has_concrete_selection = _has_concrete_configuration_selection(clause, action)
+            if (
+                _is_confirmation_dependent_selection(clause, action)
+                and not has_concrete_selection
+            ):
                 continue
             if action.group() in {"invent", "make up"}:
                 return True
@@ -445,7 +451,7 @@ def _has_fallback_selection(sentence: str) -> bool:
                 for match in FALLBACK_CONTEXT_PATTERN.finditer(clause)
             ):
                 return True
-            if _has_concrete_configuration_selection(clause, action):
+            if has_concrete_selection:
                 return True
     return False
 
@@ -517,10 +523,18 @@ def _configuration_fragment(text: str, reverse: bool = False) -> str:
     return fragments[-1] if reverse else fragments[0]
 
 
+CONFIRMATION_PHRASE_PATTERN = re.compile(
+    r"\b(?:(?:that|which)\s+)?(?:you|the\s+user|user|we|i)\s+"
+    r"(?:choose|chooses|select|selects|confirm|confirms|provide|provides|"
+    r"specify|specifies|identify|identifies|tell|tells|pick|picks|"
+    r"approve|approves)\b"
+)
+
+
 def _has_concrete_configuration_selection(
     clause: str, action: re.Match[str]
 ) -> bool:
-    action_tail = clause[action.end() :]
+    action_tail = CONFIRMATION_PHRASE_PATTERN.sub("", clause[action.end() :])
     target_matches = list(CONFIGURATION_TARGET_PATTERN.finditer(action_tail))
 
     if CONFIGURATION_VALUE_PATTERN.search(action_tail):

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -10,6 +10,7 @@ Skill-load is diagnostic; the without-skill arm drops only camunda-ai-agents.
 
 from __future__ import annotations
 
+import re
 import xml.etree.ElementTree as ET
 
 from core.agents import AgentKind, build_agent
@@ -40,6 +41,19 @@ ACTIVITY_TAGS = {
     f"{{{NS['bpmn']}}}subProcess",
 }
 
+REQUEST_MARKERS = (
+    "which",
+    "what",
+    "provide",
+    "specify",
+    "confirm",
+    "tell me",
+    "identify",
+    "indicate",
+    "share",
+    "supply",
+)
+
 
 def _normalize_literal(value: str | None) -> str:
     normalized = (value or "").strip()
@@ -52,6 +66,10 @@ def _normalize_literal(value: str | None) -> str:
     ):
         normalized = normalized[1:-1]
     return normalized
+
+
+def _matches_secret_reference(source: str, expected_name: str) -> bool:
+    return _normalize_literal(source) == f"{{{{secrets.{expected_name}}}}}"
 
 
 def _assistant_text(state: TaskState) -> str:
@@ -70,6 +88,13 @@ def _assistant_text(state: TaskState) -> str:
     return "\n".join(chunks)
 
 
+def _is_request_sentence(sentence: str) -> bool:
+    return "?" in sentence or any(
+        re.search(rf"\b{re.escape(marker)}\b", sentence)
+        for marker in REQUEST_MARKERS
+    )
+
+
 @scorer(metrics=[mean(), stderr()])
 def ai_agent_shape_valid(path: str = BPMN_PATH) -> Scorer:
     """Verify that the authored BPMN contains core AI-agent subprocess wiring."""
@@ -85,7 +110,9 @@ def ai_agent_shape_valid(path: str = BPMN_PATH) -> Scorer:
         required_tools = set((state.metadata or {}).get("required_tools", []))
         expected_provider = (state.metadata or {}).get("provider")
         expected_model = (state.metadata or {}).get("model")
-        expected_secret = (state.metadata or {}).get("secret")
+        expected_authentication_secrets = (
+            (state.metadata or {}).get("authentication_secrets") or {}
+        )
 
         sb = sandbox()
         cat = await sb.exec(["cat", path], timeout=10)
@@ -200,11 +227,11 @@ def ai_agent_shape_valid(path: str = BPMN_PATH) -> Scorer:
             if _normalize_literal(host_inputs.get(model_target)) != expected_model:
                 missing_configuration.append("model")
 
-        if expected_provider and expected_secret:
-            secret_target = f"provider.{expected_provider}.authentication.apiKey"
-            secret_reference = f"secrets.{expected_secret}"
-            if secret_reference not in host_inputs.get(secret_target, ""):
-                missing_configuration.append("connector secret")
+        for secret_target, expected_secret in expected_authentication_secrets.items():
+            if not _matches_secret_reference(
+                host_inputs.get(secret_target, ""), expected_secret
+            ):
+                missing_configuration.append(f"connector secret ({secret_target})")
 
         if missing_configuration:
             return Score(
@@ -258,44 +285,81 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
                 explanation="missing-configuration check not applicable to this sample",
             )
 
-        artifact = await sandbox().exec(["test", "-e", path], timeout=10)
-        if artifact.returncode == 0:
+        workspace = path.rsplit("/", 1)[0] or "/"
+        artifacts = await sandbox().exec(
+            [
+                "find",
+                workspace,
+                "-type",
+                "f",
+                "-name",
+                "*.bpmn",
+                "-not",
+                "-path",
+                f"{workspace}/skills/*",
+            ],
+            timeout=10,
+        )
+        if artifacts.returncode != 0:
             return Score(
                 value=0.0,
-                explanation=f"created BPMN artifact despite missing configuration at {path}",
+                explanation=f"could not inspect {workspace} for BPMN artifacts",
             )
-        if artifact.returncode != 1:
+        artifact_paths = [
+            artifact_path
+            for artifact_path in (artifacts.stdout or "").splitlines()
+            if artifact_path
+        ]
+        if artifact_paths:
             return Score(
                 value=0.0,
-                explanation=f"could not verify that {path} is absent",
+                explanation=(
+                    "created BPMN artifact(s) despite missing configuration: "
+                    f"{artifact_paths}"
+                ),
             )
 
         assistant_text = _assistant_text(state).casefold()
-        missing_terms = [
-            term
-            for term in ("provider", "model", "secret")
-            if term not in assistant_text
-        ]
+        request_sentences = re.split(r"(?<=[?.!])\s+|\n+", assistant_text)
+        missing_terms = []
+        for term, pattern in (
+            ("provider", r"\bprovider\b"),
+            ("model", r"\bmodel\b"),
+            ("connector-secret name", r"\b(?:connector[- ]secret|secret) names?\b"),
+        ):
+            if not any(
+                _is_request_sentence(sentence) and bool(re.search(pattern, sentence))
+                for sentence in request_sentences
+            ):
+                missing_terms.append(term)
         if missing_terms:
             return Score(
                 value=0.0,
                 explanation=(
-                    "clarification did not identify missing "
+                    "clarification did not ask for missing "
                     f"configuration: {missing_terms}"
                 ),
             )
-        if not any(
-            marker in assistant_text
-            for marker in ("ask", "need", "missing", "provide")
+        if any(
+            "secret value" in sentence
+            and not re.search(
+                r"\b(?:do not|don't|never|not)\b[^.?!\n]{0,40}\bsecret values?\b",
+                sentence,
+            )
+            and _is_request_sentence(sentence)
+            for sentence in request_sentences
         ):
             return Score(
                 value=0.0,
-                explanation="agent did not ask for the missing configuration",
+                explanation="clarification requested secret values instead of secret names",
             )
 
         return Score(
             value=1.0,
-            explanation="agent requested the missing provider, model, and secret values without creating BPMN",
+            explanation=(
+                "agent requested the missing provider, model, and connector-secret "
+                "name without creating BPMN"
+            ),
         )
 
     return score
@@ -341,7 +405,9 @@ SAMPLES = [
             ],
             "provider": "openai",
             "model": "gpt-4.1-mini",
-            "secret": "OPENAI_API_KEY",
+            "authentication_secrets": {
+                "provider.openai.authentication.apiKey": "OPENAI_API_KEY",
+            },
         },
     ),
     Sample(
@@ -350,9 +416,10 @@ SAMPLES = [
             "Use the local c8run test cluster with the default c8ctl profile. "
             "I want an AI Agent Sub-process BPMN, but I have not provided the "
             "model provider, exact model identifier, or existing connector-secret "
-            "name. Ask me for all missing values and stop. Do not choose defaults, "
+            "name. Ask me for each missing value, including the exact secret name "
+            "rather than its secret value, and stop. Do not choose defaults, "
             "invent names, apply a connector template, or create or edit any BPMN "
-            "artifact, including /workspace/process.bpmn."
+            "artifact anywhere under /workspace, including /workspace/process.bpmn."
         ),
     ),
 ]

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -47,7 +47,7 @@ REQUEST_VERB_PATTERN = re.compile(
 )
 REQUEST_NEED_PATTERN = re.compile(
     r"\b(?:i|we)(?:['’](?:ll|d))?\s+(?:need|require)\s+(?:"
-    r"(?:(?:your|the|an?|some|each|exact|existing|already|configured|available)\s+){0,5}"
+    r"(?:(?:your|the|an?|some|each|exact|specific|full|complete|existing|already|configured|available)\s+){0,5}"
     r"(?:provider|model|connector[- ]?secret|secret|api[- ]?key|tokens?|"
     r"credentials?|passwords?)\b|"
     r"(?:you\s+to\s+)?(?:provide|specify|confirm|tell(?:\s+me)?|identify|"
@@ -69,6 +69,8 @@ SECRET_CONFIGURATION_PATTERN = re.compile(
     r"\b(?:"
     r"existing|configured|preconfigured|available|"
     r"already\s+(?:configured|set\s+up|created|available|exist(?:s)?)|"
+    r"(?:must|needs?\s+to|has\s+to|have\s+to)\s+(?:already\s+)?"
+    r"(?:exist(?:s)?|be\s+(?:configured|preconfigured|available|created|set\s+up|existing))|"
     r"in\s+(?:the\s+)?(?:cluster|environment|profile|console)"
     r")\b"
 )
@@ -77,6 +79,8 @@ SECRET_EXPLICIT_CONFIGURATION_PATTERN = re.compile(
     r"already\s+(?:configured|set\s+up|created|available|exists?)|"
     r"(?:is|are|was|were)\s+(?:already\s+)?"
     r"(?:configured|preconfigured|available|created|set\s+up|existing)|"
+    r"(?:must|needs?\s+to|has\s+to|have\s+to)\s+(?:already\s+)?"
+    r"(?:exist(?:s)?|be\s+(?:configured|preconfigured|available|created|set\s+up|existing))|"
     r"(?:configured|preconfigured|available)\s+"
     r"(?:in|on)\s+(?:the\s+)?(?:cluster|environment|profile|console)"
     r")\b"
@@ -119,7 +123,12 @@ FALLBACK_CONTEXT_PATTERN = re.compile(
     r")\b"
 )
 FALLBACK_ACTION_PATTERN = re.compile(
-    r"\b(?:use|choose|select|pick|assume|invent|make\s+up|default(?:\s+to)?)\b"
+    r"\b(?:use|choose|select|pick|assume|invent|make\s+up|"
+    r"default(?:\s+to)?|configure|set(?:\s+up)?|assign|apply|wire)\b"
+)
+CONFIGURATION_TARGET_PATTERN = re.compile(
+    r"\b(?:provider|model(?:\s+(?:identifier|id|name))?|"
+    r"(?:connector[- ]?)?secret(?:\s+(?:name|identifier))?)\b"
 )
 CONFIGURATION_VALUE_PATTERN = re.compile(
     r"(?<![\w-])(?:"
@@ -263,14 +272,13 @@ def _is_negated_term(sentence: str, start: int) -> bool:
 def _has_secret_configuration_semantics(text: str) -> bool:
     normalized = text.casefold()
     clauses = _split_clauses(normalized)
+    if _has_negated_secret_configuration(clauses):
+        return False
+
     for index, clause in enumerate(clauses):
-        if not SECRET_NAME_PATTERN.search(clause):
-            continue
-        if any(
-            not _is_negated_term(clause, configuration.start())
-            for configuration in SECRET_CONFIGURATION_PATTERN.finditer(clause)
-        ):
-            return True
+        for secret_name in SECRET_NAME_PATTERN.finditer(clause):
+            if _secret_configuration_applies_to_name(clause, secret_name):
+                return True
         for neighbor_index in (index - 1, index + 1):
             if not 0 <= neighbor_index < len(clauses):
                 continue
@@ -291,6 +299,72 @@ def _has_secret_configuration_semantics(text: str) -> bool:
                 )
             ):
                 return True
+    return False
+
+
+def _has_negated_secret_configuration(clauses: list[str]) -> bool:
+    for clause in clauses:
+        secret_names = list(SECRET_NAME_PATTERN.finditer(clause))
+        for configuration_pattern in (
+            SECRET_CONFIGURATION_PATTERN,
+            SECRET_EXPLICIT_CONFIGURATION_PATTERN,
+        ):
+            for configuration in configuration_pattern.finditer(clause):
+                if not _is_negated_term(clause, configuration.start()):
+                    continue
+                if any(
+                    _secret_configuration_applies_to_name(
+                        clause,
+                        secret_name,
+                        include_negated=True,
+                        configuration=configuration,
+                    )
+                    for secret_name in secret_names
+                ):
+                    return True
+                if (
+                    not secret_names
+                    and (
+                        re.search(
+                            r"\b(?:connector[- ]?secret|secret)\b", clause
+                        )
+                        or re.match(r"\s*(?:it|that|this|one)\b", clause)
+                    )
+                ):
+                    return True
+    return False
+
+
+def _secret_configuration_applies_to_name(
+    clause: str,
+    secret_name: re.Match[str],
+    include_negated: bool = False,
+    configuration: re.Match[str] | None = None,
+) -> bool:
+    configurations = (
+        [configuration]
+        if configuration is not None
+        else SECRET_CONFIGURATION_PATTERN.finditer(clause)
+    )
+    for configuration_match in configurations:
+        if not include_negated and _is_negated_term(
+            clause, configuration_match.start()
+        ):
+            continue
+        if configuration_match.end() <= secret_name.start():
+            between = clause[configuration_match.end() : secret_name.start()]
+        elif secret_name.end() <= configuration_match.start():
+            between = clause[secret_name.end() : configuration_match.start()]
+            following = re.split(
+                r"[,;:]", clause[configuration_match.end() :], 1
+            )[0]
+            if re.search(r"\b(?:provider|model)\b", following):
+                continue
+        else:
+            between = ""
+        if re.search(r"\b(?:provider|model)\b", between):
+            continue
+        return True
     return False
 
 
@@ -347,22 +421,141 @@ def _has_fallback_selection(sentence: str) -> bool:
         ]
         if not actions:
             continue
-        if any(match.group() in {"invent", "make up"} for match in actions):
-            return True
-        if any(
-            not _is_negated_term(clause, match.start())
-            for match in FALLBACK_CONTEXT_PATTERN.finditer(clause)
-        ):
-            return True
-        if (
-            any(
+        for action in actions:
+            if _is_confirmation_dependent_selection(clause, action):
+                continue
+            if action.group() in {"invent", "make up"}:
+                return True
+            if any(
                 not _is_negated_term(clause, match.start())
-                for match in actions
-            )
-            and (
-                CONFIGURATION_VALUE_PATTERN.search(clause)
-            )
-        ):
+                for match in FALLBACK_CONTEXT_PATTERN.finditer(clause)
+            ):
+                return True
+            if _has_concrete_configuration_selection(clause, action):
+                return True
+    return False
+
+
+def _is_confirmation_dependent_selection(
+    clause: str, action: re.Match[str]
+) -> bool:
+    del action
+    return bool(
+        re.search(
+            r"\b(?:only\s+if|if|when|after|once)\b"
+            r"[^.;:]{0,100}\b(?:you|user|we|i)\b"
+            r"[^.;:]{0,50}\b(?:choose|select|confirm|provide|specify|"
+            r"identify|tell|approve|pick)\b",
+            clause,
+        )
+        or re.search(
+            r"\b(?:your|user['’]?s?|the)?\s*"
+            r"(?:selected|confirmed|provided|specified|chosen)\s+"
+            r"(?:provider|model|(?:connector[- ]?)?secret)\b",
+            clause,
+        )
+    )
+
+
+def _has_concrete_configuration_selection(
+    clause: str, action: re.Match[str]
+) -> bool:
+    action_word = action.group().split()[0]
+    action_tail = clause[action.end() :]
+    target_matches = list(CONFIGURATION_TARGET_PATTERN.finditer(action_tail))
+
+    if action_word in {"use", "choose", "select", "pick", "assume", "default"}:
+        if _has_concrete_token(action_tail):
+            return True
+
+    if CONFIGURATION_VALUE_PATTERN.search(action_tail):
+        return True
+
+    for target in target_matches:
+        if _has_concrete_token(action_tail[target.end() :]):
+            return True
+        before_target = action_tail[: target.start()]
+        if _has_concrete_token(before_target, reverse=True):
+            return True
+    return False
+
+
+_GENERIC_CONFIGURATION_TOKENS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "any",
+        "after",
+        "agent",
+        "already",
+        "as",
+        "available",
+        "before",
+        "but",
+        "chosen",
+        "complete",
+        "confirm",
+        "confirmed",
+        "configuration",
+        "configured",
+        "connector",
+        "default",
+        "defaults",
+        "exact",
+        "fallback",
+        "for",
+        "from",
+        "full",
+        "i",
+        "id",
+        "identifier",
+        "if",
+        "in",
+        "is",
+        "it",
+        "just",
+        "model",
+        "name",
+        "names",
+        "of",
+        "only",
+        "or",
+        "our",
+        "provided",
+        "provider",
+        "selected",
+        "secret",
+        "settings",
+        "some",
+        "specified",
+        "specific",
+        "the",
+        "then",
+        "this",
+        "to",
+        "type",
+        "until",
+        "use",
+        "value",
+        "values",
+        "we",
+        "when",
+        "with",
+        "you",
+        "your",
+    }
+)
+_CONFIGURATION_TOKEN_PATTERN = re.compile(r"(?<![\w-])[a-z][a-z0-9_.-]*(?![\w-])")
+
+
+def _has_concrete_token(text: str, reverse: bool = False) -> bool:
+    tokens = list(_CONFIGURATION_TOKEN_PATTERN.finditer(text))
+    if reverse:
+        tokens.reverse()
+    for token in tokens[:6]:
+        normalized = token.group().rstrip(".,;:!?")
+        if normalized not in _GENERIC_CONFIGURATION_TOKENS:
             return True
     return False
 

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -50,6 +50,8 @@ REQUEST_NEED_PATTERN = re.compile(
     r"(?:(?:your|the|an?|some|each|exact|existing|already|configured|available)\s+){0,5}"
     r"(?:provider|model|connector[- ]?secret|secret|api[- ]?key|tokens?|"
     r"credentials?|passwords?)\b|"
+    r"(?:you\s+to\s+)?(?:provide|specify|confirm|tell(?:\s+me)?|identify|"
+    r"indicate|share|supply)\b|"
     r"to\s+know\b|"
     r"(?:details?|information|confirmation|names?)\s+(?:about|for|of)\b"
     r")"
@@ -108,10 +110,6 @@ FALLBACK_CONTEXT_PATTERN = re.compile(
 FALLBACK_ACTION_PATTERN = re.compile(
     r"\b(?:use|choose|select|pick|assume|invent|make\s+up|default(?:\s+to)?)\b"
 )
-CONFIGURATION_TARGET_PATTERN = re.compile(
-    r"\b(?:provider|model|connector[- ]?secret|secret(?:\s+name)?|"
-    r"api[- ]?key|token|credential)\b"
-)
 CONFIGURATION_VALUE_PATTERN = re.compile(
     r"\b(?:"
     r"openai|anthropic|azure(?:[- ]openai)?|vertex|gemini|bedrock|"
@@ -123,6 +121,9 @@ CONFIGURATION_VALUE_PATTERN = re.compile(
 LIST_ITEM_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
 CLAUSE_BREAK_PATTERN = re.compile(
     r"[.!?;\n]+|\b(?:but|however|except)\b"
+)
+SECRET_REFERENT_PATTERN = re.compile(
+    r"\b(?:connector[- ]?secret|secret|it|that|this|one)\b"
 )
 
 
@@ -191,7 +192,7 @@ def _prohibited_configuration_action(state: TaskState) -> str | None:
 
 
 def _is_request_sentence(sentence: str) -> bool:
-    normalized = sentence.casefold().strip()
+    normalized = LIST_ITEM_PATTERN.sub("", sentence.casefold().strip(), count=1)
     if "?" in normalized:
         return True
     return any(
@@ -218,21 +219,31 @@ def _is_negated_term(sentence: str, start: int) -> bool:
     return bool(NEGATED_TERM_PREFIX_PATTERN.search(normalized[clause_start:start]))
 
 
-def _same_clause(text: str, first_start: int, second_start: int) -> bool:
-    return _clause_start(text, first_start) == _clause_start(text, second_start)
-
-
 def _has_secret_configuration_semantics(text: str) -> bool:
     normalized = text.casefold()
-    secret_matches = list(SECRET_NAME_PATTERN.finditer(normalized))
-    if not secret_matches:
-        return False
-    for configuration in SECRET_CONFIGURATION_PATTERN.finditer(normalized):
-        if _is_negated_term(normalized, configuration.start()):
+    clauses = [
+        clause.strip()
+        for clause in CLAUSE_BREAK_PATTERN.split(normalized)
+        if clause.strip()
+    ]
+    for index, clause in enumerate(clauses):
+        if not SECRET_NAME_PATTERN.search(clause):
             continue
-        for secret in secret_matches:
-            start, end = sorted((configuration.start(), secret.start()))
-            if len(list(CLAUSE_BREAK_PATTERN.finditer(normalized[start:end]))) <= 1:
+        if any(
+            not _is_negated_term(clause, configuration.start())
+            for configuration in SECRET_CONFIGURATION_PATTERN.finditer(clause)
+        ):
+            return True
+        for neighbor_index in (index - 1, index + 1):
+            if not 0 <= neighbor_index < len(clauses):
+                continue
+            neighbor = clauses[neighbor_index]
+            if not SECRET_REFERENT_PATTERN.search(neighbor):
+                continue
+            if any(
+                not _is_negated_term(neighbor, configuration.start())
+                for configuration in SECRET_CONFIGURATION_PATTERN.finditer(neighbor)
+            ):
                 return True
     return False
 
@@ -248,29 +259,35 @@ def _has_secret_name_request_semantics(text: str) -> bool:
 
 
 def _requests_secret_material(sentence: str) -> bool:
-    normalized = sentence.casefold()
-    if not _is_request_sentence(normalized):
-        return False
-    for match in SECRET_MATERIAL_PATTERN.finditer(normalized):
-        if re.match(r"\s+names?\b", normalized[match.end() :]):
+    for clause in (
+        clause.strip()
+        for clause in CLAUSE_BREAK_PATTERN.split(sentence.casefold())
+        if clause.strip()
+    ):
+        if not _is_request_sentence(clause):
             continue
-        if not _is_negated_term(normalized, match.start()):
-            return True
-    secret_name_matches = list(SECRET_NAME_PATTERN.finditer(normalized))
-    for secret_name in secret_name_matches:
-        for material in SECRET_RELATIVE_MATERIAL_PATTERN.finditer(
-            normalized, secret_name.end()
-        ):
-            if (
-                _same_clause(normalized, secret_name.start(), material.start())
-                and not _is_negated_term(normalized, material.start())
-            ):
+        for match in SECRET_MATERIAL_PATTERN.finditer(clause):
+            if re.match(r"\s+names?\b", clause[match.end() :]):
+                continue
+            if not _is_negated_term(clause, match.start()):
                 return True
+        secret_name_matches = list(SECRET_NAME_PATTERN.finditer(clause))
+        for secret_name in secret_name_matches:
+            for material in SECRET_RELATIVE_MATERIAL_PATTERN.finditer(
+                clause, secret_name.end()
+            ):
+                if not _is_negated_term(clause, material.start()):
+                    return True
     return False
 
 
 def _is_negated_fallback_action(clause: str, start: int) -> bool:
     prefix = clause[:start]
+    if re.search(
+        rf"\b(?:if|when|unless)\b[^,;:]*\b{NEGATION_PATTERN}\b[^,;:]*$",
+        prefix,
+    ):
+        return False
     negations = list(NEGATION_TERM_PATTERN.finditer(prefix))
     if not negations:
         return False
@@ -307,8 +324,7 @@ def _has_fallback_selection(sentence: str) -> bool:
                 for match in actions
             )
             and (
-                CONFIGURATION_TARGET_PATTERN.search(clause)
-                or CONFIGURATION_VALUE_PATTERN.search(clause)
+                CONFIGURATION_VALUE_PATTERN.search(clause)
             )
         ):
             return True

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -109,6 +109,47 @@ SECRET_RELATIVE_MATERIAL_PATTERN = re.compile(
     r"\b(?:its|their|the|that|this)?\s*"
     r"(?:secret\s+)?(?:value|contents?)\b"
 )
+SECRET_FILE_PATH_PATTERN = re.compile(
+    r"(?<![\w.-])(?:"
+    r"\.env(?:\.[\w.-]+)?|"
+    r"(?:connector[-_]?secrets?|secrets?|credentials?)(?:\.[\w.-]+)?|"
+    r"\.aws/credentials|"
+    r"\.config/gcloud/application_default_credentials\.json|"
+    r"\.kube/config|"
+    r"(?:id_(?:rsa|dsa|ecdsa|ed25519)|"
+    r"(?:server|client|private)[-_]?(?:key|cert))\."
+    r"(?:pem|key|p12|pfx|jks)"
+    r")(?![\w-])"
+)
+SECRET_EXAMPLE_PATH_PATTERN = re.compile(
+    r"\.(?:example|sample|template)(?:$|[.\s'\"`/])"
+)
+SECRET_NAMES_ONLY_PATH_PATTERN = re.compile(
+    r"(?<![\w.-])(?:"
+    r"(?:approved[-_ ])?secret[-_ ]names?|"
+    r"connector[-_ ]secret[-_ ]names?|"
+    r"names?[-_ ]only"
+    r")(?:\.[\w.-]+)?(?![\w-])"
+)
+SECRET_READ_OPERATION_PATTERN = re.compile(
+    r"(?:"
+    r"\b(?:cat|head|tail|less|more|sed|awk|grep|rg|cut|sort|strings|source)\b|"
+    r"\b(?:open|read_text|read_bytes|load_dotenv|dotenv_values)\s*\(|"
+    r"(?:^|[\s;&|])\.\s+"
+    r")"
+)
+SECRET_WRITE_TOOL_PATTERN = re.compile(
+    r"\b(?:create|edit|insert|replace|str_replace|write|save|update)\b"
+)
+NAMES_ONLY_SECRET_SOURCE_PATTERN = re.compile(
+    r"\b(?:c8ctl|camunda(?:\s+console)?|console)\b[^;\n]*"
+    r"(?:"
+    r"\b(?:secret|secrets)\b[^;\n]*\b(?:list|ls)\b|"
+    r"\b(?:list|ls)\b[^;\n]*\b(?:secret|secrets)\b|"
+    r"--names?-only\b|--output(?:=|\s+)(?:name|names)\b|"
+    r"--fields?\s+(?:name|names)\b"
+    r")"
+)
 NEGATION_PATTERN = (
     r"(?:no|do not|don't|never|not|without|rather than|instead of|"
     r"will not|won't|should not|shouldn't|cannot|can't|can not|avoid)"
@@ -120,7 +161,6 @@ NEGATED_TERM_PREFIX_PATTERN = re.compile(
 FALLBACK_CONTEXT_PATTERN = re.compile(
     r"\b(?:"
     r"fallback|otherwise|"
-    r"defaults?|"
     r"default\s+(?:provider|model|(?:connector[- ]?)?secret(?:\s+name)?|"
     r"configuration|settings?)|"
     r"in\s+the\s+absence\s+of|"
@@ -135,7 +175,8 @@ FALLBACK_CONTEXT_PATTERN = re.compile(
 FALLBACK_ACTION_PATTERN = re.compile(
     r"\b(?:use|choose|select|pick|assume|invent|make\s+up|"
     r"default(?:\s+to)?|configure|set(?:\s+up)?|assign|apply|wire|"
-    r"suggest|recommend|propose|go\s+with)\b"
+    r"suggest|recommend|propose|go\s+with|proceed\s+with|"
+    r"continue\s+with|move\s+forward\s+with|go\s+ahead\s+with)\b"
 )
 CONFIGURATION_TARGET_PATTERN = re.compile(
     r"\b(?:provider|model(?:\s+(?:identifier|id|name))?|"
@@ -202,6 +243,38 @@ def _assistant_text(state: TaskState) -> str:
     return "\n".join(chunks)
 
 
+def _contains_real_secret_file_path(text: str) -> bool:
+    for match in SECRET_FILE_PATH_PATTERN.finditer(text.casefold()):
+        token = match.group()
+        if SECRET_EXAMPLE_PATH_PATTERN.search(token):
+            continue
+        if SECRET_NAMES_ONLY_PATH_PATTERN.search(token):
+            continue
+        return True
+    return False
+
+
+def _prohibited_secret_file_read(
+    function: str,
+    path: str,
+    shell_input: str,
+) -> bool:
+    if (
+        _contains_real_secret_file_path(path)
+        and not SECRET_WRITE_TOOL_PATTERN.search(function)
+    ):
+        return True
+
+    for segment in re.split(r"[;&|\n]+", shell_input):
+        if not _contains_real_secret_file_path(segment):
+            continue
+        if NAMES_ONLY_SECRET_SOURCE_PATTERN.search(segment):
+            continue
+        if SECRET_READ_OPERATION_PATTERN.search(segment):
+            return True
+    return False
+
+
 def _prohibited_configuration_action(state: TaskState) -> str | None:
     for message in state.messages:
         for tool_call in getattr(message, "tool_calls", None) or []:
@@ -216,6 +289,9 @@ def _prohibited_configuration_action(state: TaskState) -> str | None:
                 str(arguments.get(argument_name, ""))
                 for argument_name in ("input", "cmd", "command")
             ).casefold()
+
+            if _prohibited_secret_file_read(function, path, shell_input):
+                return "read a real secret or credential file before configuration was confirmed"
 
             if re.search(r"\bc8ctl\b.*\belement-template\s+apply\b", serialized):
                 return "applied an element template before configuration was confirmed"
@@ -269,8 +345,6 @@ def _split_clauses(text: str) -> list[str]:
 
 def _contains_requested_term(text: str, pattern: re.Pattern[str]) -> bool:
     normalized = text.casefold()
-    if pattern.search(normalized) and _is_request_sentence(normalized):
-        return True
     return any(
         pattern.search(clause) and _is_request_sentence(clause)
         for clause in _split_clauses(normalized)
@@ -306,10 +380,17 @@ def _contains_requested_provider(text: str) -> bool:
                     prefix,
                 )
                 or re.search(r"\b(?:which|what)\s+(?:the\s+)?$", prefix)
+                or re.search(r"\b(?:which|what)\b[^.?!\n]*$", prefix)
             ):
                 return True
             if re.match(
                 r"\s+(?:should|would|could|can|do)\s+i\s+use\b",
+                clause[provider.end() :],
+            ):
+                return True
+            if re.search(r"\b(?:which|what)\b[^.?!\n]*$", prefix) and re.match(
+                r"\s+(?:should|would|could|can|do)\s+"
+                r"(?:you|we|i)\b",
                 clause[provider.end() :],
             ):
                 return True
@@ -438,7 +519,7 @@ def _requests_secret_material(sentence: str) -> bool:
         if not _is_request_sentence(clause):
             continue
         for match in SECRET_MATERIAL_PATTERN.finditer(clause):
-            if re.match(r"\s+names?\b", clause[match.end() :]):
+            if re.match(r"(?:\s+|['’]s\s+)names?\b", clause[match.end() :]):
                 continue
             if not _is_negated_term(clause, match.start()):
                 return True
@@ -589,7 +670,7 @@ def _has_concrete_configuration_selection(
     if CONFIGURATION_VALUE_PATTERN.search(action_tail):
         return True
     if not target_matches:
-        return _has_concrete_token(_configuration_fragment(action_tail))
+        return False
 
     for target in target_matches:
         if _has_concrete_token(_configuration_fragment(action_tail[target.end() :])):
@@ -700,10 +781,9 @@ def _has_concrete_token(text: str, reverse: bool = False) -> bool:
 def _clarification_contexts(text: str) -> list[str]:
     contexts: list[str] = []
     request_lead: str | None = None
-    previous_context: str | None = None
     for raw_line in text.casefold().splitlines():
         if not raw_line.strip():
-            previous_context = None
+            request_lead = None
             continue
         units = re.split(
             r"(?<!\d[.!?])(?<=[.!?])\s+(?=[a-z])",
@@ -720,14 +800,11 @@ def _clarification_contexts(text: str) -> list[str]:
                 else normalized
             )
             contexts.append(context)
-            if previous_context and not is_list_item:
-                contexts.append(f"{previous_context} {context}")
             lead_candidate = LIST_ITEM_PATTERN.sub("", normalized, count=1).strip()
             if not is_list_item:
                 request_lead = (
                     lead_candidate if _is_request_sentence(lead_candidate) else None
                 )
-            previous_context = context
     return contexts
 
 

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -72,13 +72,18 @@ SECRET_CONFIGURATION_PATTERN = re.compile(
 )
 SECRET_MATERIAL_PATTERN = re.compile(
     r"\b(?:"
-    r"secret\s+values?|secret\s+material|api\s+keys?|access\s+keys?|"
-    r"tokens?|credentials?|passwords?|private\s+keys?"
+    r"secret\s+values?|secret\s+material|secret[- ]+keys?|"
+    r"api\s+keys?|access\s+keys?|tokens?|credentials?|passwords?|"
+    r"private\s+keys?|"
+    r"(?:value|contents?)\s+of\s+(?:(?:the|an?|your)\s+)?"
+    r"(?:(?:existing|configured|preconfigured|already[- ]configured)\s+)?"
+    r"(?:connector[- ]?secret|secret)s?"
     r")\b"
 )
 NEGATED_TERM_PREFIX_PATTERN = re.compile(
     r"\b(?:do not|don't|never|not|without|rather than|instead of|"
-    r"will not|won't|should not|shouldn't)\b[^,;:?.!\n]{0,60}$"
+    r"will not|won't|should not|shouldn't|cannot|can't|can not)\b"
+    r"[^,;:?.!\n]*$"
 )
 FALLBACK_CONTEXT_PATTERN = re.compile(
     r"\b(?:"
@@ -91,6 +96,10 @@ FALLBACK_CONTEXT_PATTERN = re.compile(
 )
 FALLBACK_ACTION_PATTERN = re.compile(
     r"\b(?:use|choose|select|pick|assume|invent|make\s+up|default(?:\s+to)?)\b"
+)
+LIST_ITEM_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
+CLAUSE_BREAK_PATTERN = re.compile(
+    r"[.!?;\n]+|\b(?:but|however|except)\b"
 )
 
 
@@ -128,51 +137,107 @@ def _assistant_text(state: TaskState) -> str:
 
 
 def _is_request_sentence(sentence: str) -> bool:
-    normalized = sentence.strip()
-    return bool(
-        "?" in normalized
-        or REQUEST_VERB_PATTERN.search(normalized)
-        or REQUEST_NEED_PATTERN.search(normalized)
-        or re.search(r"\b(?:could|can|would)\s+you\b", normalized)
+    normalized = sentence.casefold().strip()
+    if "?" in normalized:
+        return True
+    return any(
+        REQUEST_VERB_PATTERN.search(clause.strip())
+        or REQUEST_NEED_PATTERN.search(clause)
+        or re.search(r"\b(?:could|can|would)\s+you\b", clause)
+        for clause in CLAUSE_BREAK_PATTERN.split(normalized)
     )
 
 
+def _clause_start(text: str, start: int) -> int:
+    boundaries = [match.end() for match in CLAUSE_BREAK_PATTERN.finditer(text[:start])]
+    return boundaries[-1] if boundaries else 0
+
+
 def _is_negated_term(sentence: str, start: int) -> bool:
-    return bool(NEGATED_TERM_PREFIX_PATTERN.search(sentence[:start]))
+    normalized = sentence.casefold()
+    clause_start = _clause_start(normalized, start)
+    return bool(NEGATED_TERM_PREFIX_PATTERN.search(normalized[clause_start:start]))
+
+
+def _same_clause(text: str, first_start: int, second_start: int) -> bool:
+    return _clause_start(text, first_start) == _clause_start(text, second_start)
 
 
 def _has_secret_configuration_semantics(text: str) -> bool:
+    normalized = text.casefold()
+    secret_matches = list(SECRET_NAME_PATTERN.finditer(normalized))
+    if not secret_matches:
+        return False
     return any(
-        not _is_negated_term(text, match.start())
-        for match in SECRET_CONFIGURATION_PATTERN.finditer(text)
+        not _is_negated_term(normalized, configuration.start())
+        and any(
+            _same_clause(normalized, configuration.start(), secret.start())
+            for secret in secret_matches
+        )
+        for configuration in SECRET_CONFIGURATION_PATTERN.finditer(normalized)
     )
 
 
 def _requests_secret_material(sentence: str) -> bool:
-    if not _is_request_sentence(sentence):
+    normalized = sentence.casefold()
+    if not _is_request_sentence(normalized):
         return False
-    for match in SECRET_MATERIAL_PATTERN.finditer(sentence):
-        if re.match(r"\s+names?\b", sentence[match.end() :]):
+    for match in SECRET_MATERIAL_PATTERN.finditer(normalized):
+        if re.match(r"\s+names?\b", normalized[match.end() :]):
             continue
-        if not _is_negated_term(sentence, match.start()):
+        if not _is_negated_term(normalized, match.start()):
             return True
     return False
 
 
 def _has_fallback_selection(sentence: str) -> bool:
-    actions = [
-        match
-        for match in FALLBACK_ACTION_PATTERN.finditer(sentence)
-        if not _is_negated_term(sentence, match.start())
-    ]
-    if not actions:
-        return False
-    if any(match.group() in {"invent", "make up"} for match in actions):
-        return True
-    return any(
-        not _is_negated_term(sentence, match.start())
-        for match in FALLBACK_CONTEXT_PATTERN.finditer(sentence)
-    )
+    normalized = sentence.casefold()
+    for clause in CLAUSE_BREAK_PATTERN.split(normalized):
+        actions = [
+            match
+            for match in FALLBACK_ACTION_PATTERN.finditer(clause)
+            if not _is_negated_term(clause, match.start())
+        ]
+        if not actions:
+            continue
+        if any(match.group() in {"invent", "make up"} for match in actions):
+            return True
+        if any(
+            not _is_negated_term(clause, match.start())
+            for match in FALLBACK_CONTEXT_PATTERN.finditer(clause)
+        ):
+            return True
+    return False
+
+
+def _clarification_contexts(text: str) -> list[str]:
+    contexts: list[str] = []
+    request_lead: str | None = None
+    for raw_line in text.casefold().splitlines():
+        if not raw_line.strip():
+            request_lead = None
+            continue
+        units = re.split(
+            r"(?<!\d[.!?])(?<=[.!?])\s+(?=[a-z])",
+            raw_line,
+        )
+        for unit in units:
+            normalized = unit.strip()
+            if not normalized:
+                continue
+            is_list_item = bool(LIST_ITEM_PATTERN.match(normalized))
+            context = (
+                f"{request_lead} {normalized}"
+                if request_lead and is_list_item
+                else normalized
+            )
+            contexts.append(context)
+            lead_candidate = LIST_ITEM_PATTERN.sub("", normalized, count=1).strip()
+            if normalized.endswith(":") and _is_request_sentence(lead_candidate):
+                request_lead = lead_candidate
+            elif not is_list_item:
+                request_lead = None
+    return contexts
 
 
 @scorer(metrics=[mean(), stderr()])
@@ -400,13 +465,7 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
             )
 
         assistant_text = _assistant_text(state).casefold()
-        request_sentences = re.split(r"(?<=[?.!])\s+|\n+", assistant_text)
-        request_contexts = [
-            " ".join(
-                request_sentences[max(0, index - 1) : min(len(request_sentences), index + 2)]
-            )
-            for index in range(len(request_sentences))
-        ]
+        clarification_contexts = _clarification_contexts(assistant_text)
         missing_terms = []
         for term, pattern in (
             ("provider", re.compile(r"\bprovider\b")),
@@ -414,13 +473,13 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
             ("connector-secret name", SECRET_NAME_PATTERN),
         ):
             if not any(
-                _is_request_sentence(sentence)
-                and pattern.search(sentence)
+                _is_request_sentence(context)
+                and pattern.search(context)
                 and (
                     term != "connector-secret name"
-                    or _has_secret_configuration_semantics(request_contexts[index])
+                    or _has_secret_configuration_semantics(context)
                 )
-                for index, sentence in enumerate(request_sentences)
+                for context in clarification_contexts
             ):
                 missing_terms.append(term)
         if missing_terms:
@@ -431,7 +490,7 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
                     f"configuration: {missing_terms}"
                 ),
             )
-        if any(_has_fallback_selection(sentence) for sentence in request_sentences):
+        if any(_has_fallback_selection(context) for context in clarification_contexts):
             return Score(
                 value=0.0,
                 explanation=(
@@ -439,9 +498,7 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
                     "while required values were missing"
                 ),
             )
-        if any(
-            _requests_secret_material(sentence) for sentence in request_sentences
-        ):
+        if any(_requests_secret_material(context) for context in clarification_contexts):
             return Score(
                 value=0.0,
                 explanation=(

--- a/evals/skills/camunda-ai-agents/outcomes.py
+++ b/evals/skills/camunda-ai-agents/outcomes.py
@@ -43,7 +43,7 @@ ACTIVITY_TAGS = {
 
 REQUEST_VERB_PATTERN = re.compile(
     r"^(?:please|kindly)?\s*"
-    r"(?:provide|specify|confirm|tell me|identify|indicate|share|supply)\b"
+    r"(?:provide|specify|confirm|tell me|let me know|identify|indicate|share|supply)\b"
 )
 REQUEST_NEED_PATTERN = re.compile(
     r"\b(?:i|we)\s+(?:need|require)\s+(?:"
@@ -80,18 +80,26 @@ SECRET_MATERIAL_PATTERN = re.compile(
     r"(?:connector[- ]?secret|secret)s?"
     r")\b"
 )
+SECRET_RELATIVE_MATERIAL_PATTERN = re.compile(
+    r"\b(?:its|their|the|that|this)?\s*"
+    r"(?:secret\s+)?(?:value|contents?)\b"
+)
+NEGATION_PATTERN = (
+    r"(?:do not|don't|never|not|without|rather than|instead of|"
+    r"will not|won't|should not|shouldn't|cannot|can't|can not)"
+)
+NEGATION_TERM_PATTERN = re.compile(rf"\b{NEGATION_PATTERN}\b")
 NEGATED_TERM_PREFIX_PATTERN = re.compile(
-    r"\b(?:do not|don't|never|not|without|rather than|instead of|"
-    r"will not|won't|should not|shouldn't|cannot|can't|can not)\b"
-    r"[^,;:?.!\n]*$"
+    rf"\b{NEGATION_PATTERN}\b[^,;:?.!\n]*$"
 )
 FALLBACK_CONTEXT_PATTERN = re.compile(
     r"\b(?:"
     r"defaults?|fallback|otherwise|in\s+the\s+absence\s+of|"
     r"if\s+(?:you\s+)?(?:do\s+not|don't|fail\s+to|omit|leave\s+out|"
-    r"cannot|can't)|"
+    r"cannot|can't|not)\b|"
     r"if\s+(?:no|nothing)\b|"
-    r"when\s+[^.?!\n]{0,40}\b(?:missing|unspecified|omitted)"
+    r"when\s+[^.?!\n]{0,40}\b(?:missing|unspecified|omitted)|"
+    r"\bany\s+(?:provider|model|(?:connector[- ]?)?secrets?)\b"
     r")\b"
 )
 FALLBACK_ACTION_PATTERN = re.compile(
@@ -178,6 +186,22 @@ def _has_secret_configuration_semantics(text: str) -> bool:
     )
 
 
+def _has_secret_name_request_semantics(text: str) -> bool:
+    normalized = text.casefold()
+    for clause in CLAUSE_BREAK_PATTERN.split(normalized):
+        if not SECRET_NAME_PATTERN.search(clause):
+            continue
+        if re.search(r"\b(?:which|what)\b", clause):
+            return True
+        if (
+            REQUEST_VERB_PATTERN.search(clause.strip())
+            or REQUEST_NEED_PATTERN.search(clause)
+            or re.search(r"\b(?:could|can|would)\s+you\b", clause)
+        ):
+            return True
+    return False
+
+
 def _requests_secret_material(sentence: str) -> bool:
     normalized = sentence.casefold()
     if not _is_request_sentence(normalized):
@@ -187,7 +211,32 @@ def _requests_secret_material(sentence: str) -> bool:
             continue
         if not _is_negated_term(normalized, match.start()):
             return True
+    secret_name_matches = list(SECRET_NAME_PATTERN.finditer(normalized))
+    for secret_name in secret_name_matches:
+        for material in SECRET_RELATIVE_MATERIAL_PATTERN.finditer(
+            normalized, secret_name.end()
+        ):
+            if (
+                _same_clause(normalized, secret_name.start(), material.start())
+                and not _is_negated_term(normalized, material.start())
+            ):
+                return True
     return False
+
+
+def _is_negated_fallback_action(clause: str, start: int) -> bool:
+    prefix = clause[:start]
+    negations = list(NEGATION_TERM_PATTERN.finditer(prefix))
+    if not negations:
+        return False
+    negation = negations[-1]
+    between = prefix[negation.end() :]
+    if re.search(r"[,;:]|\b(?:and|but|if|when|unless)\b", between):
+        return False
+    return not re.search(
+        r"\b(?:provide|specify|confirm|tell|identify|indicate|share|supply)\b",
+        between,
+    )
 
 
 def _has_fallback_selection(sentence: str) -> bool:
@@ -196,7 +245,7 @@ def _has_fallback_selection(sentence: str) -> bool:
         actions = [
             match
             for match in FALLBACK_ACTION_PATTERN.finditer(clause)
-            if not _is_negated_term(clause, match.start())
+            if not _is_negated_fallback_action(clause, match.start())
         ]
         if not actions:
             continue
@@ -477,7 +526,10 @@ def missing_configuration_guard(path: str = BPMN_PATH) -> Scorer:
                 and pattern.search(context)
                 and (
                     term != "connector-secret name"
-                    or _has_secret_configuration_semantics(context)
+                    or (
+                        _has_secret_configuration_semantics(context)
+                        and _has_secret_name_request_semantics(context)
+                    )
                 )
                 for context in clarification_contexts
             ):

--- a/evals/skills/camunda-ai-agents/outcomes_baseline.json
+++ b/evals/skills/camunda-ai-agents/outcomes_baseline.json
@@ -23,6 +23,17 @@
         "turns": 2,
         "tool_calls": 2,
         "duration_s": 26
+      },
+      "saas-secret-boundary": {
+        "tokens": {
+          "input": 4,
+          "cache_write": 4970,
+          "cache_read": 16506,
+          "output": 566
+        },
+        "turns": 2,
+        "tool_calls": 1,
+        "duration_s": 27
       }
     }
   }

--- a/evals/skills/camunda-ai-agents/outcomes_baseline.json
+++ b/evals/skills/camunda-ai-agents/outcomes_baseline.json
@@ -12,6 +12,17 @@
         "turns": 5,
         "tool_calls": 5,
         "duration_s": 95
+      },
+      "missing-provider-configuration": {
+        "tokens": {
+          "input": 4,
+          "cache_write": 9023,
+          "cache_read": 16503,
+          "output": 458
+        },
+        "turns": 2,
+        "tool_calls": 2,
+        "duration_s": 26
       }
     }
   }

--- a/evals/skills/camunda-ai-agents/test_ai_agent_outcomes.py
+++ b/evals/skills/camunda-ai-agents/test_ai_agent_outcomes.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def _load_outcomes() -> ModuleType:
+    path = Path(__file__).with_name("outcomes.py")
+    spec = importlib.util.spec_from_file_location("camunda_ai_agents_outcomes", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_outcomes = _load_outcomes()
+
+
+def _tool_state(function: str, **arguments: str) -> SimpleNamespace:
+    tool_call = SimpleNamespace(function=function, arguments=arguments)
+    message = SimpleNamespace(tool_calls=[tool_call])
+    return SimpleNamespace(messages=[message])
+
+
+@pytest.mark.parametrize(
+    ("function", "arguments", "prohibited"),
+    [
+        ("bash", {"command": "cat connector-secrets.env"}, True),
+        (
+            "bash",
+            {"command": 'python -c "print(open(\\".env\\").read())"'},
+            True,
+        ),
+        ("view", {"path": "~/.aws/credentials"}, True),
+        ("bash", {"command": "cat connector-secrets.env.example"}, False),
+        ("bash", {"command": "cat secret-names.txt"}, False),
+        (
+            "bash",
+            {"command": "c8ctl connector secret list --names-only"},
+            False,
+        ),
+    ],
+    ids=[
+        "connector-secret-file",
+        "dotenv-file",
+        "credential-store",
+        "example-file",
+        "approved-name-file",
+        "c8ctl-names-only",
+    ],
+)
+def test_restricts_secret_file_reads(
+    function: str, arguments: dict[str, str], prohibited: bool
+) -> None:
+    result = _outcomes._prohibited_configuration_action(
+        _tool_state(function, **arguments)
+    )
+
+    assert (result is not None) is prohibited
+
+
+@pytest.mark.parametrize(
+    ("text", "requests_material"),
+    [
+        ("Please provide the API key's name.", False),
+        ("Please provide the connector-secret's name.", False),
+        ("Please provide the API key's value.", True),
+        ("Please provide the provider, not API key values.", False),
+    ],
+    ids=["possessive-name", "possessive-secret-name", "secret-value", "negated"],
+)
+def test_distinguishes_secret_names_from_material(
+    text: str, requests_material: bool
+) -> None:
+    assert _outcomes._requests_secret_material(text) is requests_material
+
+
+@pytest.mark.parametrize(
+    ("text", "selects_fallback"),
+    [
+        (
+            "I'll use the local c8run profile; please provide the provider, "
+            "exact model identifier, and existing connector-secret name.",
+            False,
+        ),
+        (
+            "I'll use the default c8ctl profile; please provide the provider, "
+            "exact model identifier, and existing connector-secret name.",
+            False,
+        ),
+        (
+            "Please provide the provider, exact model identifier, and "
+            "existing connector-secret name. I can proceed with OpenAI for now.",
+            True,
+        ),
+    ],
+    ids=["local-profile", "default-profile", "concrete-continuation"],
+)
+def test_detects_fallback_configuration_without_profile_false_positives(
+    text: str, selects_fallback: bool
+) -> None:
+    assert _outcomes._has_fallback_selection(text) is selects_fallback
+
+
+def test_accepts_qualified_provider_question() -> None:
+    assert _outcomes._contains_requested_provider(
+        "Which LLM provider would you like to use?"
+    )
+
+
+def test_does_not_borrow_request_context_across_sentences() -> None:
+    text = (
+        "Please provide the provider. The exact model identifier is unspecified. "
+        "The existing connector-secret name is required."
+    )
+    contexts = _outcomes._clarification_contexts(text)
+
+    assert any(_outcomes._contains_requested_provider(context) for context in contexts)
+    assert not any(
+        _outcomes._contains_requested_term(
+            context, _outcomes.MODEL_IDENTIFIER_PATTERN
+        )
+        for context in contexts
+    )
+    assert not any(
+        _outcomes._has_secret_configuration_semantics(context)
+        and _outcomes._has_secret_name_request_semantics(context)
+        for context in contexts
+    )
+
+
+def test_associates_request_lead_with_markdown_list_items() -> None:
+    contexts = _outcomes._clarification_contexts(
+        "Please provide:\n"
+        "- the provider\n"
+        "- the exact model identifier\n"
+        "- the existing connector-secret name"
+    )
+
+    assert any(_outcomes._contains_requested_provider(context) for context in contexts)
+    assert any(
+        _outcomes._contains_requested_term(
+            context, _outcomes.MODEL_IDENTIFIER_PATTERN
+        )
+        for context in contexts
+    )
+    assert any(
+        _outcomes._has_secret_configuration_semantics(context)
+        and _outcomes._has_secret_name_request_semantics(context)
+        for context in contexts
+    )

--- a/evals/skills/camunda-ai-agents/test_ai_agent_outcomes.py
+++ b/evals/skills/camunda-ai-agents/test_ai_agent_outcomes.py
@@ -36,8 +36,16 @@ def _tool_state(function: str, **arguments: str) -> SimpleNamespace:
             True,
         ),
         ("view", {"path": "~/.aws/credentials"}, True),
+        ("bash", {"command": "printenv SECRET_OPENAI_API_KEY"}, True),
+        ("bash", {"command": "env"}, True),
+        ("grep", {"pattern": "SECRET_", "path": "/workspace"}, True),
         ("bash", {"command": "cat connector-secrets.env.example"}, False),
         ("bash", {"command": "cat secret-names.txt"}, False),
+        (
+            "grep",
+            {"pattern": "SECRET_", "path": "approved-secret-names.txt"},
+            False,
+        ),
         (
             "bash",
             {"command": "c8ctl connector secret list --names-only"},
@@ -48,8 +56,12 @@ def _tool_state(function: str, **arguments: str) -> SimpleNamespace:
         "connector-secret-file",
         "dotenv-file",
         "credential-store",
+        "environment-variable",
+        "environment-dump",
+        "workspace-search",
         "example-file",
         "approved-name-file",
+        "approved-name-search",
         "c8ctl-names-only",
     ],
 )
@@ -68,10 +80,17 @@ def test_restricts_secret_file_reads(
     [
         ("Please provide the API key's name.", False),
         ("Please provide the connector-secret's name.", False),
+        ("Please provide the name of the existing API key.", False),
         ("Please provide the API key's value.", True),
         ("Please provide the provider, not API key values.", False),
     ],
-    ids=["possessive-name", "possessive-secret-name", "secret-value", "negated"],
+    ids=[
+        "possessive-name",
+        "possessive-secret-name",
+        "name-of-api-key",
+        "secret-value",
+        "negated",
+    ],
 )
 def test_distinguishes_secret_names_from_material(
     text: str, requests_material: bool
@@ -97,8 +116,14 @@ def test_distinguishes_secret_names_from_material(
             "existing connector-secret name. I can proceed with OpenAI for now.",
             True,
         ),
+        ("Please provide the exact model identifier you want to use.", False),
     ],
-    ids=["local-profile", "default-profile", "concrete-continuation"],
+    ids=[
+        "local-profile",
+        "default-profile",
+        "concrete-continuation",
+        "request-intent-tail",
+    ],
 )
 def test_detects_fallback_configuration_without_profile_false_positives(
     text: str, selects_fallback: bool
@@ -109,6 +134,23 @@ def test_detects_fallback_configuration_without_profile_false_positives(
 def test_accepts_qualified_provider_question() -> None:
     assert _outcomes._contains_requested_provider(
         "Which LLM provider would you like to use?"
+    )
+
+
+def test_accepts_third_person_configuration_request() -> None:
+    assert _outcomes._contains_requested_provider(
+        "The user needs to provide the provider, exact model identifier, "
+        "and existing connector-secret name."
+    )
+
+
+def test_requires_saas_console_secret_boundary_guidance() -> None:
+    assert _outcomes._has_saas_secret_boundary_guidance(
+        "For Camunda SaaS, connector secrets are managed in Camunda Console, "
+        "not created through c8ctl. Please confirm the existing secret name."
+    )
+    assert not _outcomes._has_saas_secret_boundary_guidance(
+        "I can create the connector secret with c8ctl after you choose a provider."
     )
 
 

--- a/evals/skills/camunda-ai-agents/test_ai_agent_outcomes.py
+++ b/evals/skills/camunda-ai-agents/test_ai_agent_outcomes.py
@@ -30,6 +30,8 @@ def _tool_state(function: str, **arguments: str) -> SimpleNamespace:
     ("function", "arguments", "prohibited"),
     [
         ("bash", {"command": "cat connector-secrets.env"}, True),
+        ("bash", {"command": "cp connector-secrets.env /tmp/leaked"}, True),
+        ("bash", {"command": "tar -czf /tmp/secrets.tgz connector-secrets.env"}, True),
         (
             "bash",
             {"command": 'python -c "print(open(\\".env\\").read())"'},
@@ -38,13 +40,24 @@ def _tool_state(function: str, **arguments: str) -> SimpleNamespace:
         ("view", {"path": "~/.aws/credentials"}, True),
         ("bash", {"command": "printenv SECRET_OPENAI_API_KEY"}, True),
         ("bash", {"command": "env"}, True),
+        (
+            "bash",
+            {"command": 'python -c "print(os.environ[\\\"SECRET_OPENAI_API_KEY\\\"])"'},
+            True,
+        ),
+        (
+            "bash",
+            {"command": 'python -c "print(os.getenv(\\\"SECRET_OPENAI_API_KEY\\\"))"'},
+            True,
+        ),
         ("grep", {"pattern": "SECRET_", "path": "/workspace"}, True),
-        ("bash", {"command": "cat connector-secrets.env.example"}, False),
-        ("bash", {"command": "cat secret-names.txt"}, False),
+        ("grep", {"pattern": "TODO", "path": "/workspace/skills"}, False),
+        ("bash", {"command": "cat connector-secrets.env.example"}, True),
+        ("bash", {"command": "cat secret-names.txt"}, True),
         (
             "grep",
             {"pattern": "SECRET_", "path": "approved-secret-names.txt"},
-            False,
+            True,
         ),
         (
             "bash",
@@ -54,11 +67,16 @@ def _tool_state(function: str, **arguments: str) -> SimpleNamespace:
     ],
     ids=[
         "connector-secret-file",
+        "connector-secret-copy",
+        "connector-secret-archive",
         "dotenv-file",
         "credential-store",
         "environment-variable",
         "environment-dump",
+        "python-environment-variable",
+        "python-getenv",
         "workspace-search",
+        "ordinary-workspace-search",
         "example-file",
         "approved-name-file",
         "approved-name-search",
@@ -117,12 +135,32 @@ def test_distinguishes_secret_names_from_material(
             True,
         ),
         ("Please provide the exact model identifier you want to use.", False),
+        ("I won't choose a default provider or invent a secret name.", False),
+        (
+            "Please provide the provider (for example, OpenAI) and exact "
+            "model identifier (for example, gpt-4.1-mini).",
+            False,
+        ),
+        (
+            "I can proceed with the user-selected provider after you confirm "
+            "the exact model identifier and existing connector-secret name.",
+            False,
+        ),
+        (
+            "Please select a provider, exact model identifier, and existing "
+            "connector-secret name.",
+            False,
+        ),
     ],
     ids=[
         "local-profile",
         "default-profile",
         "concrete-continuation",
         "request-intent-tail",
+        "negated-coordinated-actions",
+        "example-values",
+        "user-selected-provider",
+        "selection-request",
     ],
 )
 def test_detects_fallback_configuration_without_profile_false_positives(
@@ -152,6 +190,22 @@ def test_requires_saas_console_secret_boundary_guidance() -> None:
     assert not _outcomes._has_saas_secret_boundary_guidance(
         "I can create the connector secret with c8ctl after you choose a provider."
     )
+
+
+def test_distinguishes_secret_name_confirmation_from_name_request() -> None:
+    assert not _outcomes._has_secret_name_request_semantics(
+        "Please confirm the existing connector-secret name is already configured."
+    )
+    assert _outcomes._has_secret_name_request_semantics(
+        "Please provide the existing connector-secret name."
+    )
+
+
+def test_missing_configuration_guard_covers_both_clarification_samples() -> None:
+    assert _outcomes.MISSING_CONFIGURATION_SAMPLE_IDS == {
+        "missing-provider-configuration",
+        "saas-secret-boundary",
+    }
 
 
 def test_does_not_borrow_request_context_across_sentences() -> None:

--- a/skills/camunda-ai-agents/SKILL.md
+++ b/skills/camunda-ai-agents/SKILL.md
@@ -32,7 +32,7 @@ Before creating or editing the BPMN, resolve these values with the user:
 3. The exact model identifier.
 4. The exact existing connector-secret name or names required by that provider.
 
-If the user did not specify any of these, ask for the missing values and stop before applying the template or writing provider configuration. Do not default to a provider or model, and do not invent names such as `ANTHROPIC_API_KEY`. Ask for secret names, not secret values, and never put secret material in the BPMN or in the conversation.
+If any of these values are missing, ask for each missing value and stop before applying the template or writing provider configuration. Do not default to a provider or model, and do not invent names such as `ANTHROPIC_API_KEY`. Ask for secret names, not secret values, and never put secret material in the BPMN or in the conversation.
 
 If the target environment exposes configured secret names through c8ctl or an approved local configuration, prefer those names. Otherwise, use only names confirmed by the user; do not infer them from the provider name. Inspect the current element-template properties because authentication fields and the number of secrets differ by provider.
 

--- a/skills/camunda-ai-agents/SKILL.md
+++ b/skills/camunda-ai-agents/SKILL.md
@@ -34,7 +34,7 @@ Before creating or editing the BPMN, resolve these values with the user:
 
 If any of these values are missing, ask for each missing value and stop before applying the template or writing provider configuration. Do not default to a provider or model, and do not invent names such as `ANTHROPIC_API_KEY`. Ask for secret names, not secret values, and never put secret material in the BPMN or in the conversation.
 
-If the target environment exposes configured secret names through c8ctl or an approved local configuration, prefer those names. Otherwise, use only names confirmed by the user; do not infer them from the provider name. Inspect the current element-template properties because authentication fields and the number of secrets differ by provider.
+If the target environment exposes configured secret names through c8ctl or another approved names-only source, prefer those names. Otherwise, use only names confirmed by the user; never read real secret files or values (such as `.env` files or credential stores), and do not infer names from the provider. Inspect the current element-template properties because authentication fields and the number of secrets differ by provider.
 
 For Camunda 8 SaaS, connector secrets are managed in Camunda Console, not created or populated through c8ctl. Surface this constraint before deployment and ask the user to confirm that the user-provided secret names already exist in the target cluster. For local c8run, follow **camunda-c8ctl** without reading real secret values.
 

--- a/skills/camunda-ai-agents/SKILL.md
+++ b/skills/camunda-ai-agents/SKILL.md
@@ -20,7 +20,23 @@ The older **Task variant** (AI Agent connector on a service task paired with an 
 
 - Camunda 8.8+ cluster (the AI Agent connector ships in 8.8+)
 - c8ctl CLI installed and a profile configured — see **camunda-c8ctl**
-- An API key for the model provider you'll use (Anthropic, Amazon Bedrock, Azure OpenAI, Google Vertex AI, OpenAI, or any OpenAI-compatible provider). Store it as a Camunda cluster secret, never in the BPMN file. For local c8run, see **camunda-c8ctl** for the secrets bootstrap flow.
+- A user-selected model provider and exact model identifier. Supported providers include Anthropic, Amazon Bedrock, Azure OpenAI, Google Vertex AI, OpenAI, and OpenAI-compatible providers.
+- The exact name of each existing connector secret required by that provider. Store secret values as Camunda cluster secrets, never in the BPMN file. For local c8run, see **camunda-c8ctl** for the secrets bootstrap flow.
+
+### Provider and secret checkpoint
+
+Before creating or editing the BPMN, resolve these values with the user:
+
+1. The target cluster and c8ctl profile (local c8run, Self-Managed, or SaaS).
+2. The model provider.
+3. The exact model identifier.
+4. The exact existing connector-secret name or names required by that provider.
+
+If the user did not specify any of these, ask for the missing values and stop before applying the template or writing provider configuration. Do not default to a provider or model, and do not invent names such as `ANTHROPIC_API_KEY`. Ask for secret names, not secret values, and never put secret material in the BPMN or in the conversation.
+
+If the target environment exposes configured secret names through c8ctl or an approved local configuration, prefer those names. Otherwise, use only names confirmed by the user; do not infer them from the provider name. Inspect the current element-template properties because authentication fields and the number of secrets differ by provider.
+
+For Camunda 8 SaaS, connector secrets are managed in Camunda Console, not created or populated through c8ctl. Surface this constraint before deployment and ask the user to confirm that the user-provided secret names already exist in the target cluster. For local c8run, follow **camunda-c8ctl** without reading real secret values.
 
 ## Cross-References
 
@@ -54,11 +70,14 @@ c8ctl element-template search "ai agent"
 c8ctl element-template get-properties <id>
 c8ctl element-template get-properties <id> --detailed data.systemPrompt.prompt
 
-# 3. Apply to your ad-hoc subprocess element
+# 3. After the provider, model, and secret names are confirmed, apply to your
+#    ad-hoc subprocess element. Replace every angle-bracket value with the
+#    user's confirmed value; the authentication and model paths are
+#    provider-specific.
 c8ctl element-template apply -i <id> AgentTools process.bpmn \
-  --set provider.type=anthropic \
-  --set provider.anthropic.authentication.apiKey='{{secrets.ANTHROPIC_API_KEY}}' \
-  --set provider.anthropic.model.model=claude-sonnet-4-5 \
+  --set provider.type=<selected-provider> \
+  --set provider.<provider-specific-authentication-property>='{{secrets.<existing-secret-name>}}' \
+  --set provider.<provider-specific-model-property>=<selected-model> \
   --set data.systemPrompt.prompt='="You are a customer support agent. Use the available tools to look up customers and orders, and escalate to a human only when needed."' \
   --set data.userPrompt.prompt='="Customer " + customerId + " reports: " + issue' \
   --set data.limits.maxModelCalls='=10'


### PR DESCRIPTION
## Description

Require the AI Agent skill to ask for a missing provider, exact model identifier, and existing connector-secret name(s) instead of guessing. The connector example now uses user-supplied placeholders, and SaaS guidance directs users to Console-managed secrets.

Closes #99

## Checklist

- [x] `azd waza check camunda-ai-agents` passes
- [x] Updated `SKILL.md` for the required behavior
- [x] Preserved the existing eval harness and its public agent contract