### PR TITLE
feat(repo): define skills portability contract

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install compatibility checker dependencies
+        run: python3 -m pip install --disable-pip-version-check --no-input "jsonschema>=4.20"
       - name: Check portability inventory and contract
         run: python3 compatibility/check.py
       - name: Run Claude deterministic mock

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "compatibility/**"
       - "skills/**"
+      - "README.md"
       - ".github/workflows/compatibility.yml"
   workflow_dispatch:
 
@@ -20,9 +21,5 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install compatibility checker dependencies
         run: python3 -m pip install --disable-pip-version-check --no-input "jsonschema>=4.20"
-      - name: Check portability inventory and contract
-        run: python3 compatibility/check.py
-      - name: Run Claude deterministic mock
-        run: compatibility/adapters/mock-claude
-      - name: Run Copilot deterministic mock
-        run: compatibility/adapters/mock-copilot
+      - name: Run compatibility contract gate
+        run: make compatibility-check

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           enable-cache: true
       - name: Install repository Python environment
-        run: uv sync --frozen --no-dev
+        run: uv sync --frozen
+      - name: Run compatibility regression tests
+        run: uv run pytest compatibility
       - name: Run compatibility contract gate
         run: make compatibility-check

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -7,6 +7,10 @@ on:
       - "compatibility/**"
       - "skills/**"
       - "README.md"
+      - "Makefile"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".python-version"
       - ".github/workflows/compatibility.yml"
   workflow_dispatch:
 
@@ -19,7 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Install compatibility checker dependencies
-        run: python3 -m pip install --disable-pip-version-check --no-input "jsonschema>=4.20"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+      - name: Install repository Python environment
+        run: uv sync --frozen --no-dev
       - name: Run compatibility contract gate
         run: make compatibility-check

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -11,6 +11,7 @@ on:
       - "pyproject.toml"
       - "uv.lock"
       - ".python-version"
+      - ".claude-plugin/**"
       - ".github/workflows/compatibility.yml"
   workflow_dispatch:
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,26 @@
+name: Skills compatibility contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "compatibility/**"
+      - "skills/**"
+      - ".github/workflows/compatibility.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    name: Portability conformance and deterministic smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check portability inventory and contract
+        run: python3 compatibility/check.py
+      - name: Run Claude deterministic mock
+        run: compatibility/adapters/mock-claude
+      - name: Run Copilot deterministic mock
+        run: compatibility/adapters/mock-copilot

--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,11 @@ lint:
 
 .PHONY: compatibility-check
 compatibility-check:
-	@python3 compatibility/check.py
-	@compatibility/adapters/mock-claude >/dev/null
-	@compatibility/adapters/mock-copilot >/dev/null
+	@status=0; \
+	uv run --project . --no-dev python compatibility/check.py || status=$$?; \
+	compatibility/adapters/mock-claude || status=$$?; \
+	compatibility/adapters/mock-copilot || status=$$?; \
+	exit $$status
 
 .PHONY: build-docker-images
 build-docker-images:

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ help:
 	@echo "  help                 Show this help."
 	@echo "  try                  Launch an interactive Claude Code session with this repo's skills loaded (no install)."
 	@echo "  lint                 Run waza check across all skills (or one if SKILL=<name> is set)."
+	@echo "  compatibility-check  Validate portability metadata and run deterministic smoke adapters."
 	@echo ""
 	@echo "Run:"
 	@echo "  run-trigger-evals    Run trigger evals: every skill, or one with SKILL=<name>."
@@ -91,6 +92,12 @@ lint:
 	else \
 		waza check; \
 	fi
+
+.PHONY: compatibility-check
+compatibility-check:
+	@python3 compatibility/check.py
+	@compatibility/adapters/mock-claude >/dev/null
+	@compatibility/adapters/mock-copilot >/dev/null
 
 .PHONY: build-docker-images
 build-docker-images:

--- a/compatibility/adapters/bpmn_lint.py
+++ b/compatibility/adapters/bpmn_lint.py
@@ -117,8 +117,10 @@ def validate_bpmn(path: Path) -> None:
     if process.get("isExecutable") != "true":
         raise ValueError("process must be executable")
 
-    element_ids: set[str] = set()
+    element_ids: set[str] = {definitions_id}
     for element in root.iter():
+        if element is root:
+            continue
         if not isinstance(element.tag, str) or not element.tag.startswith(
             f"{{{BPMN_NAMESPACE}}}"
         ):

--- a/compatibility/adapters/bpmn_lint.py
+++ b/compatibility/adapters/bpmn_lint.py
@@ -72,7 +72,7 @@ def validate_bpmn(path: Path) -> None:
     if process.get("isExecutable") != "true":
         raise ValueError("process must be executable")
 
-    element_ids = {process_id}
+    element_ids = {root.get("id"), process_id}
     flow_nodes = []
     flows = []
     for element in process:
@@ -107,6 +107,19 @@ def validate_bpmn(path: Path) -> None:
             or flow.get("targetRef") not in flow_node_ids
         ):
             raise ValueError("sequence flow references an unknown element")
+
+    di_ids: set[str] = set()
+    for element in root.iter():
+        if not isinstance(element.tag, str) or not element.tag.startswith(
+            f"{{{BPMNDI_NAMESPACE}}}"
+        ):
+            continue
+        element_id = element.get("id")
+        if not element_id:
+            raise ValueError(f"{local_name(element.tag)} must have an id")
+        if element_id in element_ids or element_id in di_ids:
+            raise ValueError(f"duplicate BPMN DI id: {element_id}")
+        di_ids.add(element_id)
 
     diagrams = [element for element in root.iter() if element.tag == f"{{{BPMNDI_NAMESPACE}}}BPMNDiagram"]
     if len(diagrams) != 1:

--- a/compatibility/adapters/bpmn_lint.py
+++ b/compatibility/adapters/bpmn_lint.py
@@ -1,0 +1,50 @@
+"""Small deterministic BPMN validity check used by the mock c8ctl command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from xml.etree import ElementTree
+
+BPMN_NAMESPACE = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def validate_bpmn(path: Path) -> None:
+    if not path.is_file():
+        raise ValueError(f"{path} does not exist")
+
+    try:
+        root = ElementTree.parse(path).getroot()
+    except (OSError, ElementTree.ParseError) as error:
+        raise ValueError(f"{path} is not well-formed XML: {error}") from error
+
+    if root.tag != f"{{{BPMN_NAMESPACE}}}definitions":
+        raise ValueError("root element must be BPMN definitions")
+
+    processes = [element for element in root if local_name(element.tag) == "process"]
+    if len(processes) != 1:
+        raise ValueError("artifact must contain exactly one process")
+
+    process = processes[0]
+    if not process.get("id"):
+        raise ValueError("process must have an id")
+
+    element_ids = {
+        element.get("id")
+        for element in process
+        if element.get("id")
+    }
+    if not any(local_name(element.tag) == "startEvent" for element in process):
+        raise ValueError("process must contain a start event")
+    if not any(local_name(element.tag) == "endEvent" for element in process):
+        raise ValueError("process must contain an end event")
+
+    flows = [element for element in process if local_name(element.tag) == "sequenceFlow"]
+    if not flows:
+        raise ValueError("process must contain a sequence flow")
+    for flow in flows:
+        if flow.get("sourceRef") not in element_ids or flow.get("targetRef") not in element_ids:
+            raise ValueError("sequence flow references an unknown element")

--- a/compatibility/adapters/bpmn_lint.py
+++ b/compatibility/adapters/bpmn_lint.py
@@ -183,6 +183,11 @@ def validate_bpmn(path: Path) -> None:
             raise ValueError(f"incoming references on {node_id} do not match sequence flows")
         if declared_flow_refs(node, "outgoing") != outgoing_flow_ids[node_id]:
             raise ValueError(f"outgoing references on {node_id} do not match sequence flows")
+        node_name = local_name(node.tag)
+        if node_name == "startEvent" and incoming[node_id]:
+            raise ValueError(f"start event {node_id} must not have incoming sequence flows")
+        if node_name == "endEvent" and outgoing[node_id]:
+            raise ValueError(f"end event {node_id} must not have outgoing sequence flows")
 
     def reachable(
         starts: set[str | None], graph: dict[str | None, set[str | None]]

--- a/compatibility/adapters/bpmn_lint.py
+++ b/compatibility/adapters/bpmn_lint.py
@@ -6,6 +6,22 @@ from pathlib import Path
 from xml.etree import ElementTree
 
 BPMN_NAMESPACE = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+BPMNDI_NAMESPACE = "http://www.omg.org/spec/BPMN/20100524/DI"
+DC_NAMESPACE = "http://www.omg.org/spec/DD/20100524/DC"
+DI_NAMESPACE = "http://www.omg.org/spec/DD/20100524/DI"
+XSI_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
+ZEEBE_NAMESPACE = "http://camunda.org/schema/zeebe/1.0"
+MODELER_NAMESPACE = "http://camunda.org/schema/modeler/1.0"
+
+REQUIRED_NAMESPACES = {
+    "bpmn": BPMN_NAMESPACE,
+    "bpmndi": BPMNDI_NAMESPACE,
+    "dc": DC_NAMESPACE,
+    "di": DI_NAMESPACE,
+    "xsi": XSI_NAMESPACE,
+    "zeebe": ZEEBE_NAMESPACE,
+    "modeler": MODELER_NAMESPACE,
+}
 
 
 def local_name(tag: str) -> str:
@@ -17,34 +33,106 @@ def validate_bpmn(path: Path) -> None:
         raise ValueError(f"{path} does not exist")
 
     try:
-        root = ElementTree.parse(path).getroot()
+        root = None
+        namespaces: dict[str, str] = {}
+        for event, value in ElementTree.iterparse(path, events=("start", "start-ns")):
+            if event == "start-ns":
+                prefix, uri = value
+                namespaces[prefix or ""] = uri
+            elif root is None:
+                root = value
     except (OSError, ElementTree.ParseError) as error:
         raise ValueError(f"{path} is not well-formed XML: {error}") from error
 
-    if root.tag != f"{{{BPMN_NAMESPACE}}}definitions":
+    if root is None or root.tag != f"{{{BPMN_NAMESPACE}}}definitions":
         raise ValueError("root element must be BPMN definitions")
 
-    processes = [element for element in root if local_name(element.tag) == "process"]
+    for prefix, uri in REQUIRED_NAMESPACES.items():
+        if namespaces.get(prefix) != uri:
+            raise ValueError(f"namespace {prefix!r} must be declared as {uri!r}")
+
+    if not root.get("id"):
+        raise ValueError("definitions must have an id")
+    if not root.get("targetNamespace"):
+        raise ValueError("definitions must have a targetNamespace")
+    modeler_prefix = f"{{{MODELER_NAMESPACE}}}"
+    if root.get(f"{modeler_prefix}executionPlatform") != "Camunda Cloud":
+        raise ValueError("definitions must declare Camunda Cloud as the execution platform")
+    if not root.get(f"{modeler_prefix}executionPlatformVersion"):
+        raise ValueError("definitions must declare an execution platform version")
+
+    processes = [element for element in root if element.tag == f"{{{BPMN_NAMESPACE}}}process"]
     if len(processes) != 1:
         raise ValueError("artifact must contain exactly one process")
 
     process = processes[0]
-    if not process.get("id"):
+    process_id = process.get("id")
+    if not process_id:
         raise ValueError("process must have an id")
+    if process.get("isExecutable") != "true":
+        raise ValueError("process must be executable")
 
-    element_ids = {
-        element.get("id")
-        for element in process
-        if element.get("id")
-    }
-    if not any(local_name(element.tag) == "startEvent" for element in process):
+    element_ids = {process_id}
+    flow_nodes = []
+    flows = []
+    for element in process:
+        if not isinstance(element.tag, str):
+            continue
+        element_id = element.get("id")
+        if not element_id:
+            if local_name(element.tag) in {"extensionElements", "laneSet"}:
+                continue
+            raise ValueError(f"{local_name(element.tag)} must have an id")
+        if element_id in element_ids:
+            raise ValueError(f"duplicate BPMN id: {element_id}")
+        element_ids.add(element_id)
+        if local_name(element.tag) == "sequenceFlow":
+            flows.append(element)
+        else:
+            if not element.get("name"):
+                raise ValueError(f"{local_name(element.tag)} must have a name")
+            flow_nodes.append(element)
+
+    if not any(local_name(element.tag) == "startEvent" for element in flow_nodes):
         raise ValueError("process must contain a start event")
-    if not any(local_name(element.tag) == "endEvent" for element in process):
+    if not any(local_name(element.tag) == "endEvent" for element in flow_nodes):
         raise ValueError("process must contain an end event")
 
-    flows = [element for element in process if local_name(element.tag) == "sequenceFlow"]
     if not flows:
         raise ValueError("process must contain a sequence flow")
     for flow in flows:
         if flow.get("sourceRef") not in element_ids or flow.get("targetRef") not in element_ids:
             raise ValueError("sequence flow references an unknown element")
+
+    diagrams = [element for element in root.iter() if element.tag == f"{{{BPMNDI_NAMESPACE}}}BPMNDiagram"]
+    if len(diagrams) != 1:
+        raise ValueError("artifact must contain exactly one BPMN diagram")
+    planes = [element for element in diagrams[0] if element.tag == f"{{{BPMNDI_NAMESPACE}}}BPMNPlane"]
+    if len(planes) != 1 or planes[0].get("bpmnElement") != process_id:
+        raise ValueError("BPMN diagram must contain one plane for the process")
+
+    shapes = [
+        element
+        for element in planes[0]
+        if element.tag == f"{{{BPMNDI_NAMESPACE}}}BPMNShape"
+    ]
+    shape_refs = [shape.get("bpmnElement") for shape in shapes]
+    node_ids = {element.get("id") for element in flow_nodes}
+    if None in shape_refs or len(shape_refs) != len(set(shape_refs)) or set(shape_refs) != node_ids:
+        raise ValueError("BPMN diagram shapes must map one-to-one to process flow nodes")
+    for shape in shapes:
+        if not any(child.tag == f"{{{DC_NAMESPACE}}}Bounds" for child in shape):
+            raise ValueError("every BPMN shape must have bounds")
+
+    edges = [
+        element
+        for element in planes[0]
+        if element.tag == f"{{{BPMNDI_NAMESPACE}}}BPMNEdge"
+    ]
+    edge_refs = [edge.get("bpmnElement") for edge in edges]
+    flow_ids = {flow.get("id") for flow in flows}
+    if None in edge_refs or len(edge_refs) != len(set(edge_refs)) or set(edge_refs) != flow_ids:
+        raise ValueError("BPMN diagram edges must map one-to-one to sequence flows")
+    for edge in edges:
+        if sum(child.tag == f"{{{DI_NAMESPACE}}}waypoint" for child in edge) < 2:
+            raise ValueError("every BPMN edge must have at least two waypoints")

--- a/compatibility/adapters/bpmn_lint.py
+++ b/compatibility/adapters/bpmn_lint.py
@@ -34,11 +34,11 @@ def validate_bpmn(path: Path) -> None:
 
     try:
         root = None
-        namespaces: dict[str, str] = {}
+        namespace_uris: set[str] = set()
         for event, value in ElementTree.iterparse(path, events=("start", "start-ns")):
             if event == "start-ns":
-                prefix, uri = value
-                namespaces[prefix or ""] = uri
+                _, uri = value
+                namespace_uris.add(uri)
             elif root is None:
                 root = value
     except (OSError, ElementTree.ParseError) as error:
@@ -47,9 +47,9 @@ def validate_bpmn(path: Path) -> None:
     if root is None or root.tag != f"{{{BPMN_NAMESPACE}}}definitions":
         raise ValueError("root element must be BPMN definitions")
 
-    for prefix, uri in REQUIRED_NAMESPACES.items():
-        if namespaces.get(prefix) != uri:
-            raise ValueError(f"namespace {prefix!r} must be declared as {uri!r}")
+    for uri in REQUIRED_NAMESPACES.values():
+        if uri not in namespace_uris:
+            raise ValueError(f"required namespace URI {uri!r} is not declared")
 
     definitions_id = root.get("id")
     if not definitions_id:
@@ -75,7 +75,18 @@ def validate_bpmn(path: Path) -> None:
     if process.get("isExecutable") != "true":
         raise ValueError("process must be executable")
 
-    element_ids = {definitions_id, process_id}
+    element_ids: set[str] = set()
+    for element in root.iter():
+        if not isinstance(element.tag, str) or not element.tag.startswith(
+            f"{{{BPMN_NAMESPACE}}}"
+        ):
+            continue
+        element_id = element.get("id")
+        if element_id:
+            if element_id in element_ids:
+                raise ValueError(f"duplicate BPMN id: {element_id}")
+            element_ids.add(element_id)
+
     flow_nodes = []
     flows = []
     for element in process:
@@ -86,9 +97,6 @@ def validate_bpmn(path: Path) -> None:
             if local_name(element.tag) in {"extensionElements", "laneSet"}:
                 continue
             raise ValueError(f"{local_name(element.tag)} must have an id")
-        if element_id in element_ids:
-            raise ValueError(f"duplicate BPMN id: {element_id}")
-        element_ids.add(element_id)
         if local_name(element.tag) == "sequenceFlow":
             flows.append(element)
         else:

--- a/compatibility/adapters/bpmn_lint.py
+++ b/compatibility/adapters/bpmn_lint.py
@@ -104,12 +104,43 @@ def validate_bpmn(path: Path) -> None:
     if not flows:
         raise ValueError("process must contain a sequence flow")
     flow_node_ids = {node.get("id") for node in flow_nodes}
+    outgoing = {node_id: set() for node_id in flow_node_ids}
+    incoming = {node_id: set() for node_id in flow_node_ids}
     for flow in flows:
+        source = flow.get("sourceRef")
+        target = flow.get("targetRef")
         if (
-            flow.get("sourceRef") not in flow_node_ids
-            or flow.get("targetRef") not in flow_node_ids
+            source not in flow_node_ids
+            or target not in flow_node_ids
         ):
             raise ValueError("sequence flow references an unknown element")
+        outgoing[source].add(target)
+        incoming[target].add(source)
+
+    def reachable(
+        starts: set[str | None], graph: dict[str | None, set[str | None]]
+    ) -> set[str | None]:
+        reached = set(starts)
+        pending = list(starts)
+        while pending:
+            current = pending.pop()
+            for neighbor in graph[current]:
+                if neighbor not in reached:
+                    reached.add(neighbor)
+                    pending.append(neighbor)
+        return reached
+
+    start_ids = {
+        node.get("id") for node in flow_nodes if local_name(node.tag) == "startEvent"
+    }
+    end_ids = {
+        node.get("id") for node in flow_nodes if local_name(node.tag) == "endEvent"
+    }
+    reachable_from_start = reachable(start_ids, outgoing)
+    can_reach_end = reachable(end_ids, incoming)
+    disconnected = (flow_node_ids - reachable_from_start) | (flow_node_ids - can_reach_end)
+    if disconnected:
+        raise ValueError("all flow nodes must be on a complete start-to-end path")
 
     di_ids: set[str] = set()
     for element in root.iter():

--- a/compatibility/adapters/bpmn_lint.py
+++ b/compatibility/adapters/bpmn_lint.py
@@ -100,8 +100,12 @@ def validate_bpmn(path: Path) -> None:
 
     if not flows:
         raise ValueError("process must contain a sequence flow")
+    flow_node_ids = {node.get("id") for node in flow_nodes}
     for flow in flows:
-        if flow.get("sourceRef") not in element_ids or flow.get("targetRef") not in element_ids:
+        if (
+            flow.get("sourceRef") not in flow_node_ids
+            or flow.get("targetRef") not in flow_node_ids
+        ):
             raise ValueError("sequence flow references an unknown element")
 
     diagrams = [element for element in root.iter() if element.tag == f"{{{BPMNDI_NAMESPACE}}}BPMNDiagram"]

--- a/compatibility/adapters/bpmn_lint.py
+++ b/compatibility/adapters/bpmn_lint.py
@@ -24,7 +24,6 @@ REQUIRED_NAMESPACES = {
 }
 SUPPORTED_FLOW_NODE_TYPES = frozenset(
     {
-        "adHocSubProcess",
         "boundaryEvent",
         "businessRuleTask",
         "callActivity",
@@ -42,9 +41,7 @@ SUPPORTED_FLOW_NODE_TYPES = frozenset(
         "sendTask",
         "serviceTask",
         "startEvent",
-        "subProcess",
         "task",
-        "transaction",
         "userTask",
     }
 )
@@ -152,8 +149,6 @@ def validate_bpmn(path: Path) -> None:
         if element_name == "sequenceFlow":
             flows.append(element)
         else:
-            if not element.get("name"):
-                raise ValueError(f"{element_name} must have a name")
             flow_nodes.append(element)
 
     if not any(local_name(element.tag) == "startEvent" for element in flow_nodes):

--- a/compatibility/adapters/bpmn_lint.py
+++ b/compatibility/adapters/bpmn_lint.py
@@ -51,7 +51,8 @@ def validate_bpmn(path: Path) -> None:
         if namespaces.get(prefix) != uri:
             raise ValueError(f"namespace {prefix!r} must be declared as {uri!r}")
 
-    if not root.get("id"):
+    definitions_id = root.get("id")
+    if not definitions_id:
         raise ValueError("definitions must have an id")
     if not root.get("targetNamespace"):
         raise ValueError("definitions must have a targetNamespace")
@@ -69,10 +70,12 @@ def validate_bpmn(path: Path) -> None:
     process_id = process.get("id")
     if not process_id:
         raise ValueError("process must have an id")
+    if process_id == definitions_id:
+        raise ValueError(f"duplicate BPMN id: {process_id}")
     if process.get("isExecutable") != "true":
         raise ValueError("process must be executable")
 
-    element_ids = {root.get("id"), process_id}
+    element_ids = {definitions_id, process_id}
     flow_nodes = []
     flows = []
     for element in process:

--- a/compatibility/adapters/bpmn_lint.py
+++ b/compatibility/adapters/bpmn_lint.py
@@ -22,10 +22,52 @@ REQUIRED_NAMESPACES = {
     "zeebe": ZEEBE_NAMESPACE,
     "modeler": MODELER_NAMESPACE,
 }
+SUPPORTED_FLOW_NODE_TYPES = frozenset(
+    {
+        "adHocSubProcess",
+        "boundaryEvent",
+        "businessRuleTask",
+        "callActivity",
+        "complexGateway",
+        "endEvent",
+        "eventBasedGateway",
+        "exclusiveGateway",
+        "inclusiveGateway",
+        "intermediateCatchEvent",
+        "intermediateThrowEvent",
+        "manualTask",
+        "parallelGateway",
+        "receiveTask",
+        "scriptTask",
+        "sendTask",
+        "serviceTask",
+        "startEvent",
+        "subProcess",
+        "task",
+        "transaction",
+        "userTask",
+    }
+)
+NON_FLOW_PROCESS_ELEMENTS = frozenset({"extensionElements", "laneSet"})
 
 
 def local_name(tag: str) -> str:
     return tag.rsplit("}", 1)[-1]
+
+
+def declared_flow_refs(node: ElementTree.Element, direction: str) -> set[str]:
+    reference_tag = f"{{{BPMN_NAMESPACE}}}{direction}"
+    references = []
+    for child in node:
+        if child.tag != reference_tag:
+            continue
+        reference = (child.text or "").strip()
+        if not reference:
+            raise ValueError(f"{direction} reference on {node.get('id')} must not be empty")
+        references.append(reference)
+    if len(references) != len(set(references)):
+        raise ValueError(f"{direction} references on {node.get('id')} must be unique")
+    return set(references)
 
 
 def validate_bpmn(path: Path) -> None:
@@ -92,16 +134,24 @@ def validate_bpmn(path: Path) -> None:
     for element in process:
         if not isinstance(element.tag, str):
             continue
+        element_name = local_name(element.tag)
+        if (
+            not element.tag.startswith(f"{{{BPMN_NAMESPACE}}}")
+            or element_name not in SUPPORTED_FLOW_NODE_TYPES
+            | {"sequenceFlow"}
+            | NON_FLOW_PROCESS_ELEMENTS
+        ):
+            raise ValueError(f"unsupported process element: {element_name}")
+        if element_name in NON_FLOW_PROCESS_ELEMENTS:
+            continue
         element_id = element.get("id")
         if not element_id:
-            if local_name(element.tag) in {"extensionElements", "laneSet"}:
-                continue
-            raise ValueError(f"{local_name(element.tag)} must have an id")
-        if local_name(element.tag) == "sequenceFlow":
+            raise ValueError(f"{element_name} must have an id")
+        if element_name == "sequenceFlow":
             flows.append(element)
         else:
             if not element.get("name"):
-                raise ValueError(f"{local_name(element.tag)} must have a name")
+                raise ValueError(f"{element_name} must have a name")
             flow_nodes.append(element)
 
     if not any(local_name(element.tag) == "startEvent" for element in flow_nodes):
@@ -114,7 +164,10 @@ def validate_bpmn(path: Path) -> None:
     flow_node_ids = {node.get("id") for node in flow_nodes}
     outgoing = {node_id: set() for node_id in flow_node_ids}
     incoming = {node_id: set() for node_id in flow_node_ids}
+    outgoing_flow_ids = {node_id: set() for node_id in flow_node_ids}
+    incoming_flow_ids = {node_id: set() for node_id in flow_node_ids}
     for flow in flows:
+        flow_id = flow.get("id")
         source = flow.get("sourceRef")
         target = flow.get("targetRef")
         if (
@@ -122,8 +175,17 @@ def validate_bpmn(path: Path) -> None:
             or target not in flow_node_ids
         ):
             raise ValueError("sequence flow references an unknown element")
+        outgoing_flow_ids[source].add(flow_id)
+        incoming_flow_ids[target].add(flow_id)
         outgoing[source].add(target)
         incoming[target].add(source)
+
+    for node in flow_nodes:
+        node_id = node.get("id")
+        if declared_flow_refs(node, "incoming") != incoming_flow_ids[node_id]:
+            raise ValueError(f"incoming references on {node_id} do not match sequence flows")
+        if declared_flow_refs(node, "outgoing") != outgoing_flow_ids[node_id]:
+            raise ValueError(f"outgoing references on {node_id} do not match sequence flows")
 
     def reachable(
         starts: set[str | None], graph: dict[str | None, set[str | None]]

--- a/compatibility/adapters/c8ctl
+++ b/compatibility/adapters/c8ctl
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Deterministic local c8ctl shim for the credential-free smoke adapters."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from bpmn_lint import validate_bpmn
+
+
+def main() -> int:
+    if sys.argv[1:] != ["bpmn", "lint", "process.bpmn"]:
+        print("unsupported deterministic c8ctl command", file=sys.stderr)
+        return 2
+    try:
+        validate_bpmn(Path.cwd() / "process.bpmn")
+    except ValueError as error:
+        print(f"c8ctl bpmn lint failed: {error}", file=sys.stderr)
+        return 1
+    print("c8ctl bpmn lint process.bpmn: passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/compatibility/adapters/mock-claude
+++ b/compatibility/adapters/mock-claude
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+exec python3 "$(dirname "$0")/mock_adapter.py" --harness claude "$@"

--- a/compatibility/adapters/mock-claude
+++ b/compatibility/adapters/mock-claude
@@ -1,3 +1,5 @@
 #!/bin/sh
 set -eu
-exec python3 "$(dirname "$0")/mock_adapter.py" --harness claude "$@"
+script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+project_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+exec uv run --project "$project_root" --no-dev python "$script_dir/mock_adapter.py" --harness claude "$@"

--- a/compatibility/adapters/mock-copilot
+++ b/compatibility/adapters/mock-copilot
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+exec python3 "$(dirname "$0")/mock_adapter.py" --harness copilot "$@"

--- a/compatibility/adapters/mock-copilot
+++ b/compatibility/adapters/mock-copilot
@@ -1,3 +1,5 @@
 #!/bin/sh
 set -eu
-exec python3 "$(dirname "$0")/mock_adapter.py" --harness copilot "$@"
+script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+project_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+exec uv run --project "$project_root" --no-dev python "$script_dir/mock_adapter.py" --harness copilot "$@"

--- a/compatibility/adapters/mock_adapter.py
+++ b/compatibility/adapters/mock_adapter.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Run one credential-free deterministic harness smoke adapter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from bpmn_lint import validate_bpmn
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harness", choices=("claude", "copilot"), required=True)
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[2]
+    contract = load_json(root / "compatibility" / "harness-smoke-contract.json")
+    fixture = load_json(root / "compatibility" / "fixtures" / "camunda-bpmn-smoke.json")
+    assertions = contract["resultAssertions"]
+    expected = fixture["expected"]
+    failures: list[str] = []
+
+    required_entrypoint = root / contract["discovery"]["requiredEntrypoint"]
+    discovered = required_entrypoint.is_file()
+    activated = discovered and fixture["skillName"] == "camunda-bpmn" and bool(fixture["prompt"])
+    if not discovered:
+        failures.append(f"missing skill entrypoint: {required_entrypoint}")
+    if not activated:
+        failures.append("fixture did not activate camunda-bpmn")
+
+    artifact_name = assertions["artifact"]["path"]
+    command = assertions["toolCall"]["command"]
+    command_tokens = shlex.split(command)
+    expected_tokens = ["c8ctl", "bpmn", "lint", artifact_name]
+    if command_tokens != expected_tokens:
+        failures.append(f"unexpected tool command: {command!r}")
+
+    artifact_exists = False
+    artifact_valid = False
+    tool_executed = False
+    tool_succeeded = False
+    exit_code: int | None = None
+    tool_error: str | None = None
+
+    with tempfile.TemporaryDirectory(prefix="camunda-skills-smoke-") as directory:
+        artifact_path = Path(directory) / artifact_name
+        source_path = root / expected["artifactSource"]
+        if not source_path.is_file():
+            failures.append(f"missing smoke artifact source: {source_path}")
+        else:
+            shutil.copyfile(source_path, artifact_path)
+
+        artifact_exists = artifact_path.is_file()
+        if not artifact_exists:
+            failures.append(f"adapter did not emit {artifact_name}")
+        else:
+            try:
+                validate_bpmn(artifact_path)
+            except ValueError as error:
+                failures.append(f"invalid emitted artifact: {error}")
+            else:
+                artifact_valid = True
+
+        if command_tokens == expected_tokens and artifact_exists:
+            environment = os.environ.copy()
+            adapter_directory = str(Path(__file__).resolve().parent)
+            environment["PATH"] = adapter_directory + os.pathsep + environment.get("PATH", "")
+            try:
+                completed = subprocess.run(
+                    command_tokens,
+                    cwd=directory,
+                    env=environment,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            except (OSError, subprocess.TimeoutExpired) as error:
+                tool_error = str(error)
+            else:
+                tool_executed = True
+                exit_code = completed.returncode
+                tool_succeeded = completed.returncode == 0
+                if not tool_succeeded:
+                    failures.append(
+                        f"{command} failed with exit code {completed.returncode}: "
+                        f"{completed.stderr.strip()}"
+                    )
+        else:
+            tool_error = "tool command was not run because its prerequisites failed"
+
+    result = {
+        "adapter": args.harness,
+        "fixtureId": fixture["fixtureId"],
+        "discovered": discovered,
+        "activated": activated,
+        "artifact": {
+            "path": artifact_name,
+            "exists": artifact_exists,
+            "valid": artifact_valid,
+        },
+        "toolCall": {
+            "command": command,
+            "executed": tool_executed,
+            "succeeded": tool_succeeded,
+            "exitCode": exit_code,
+        },
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+    if expected["artifactExists"] and not artifact_exists:
+        failures.append("fixture requires the artifact to exist")
+    if expected["artifactValid"] and not artifact_valid:
+        failures.append("fixture requires a valid BPMN artifact")
+    if expected["toolExecuted"] and not tool_executed:
+        failures.append(f"tool command was not executed: {tool_error or 'unknown error'}")
+    if expected["toolSucceeded"] and not tool_succeeded:
+        failures.append("tool command did not succeed")
+
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/compatibility/adapters/mock_adapter.py
+++ b/compatibility/adapters/mock_adapter.py
@@ -61,7 +61,7 @@ def activate_skill(
 
     if not isinstance(prompt, str) or not prompt.strip():
         failures.append("activation prompt must be non-empty")
-    if not isinstance(tool_command, str) or "c8ctl bpmn lint" not in content:
+    if not isinstance(tool_command, str) or tool_command not in content:
         failures.append("skill entrypoint does not declare the required BPMN lint command")
     return not failures, failures
 
@@ -104,6 +104,7 @@ def main() -> int:
     tool_succeeded = False
     exit_code: int | None = None
     tool_error: str | None = None
+    tool_output: str | None = None
 
     with tempfile.TemporaryDirectory(prefix="camunda-skills-smoke-") as directory:
         artifact_path = Path(directory) / artifact_name
@@ -143,11 +144,20 @@ def main() -> int:
             else:
                 tool_executed = True
                 exit_code = completed.returncode
-                tool_succeeded = completed.returncode == 0
-                if not tool_succeeded:
+                tool_output = completed.stdout.strip()
+                tool_succeeded = (
+                    completed.returncode == 0
+                    and tool_output == f"{command}: passed"
+                )
+                if completed.returncode != 0:
                     failures.append(
                         f"{command} failed with exit code {completed.returncode}: "
                         f"{completed.stderr.strip()}"
+                    )
+                elif not tool_succeeded:
+                    failures.append(
+                        f"{command} did not report the expected success output: "
+                        f"{tool_output!r}"
                     )
         else:
             tool_error = "tool command was not run because its prerequisites failed"
@@ -167,6 +177,7 @@ def main() -> int:
             "executed": tool_executed,
             "succeeded": tool_succeeded,
             "exitCode": exit_code,
+            "output": tool_output,
         },
     }
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/compatibility/adapters/mock_adapter.py
+++ b/compatibility/adapters/mock_adapter.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -14,11 +15,55 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from bpmn_lint import validate_bpmn
+
+SKILL_FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---(?:\s|$)", re.DOTALL)
 
 
 def load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def activate_skill(
+    entrypoint: Path,
+    skill_name: Any,
+    prompt: Any,
+    tool_command: Any,
+) -> tuple[bool, list[str]]:
+    failures: list[str] = []
+    if not entrypoint.is_file():
+        return False, [f"missing skill entrypoint: {entrypoint}"]
+
+    try:
+        content = entrypoint.read_text(encoding="utf-8")
+    except OSError as error:
+        return False, [f"cannot read skill entrypoint: {error}"]
+
+    frontmatter = SKILL_FRONTMATTER.match(content)
+    if not frontmatter:
+        failures.append(f"skill entrypoint has no YAML frontmatter: {entrypoint}")
+    else:
+        try:
+            metadata = yaml.safe_load(frontmatter.group(1))
+        except yaml.YAMLError as error:
+            failures.append(f"skill entrypoint has invalid YAML frontmatter: {error}")
+        else:
+            if not isinstance(metadata, dict):
+                failures.append("skill entrypoint frontmatter must be a YAML object")
+            else:
+                if metadata.get("name") != skill_name:
+                    failures.append("skill entrypoint name does not match the fixture")
+                description = metadata.get("description")
+                if not isinstance(description, str) or not description.strip():
+                    failures.append("skill entrypoint description must be non-empty")
+
+    if not isinstance(prompt, str) or not prompt.strip():
+        failures.append("activation prompt must be non-empty")
+    if not isinstance(tool_command, str) or "c8ctl bpmn lint" not in content:
+        failures.append("skill entrypoint does not declare the required BPMN lint command")
+    return not failures, failures
 
 
 def main() -> int:
@@ -33,17 +78,22 @@ def main() -> int:
     expected = fixture["expected"]
     failures: list[str] = []
 
-    required_entrypoint = root / contract["discovery"]["requiredEntrypoint"]
-    discovered = required_entrypoint.is_file()
-    activated = discovered and fixture["skillName"] == "camunda-bpmn" and bool(fixture["prompt"])
-    if not discovered:
-        failures.append(f"missing skill entrypoint: {required_entrypoint}")
-    if not activated:
-        failures.append("fixture did not activate camunda-bpmn")
-
     artifact_name = assertions["artifact"]["path"]
     command = assertions["toolCall"]["command"]
     command_tokens = shlex.split(command)
+
+    required_entrypoint = root / contract["discovery"]["requiredEntrypoint"]
+    discovered = required_entrypoint.is_file()
+    activated, activation_failures = activate_skill(
+        required_entrypoint,
+        fixture["skillName"],
+        fixture["prompt"],
+        command,
+    )
+    failures.extend(activation_failures)
+    if not activated:
+        failures.append("fixture did not activate camunda-bpmn")
+
     expected_tokens = ["c8ctl", "bpmn", "lint", artifact_name]
     if command_tokens != expected_tokens:
         failures.append(f"unexpected tool command: {command!r}")

--- a/compatibility/audit.json
+++ b/compatibility/audit.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "./audit.schema.json",
+  "schemaVersion": 1,
+  "specUrl": "https://agentskills.io/specification",
+  "specRevisionOrAuditDate": "2026-09-11",
+  "auditDate": "2026-09-11",
+  "skills": [
+    {
+      "name": "camunda-ai-agents",
+      "skillDirectory": "skills/camunda-ai-agents",
+      "sidecar": "skills/camunda-ai-agents/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-bpmn",
+      "skillDirectory": "skills/camunda-bpmn",
+      "sidecar": "skills/camunda-bpmn/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-c8ctl",
+      "skillDirectory": "skills/camunda-c8ctl",
+      "sidecar": "skills/camunda-c8ctl/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-connectors",
+      "skillDirectory": "skills/camunda-connectors",
+      "sidecar": "skills/camunda-connectors/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-connectors-development",
+      "skillDirectory": "skills/camunda-connectors-development",
+      "sidecar": "skills/camunda-connectors-development/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-development",
+      "skillDirectory": "skills/camunda-development",
+      "sidecar": "skills/camunda-development/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-dmn",
+      "skillDirectory": "skills/camunda-dmn",
+      "sidecar": "skills/camunda-dmn/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-docs",
+      "skillDirectory": "skills/camunda-docs",
+      "sidecar": "skills/camunda-docs/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-feel",
+      "skillDirectory": "skills/camunda-feel",
+      "sidecar": "skills/camunda-feel/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-forms",
+      "skillDirectory": "skills/camunda-forms",
+      "sidecar": "skills/camunda-forms/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-job-workers",
+      "skillDirectory": "skills/camunda-job-workers",
+      "sidecar": "skills/camunda-job-workers/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-process-mgmt",
+      "skillDirectory": "skills/camunda-process-mgmt",
+      "sidecar": "skills/camunda-process-mgmt/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-process-test",
+      "skillDirectory": "skills/camunda-process-test",
+      "sidecar": "skills/camunda-process-test/portability.json",
+      "status": "portable-with-adapter"
+    }
+  ]
+}

--- a/compatibility/audit.schema.json
+++ b/compatibility/audit.schema.json
@@ -51,6 +51,7 @@
       "properties": {
         "name": {
           "type": "string",
+          "maxLength": 64,
           "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
         },
         "skillDirectory": {

--- a/compatibility/audit.schema.json
+++ b/compatibility/audit.schema.json
@@ -52,14 +52,26 @@
         "name": {
           "type": "string",
           "maxLength": 64,
+          "not": {
+            "enum": ["anthropic", "claude"]
+          },
           "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
         },
         "skillDirectory": {
           "type": "string",
+          "not": {
+            "enum": ["skills/anthropic", "skills/claude"]
+          },
           "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*$"
         },
         "sidecar": {
           "type": "string",
+          "not": {
+            "enum": [
+              "skills/anthropic/portability.json",
+              "skills/claude/portability.json"
+            ]
+          },
           "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*/portability\\.json$"
         },
         "status": {

--- a/compatibility/audit.schema.json
+++ b/compatibility/audit.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/camunda/skills/compatibility/audit.schema.json",
+  "title": "Camunda skills portability audit",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "specUrl",
+    "specRevisionOrAuditDate",
+    "auditDate",
+    "skills"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "./audit.schema.json"
+    },
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "specUrl": {
+      "type": "string",
+      "format": "uri",
+      "const": "https://agentskills.io/specification"
+    },
+    "specRevisionOrAuditDate": {
+      "type": "string",
+      "minLength": 1
+    },
+    "auditDate": {
+      "type": "string",
+      "format": "date"
+    },
+    "skills": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/auditEntry"
+      }
+    }
+  },
+  "$defs": {
+    "auditEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "skillDirectory", "sidecar", "status"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "skillDirectory": {
+          "type": "string",
+          "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "sidecar": {
+          "type": "string",
+          "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*/portability\\.json$"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["portable", "portable-with-adapter", "harness-specific"]
+        }
+      }
+    }
+  }
+}

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -20,6 +20,7 @@ PORTABILITY_SCHEMA_URL = (
     "compatibility/portability.schema.json"
 )
 SKILL_NAME = re.compile(r"(?=.{1,64}\Z)[a-z0-9]+(?:-[a-z0-9]+)*\Z")
+RESERVED_SKILL_NAMES = frozenset({"anthropic", "claude"})
 DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 GENERIC_DIFFERENCE = "Tool names, model configuration, and credential setup can vary by harness."
 OPTIONAL_FRONTMATTER_KEYS = {"license", "compatibility", "metadata", "allowed-tools"}
@@ -87,6 +88,14 @@ def non_empty_strings(value: Any, label: str, errors: list[str]) -> None:
         errors.append(f"{label}: expected a non-empty list of strings")
 
 
+def is_valid_skill_name(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and SKILL_NAME.fullmatch(value) is not None
+        and value not in RESERVED_SKILL_NAMES
+    )
+
+
 def status(value: Any, label: str, errors: list[str]) -> None:
     if not isinstance(value, str) or value not in {
         "portable",
@@ -118,10 +127,8 @@ def check_sidecar(sidecar: Any, label: str, spec_date: Any, errors: list[str]) -
     )
     if not isinstance(sidecar["skillDirectory"], str):
         errors.append(f"{label}.skillDirectory: expected a string")
-    if not isinstance(sidecar["skillName"], str) or not SKILL_NAME.fullmatch(
-        sidecar["skillName"]
-    ):
-        errors.append(f"{label}.skillName: invalid skill name")
+    if not is_valid_skill_name(sidecar["skillName"]):
+        errors.append(f"{label}.skillName: invalid or reserved skill name")
     status(sidecar["status"], f"{label}.status", errors)
 
     specification = sidecar["agentSkillsSpec"]
@@ -158,6 +165,11 @@ def check_sidecar(sidecar: Any, label: str, spec_date: Any, errors: list[str]) -
                 }:
                     errors.append(f"{harness_label}.status: invalid harness status")
                 non_empty_strings(declaration["differences"], f"{harness_label}.differences", errors)
+        harness_statuses = {
+            declaration.get("status")
+            for declaration in harnesses.values()
+            if isinstance(declaration, dict)
+        }
         if sidecar["status"] == "portable":
             non_native = [
                 harness_name
@@ -170,6 +182,22 @@ def check_sidecar(sidecar: Any, label: str, spec_date: Any, errors: list[str]) -
                     f"{label}.status: portable requires native harness declarations; "
                     f"non-native={sorted(non_native)}"
                 )
+        elif (
+            sidecar["status"] == "portable-with-adapter"
+            and "adapter-required" not in harness_statuses
+        ):
+            errors.append(
+                f"{label}.status: portable-with-adapter requires an "
+                "adapter-required harness declaration"
+            )
+        elif (
+            sidecar["status"] == "harness-specific"
+            and "unsupported" not in harness_statuses
+        ):
+            errors.append(
+                f"{label}.status: harness-specific requires an "
+                "unsupported harness declaration"
+            )
 
     non_empty_strings(sidecar["limitations"], f"{label}.limitations", errors)
     non_empty_strings(sidecar["differences"], f"{label}.differences", errors)
@@ -214,8 +242,8 @@ def check_skill_frontmatter(path: Path, name: str, errors: list[str]) -> None:
         )
 
     frontmatter_name = metadata.get("name")
-    if not isinstance(frontmatter_name, str) or not SKILL_NAME.fullmatch(frontmatter_name):
-        errors.append(f"{path}: frontmatter name is invalid")
+    if not is_valid_skill_name(frontmatter_name):
+        errors.append(f"{path}: frontmatter name is invalid or reserved")
     elif frontmatter_name != name:
         errors.append(f"{path}: frontmatter name must be {name!r}")
 
@@ -285,8 +313,8 @@ def check_index(index: Any, errors: list[str]) -> list[dict[str, Any]]:
         if not has_keys(entry, entry_keys, entry_label, errors):
             continue
         name = entry["name"]
-        if not isinstance(name, str) or not SKILL_NAME.fullmatch(name):
-            errors.append(f"{entry_label}.name: invalid skill name")
+        if not is_valid_skill_name(name):
+            errors.append(f"{entry_label}.name: invalid or reserved skill name")
             continue
         if name in names:
             errors.append(f"{entry_label}.name: duplicate skill name {name!r}")
@@ -334,8 +362,8 @@ def check_audit(audit: Any, errors: list[str]) -> list[dict[str, Any]]:
         if not has_keys(entry, entry_keys, entry_label, errors):
             continue
         name = entry["name"]
-        if not isinstance(name, str) or not SKILL_NAME.fullmatch(name):
-            errors.append(f"{entry_label}.name: invalid skill name")
+        if not is_valid_skill_name(name):
+            errors.append(f"{entry_label}.name: invalid or reserved skill name")
             continue
         if name in names:
             errors.append(f"{entry_label}.name: duplicate skill name {name!r}")

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -10,9 +10,13 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema.exceptions import SchemaError
+
 SPEC_URL = "https://agentskills.io/specification"
 SKILL_NAME = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+GENERIC_DIFFERENCE = "Tool names, model configuration, and credential setup can vary by harness."
 
 
 def load_json(path: Path, errors: list[str]) -> Any:
@@ -24,6 +28,27 @@ def load_json(path: Path, errors: list[str]) -> Any:
     except (OSError, json.JSONDecodeError) as error:
         errors.append(f"{path}: invalid JSON ({error})")
         return None
+
+
+def validate_schema(document: Any, schema: Any, label: str, errors: list[str]) -> None:
+    if document is None or schema is None:
+        return
+    try:
+        validator = Draft202012Validator(schema, format_checker=FormatChecker())
+        validation_errors = sorted(
+            validator.iter_errors(document),
+            key=lambda error: tuple(str(part) for part in error.absolute_path),
+        )
+    except SchemaError as error:
+        errors.append(f"{label}: invalid schema ({error.message})")
+        return
+
+    for validation_error in validation_errors:
+        location = ".".join(str(part) for part in validation_error.absolute_path) or "<root>"
+        errors.append(
+            f"{label}: schema validation failed at {location}: "
+            f"{validation_error.message}"
+        )
 
 
 def has_keys(value: Any, expected: set[str], label: str, errors: list[str]) -> bool:
@@ -122,6 +147,56 @@ def check_sidecar(sidecar: Any, label: str, spec_date: Any, errors: list[str]) -
 
     non_empty_strings(sidecar["limitations"], f"{label}.limitations", errors)
     non_empty_strings(sidecar["differences"], f"{label}.differences", errors)
+    if (
+        isinstance(sidecar["differences"], list)
+        and GENERIC_DIFFERENCE in sidecar["differences"]
+    ):
+        errors.append(f"{label}.differences: replace the generic portability claim with a skill-specific difference")
+
+
+def check_skill_frontmatter(path: Path, name: str, errors: list[str]) -> None:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as error:
+        errors.append(f"{path}: cannot read ({error})")
+        return
+
+    frontmatter = re.match(r"^---\s*\n(.*?)\n---(?:\s|$)", content, re.DOTALL)
+    if not frontmatter:
+        errors.append(f"{path}: missing YAML frontmatter")
+        return
+
+    frontmatter_body = frontmatter.group(1)
+    name_match = re.search(
+        r"^name:[ \t]*([^\s#]+)[ \t]*$",
+        frontmatter_body,
+        re.MULTILINE,
+    )
+    if not name_match or name_match.group(1) != name:
+        errors.append(f"{path}: frontmatter name must be {name!r}")
+
+    description_match = re.search(
+        r"^description:[ \t]*(.*)$",
+        frontmatter_body,
+        re.MULTILINE,
+    )
+    if not description_match:
+        errors.append(f"{path}: frontmatter description is required")
+        return
+
+    description = description_match.group(1).strip()
+    if description.startswith(("|", ">")):
+        description = " ".join(
+            line.strip()
+            for line in frontmatter_body[description_match.end() :].splitlines()
+            if line.strip()
+        )
+    else:
+        description = description.strip("\"'")
+    if not description:
+        errors.append(f"{path}: frontmatter description must not be empty")
+    elif len(description) > 1024:
+        errors.append(f"{path}: frontmatter description must be at most 1024 characters")
 
 
 def check_index(index: Any, errors: list[str]) -> list[dict[str, Any]]:
@@ -456,15 +531,31 @@ def main() -> int:
     check_contract(contract, errors)
     check_fixture(fixture, errors)
 
-    schema_files = [
-        "audit.schema.json",
-        "harness-smoke-contract.schema.json",
-        "harness-smoke-fixture.schema.json",
-        "portability.schema.json",
-        "skills-index.schema.json",
-    ]
-    for schema_file in schema_files:
-        load_json(compatibility / schema_file, errors)
+    schema_files = {
+        "audit": "audit.schema.json",
+        "contract": "harness-smoke-contract.schema.json",
+        "fixture": "harness-smoke-fixture.schema.json",
+        "portability": "portability.schema.json",
+        "index": "skills-index.schema.json",
+    }
+    schemas = {
+        name: load_json(compatibility / filename, errors)
+        for name, filename in schema_files.items()
+    }
+    validate_schema(index, schemas["index"], "compatibility/skills-index.json", errors)
+    validate_schema(audit, schemas["audit"], "compatibility/audit.json", errors)
+    validate_schema(
+        contract,
+        schemas["contract"],
+        "compatibility/harness-smoke-contract.json",
+        errors,
+    )
+    validate_schema(
+        fixture,
+        schemas["fixture"],
+        "compatibility/fixtures/camunda-bpmn-smoke.json",
+        errors,
+    )
 
     spec_date = index.get("specRevisionOrAuditDate") if isinstance(index, dict) else None
     if not isinstance(spec_date, str) or not spec_date:
@@ -477,10 +568,10 @@ def main() -> int:
     skill_directories = {
         path.name: path
         for path in skills_root.iterdir()
-        if path.is_dir() and (path / "SKILL.md").is_file()
+        if path.is_dir()
     } if skills_root.is_dir() else {}
     if not skill_directories:
-        errors.append("skills: no skill directories with SKILL.md were found")
+        errors.append("skills: no skill directories were found")
 
     index_by_name = {entry.get("name"): entry for entry in index_entries}
     audit_by_name = {entry.get("name"): entry for entry in audit_entries}
@@ -509,44 +600,61 @@ def main() -> int:
 
     for name, skill_directory in sorted(skill_directories.items()):
         skill_markdown = skill_directory / "SKILL.md"
-        try:
-            frontmatter = re.match(
-                r"^---\s*\n(.*?)\n---(?:\s|$)",
-                skill_markdown.read_text(encoding="utf-8"),
-                re.DOTALL,
-            )
-        except OSError as error:
-            errors.append(f"{skill_markdown}: cannot read ({error})")
-            frontmatter = None
-        match = re.search(r"^name:\s*([^\s#]+)\s*$", frontmatter.group(1), re.MULTILINE) if frontmatter else None
-        if not match or match.group(1) != name:
-            errors.append(f"{skill_markdown}: frontmatter name must be {name!r}")
+        if not skill_markdown.is_file():
+            errors.append(f"{skill_markdown}: required skill entrypoint does not exist")
+        else:
+            check_skill_frontmatter(skill_markdown, name, errors)
 
         expected_index = {
             "name": name,
             "skillDirectory": f"skills/{name}",
             "skillMarkdown": f"skills/{name}/SKILL.md",
             "sidecar": f"skills/{name}/portability.json",
-            "status": "portable-with-adapter",
         }
         expected_audit = {
             "name": name,
             "skillDirectory": f"skills/{name}",
             "sidecar": f"skills/{name}/portability.json",
-            "status": "portable-with-adapter",
         }
-        if index_by_name.get(name) != expected_index:
+        index_entry = index_by_name.get(name)
+        audit_entry = audit_by_name.get(name)
+        if not isinstance(index_entry, dict) or any(
+            index_entry.get(field) != value for field, value in expected_index.items()
+        ):
             errors.append(f"skills-index.json: entry for {name!r} has stale or mismatched paths")
-        if audit_by_name.get(name) != expected_audit:
+        if not isinstance(audit_entry, dict) or any(
+            audit_entry.get(field) != value for field, value in expected_audit.items()
+        ):
             errors.append(f"audit.json: entry for {name!r} has stale or mismatched paths")
 
         sidecar_path = skill_directory / "portability.json"
         sidecar = load_json(sidecar_path, errors)
+        validate_schema(sidecar, schemas["portability"], str(sidecar_path), errors)
         check_sidecar(sidecar, str(sidecar_path.relative_to(root)), spec_date, errors)
         if isinstance(sidecar, dict):
             expect(sidecar.get("skillDirectory"), f"skills/{name}", f"{sidecar_path}.skillDirectory", errors)
             expect(sidecar.get("skillName"), name, f"{sidecar_path}.skillName", errors)
-            expect(sidecar.get("status"), "portable-with-adapter", f"{sidecar_path}.status", errors)
+            if isinstance(index_entry, dict):
+                expect(
+                    index_entry.get("status"),
+                    sidecar.get("status"),
+                    f"{sidecar_path} and skills-index.json status",
+                    errors,
+                )
+            if isinstance(audit_entry, dict):
+                expect(
+                    audit_entry.get("status"),
+                    sidecar.get("status"),
+                    f"{sidecar_path} and audit.json status",
+                    errors,
+                )
+        if isinstance(index_entry, dict) and isinstance(audit_entry, dict):
+            expect(
+                audit_entry.get("status"),
+                index_entry.get("status"),
+                f"skills-index.json and audit.json status for {name!r}",
+                errors,
+            )
 
     if isinstance(contract, dict):
         required_entrypoint = contract.get("discovery", {}).get("requiredEntrypoint")

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -184,7 +184,9 @@ def check_skill_frontmatter(path: Path, name: str, errors: list[str]) -> None:
         errors.append(f"{path}: frontmatter must be a YAML object")
         return
 
-    has_keys(metadata, {"name", "description"}, f"{path}: frontmatter", errors)
+    missing = {"name", "description"} - set(metadata)
+    if missing:
+        errors.append(f"{path}: frontmatter missing keys {sorted(missing)}")
 
     frontmatter_name = metadata.get("name")
     if not isinstance(frontmatter_name, str) or not SKILL_NAME.fullmatch(frontmatter_name):

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -566,10 +566,10 @@ def check_fixture(fixture: Any, errors: list[str]) -> None:
     )
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parent.parent)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     root = args.root.resolve()
     errors: list[str] = []
 

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -12,9 +12,10 @@ from typing import Any
 
 from jsonschema import Draft202012Validator, FormatChecker
 from jsonschema.exceptions import SchemaError
+import yaml
 
 SPEC_URL = "https://agentskills.io/specification"
-SKILL_NAME = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+SKILL_NAME = re.compile(r"(?=.{1,64}\Z)[a-z0-9]+(?:-[a-z0-9]+)*\Z")
 DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 GENERIC_DIFFERENCE = "Tool names, model configuration, and credential setup can vary by harness."
 
@@ -166,35 +167,26 @@ def check_skill_frontmatter(path: Path, name: str, errors: list[str]) -> None:
         errors.append(f"{path}: missing YAML frontmatter")
         return
 
-    frontmatter_body = frontmatter.group(1)
-    name_match = re.search(
-        r"^name:[ \t]*([^\s#]+)[ \t]*$",
-        frontmatter_body,
-        re.MULTILINE,
-    )
-    if not name_match or name_match.group(1) != name:
-        errors.append(f"{path}: frontmatter name must be {name!r}")
-
-    description_match = re.search(
-        r"^description:[ \t]*(.*)$",
-        frontmatter_body,
-        re.MULTILINE,
-    )
-    if not description_match:
-        errors.append(f"{path}: frontmatter description is required")
+    try:
+        metadata = yaml.safe_load(frontmatter.group(1))
+    except yaml.YAMLError as error:
+        errors.append(f"{path}: invalid YAML frontmatter ({error})")
+        return
+    if not isinstance(metadata, dict):
+        errors.append(f"{path}: frontmatter must be a YAML object")
         return
 
-    description = description_match.group(1).strip()
-    if description.startswith(("|", ">")):
-        description = " ".join(
-            line.strip()
-            for line in frontmatter_body[description_match.end() :].splitlines()
-            if line.strip()
-        )
-    else:
-        description = description.strip("\"'")
-    if not description:
-        errors.append(f"{path}: frontmatter description must not be empty")
+    has_keys(metadata, {"name", "description"}, f"{path}: frontmatter", errors)
+
+    frontmatter_name = metadata.get("name")
+    if not isinstance(frontmatter_name, str) or not SKILL_NAME.fullmatch(frontmatter_name):
+        errors.append(f"{path}: frontmatter name is invalid")
+    elif frontmatter_name != name:
+        errors.append(f"{path}: frontmatter name must be {name!r}")
+
+    description = metadata.get("description")
+    if not isinstance(description, str) or not description.strip():
+        errors.append(f"{path}: frontmatter description must be a non-empty string")
     elif len(description) > 1024:
         errors.append(f"{path}: frontmatter description must be at most 1024 characters")
 

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -15,9 +15,14 @@ from jsonschema.exceptions import SchemaError
 import yaml
 
 SPEC_URL = "https://agentskills.io/specification"
+PORTABILITY_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/camunda/skills/main/"
+    "compatibility/portability.schema.json"
+)
 SKILL_NAME = re.compile(r"(?=.{1,64}\Z)[a-z0-9]+(?:-[a-z0-9]+)*\Z")
 DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 GENERIC_DIFFERENCE = "Tool names, model configuration, and credential setup can vary by harness."
+OPTIONAL_FRONTMATTER_KEYS = {"license", "compatibility", "metadata", "allowed-tools"}
 
 
 def load_json(path: Path, errors: list[str]) -> Any:
@@ -107,7 +112,7 @@ def check_sidecar(sidecar: Any, label: str, spec_date: Any, errors: list[str]) -
 
     expect(
         sidecar["$schema"],
-        "../../compatibility/portability.schema.json",
+        PORTABILITY_SCHEMA_URL,
         f"{label}.$schema",
         errors,
     )
@@ -184,9 +189,17 @@ def check_skill_frontmatter(path: Path, name: str, errors: list[str]) -> None:
         errors.append(f"{path}: frontmatter must be a YAML object")
         return
 
-    missing = {"name", "description"} - set(metadata)
+    required_keys = {"name", "description"}
+    allowed_keys = required_keys | OPTIONAL_FRONTMATTER_KEYS
+    missing = required_keys - set(metadata)
     if missing:
         errors.append(f"{path}: frontmatter missing keys {sorted(missing)}")
+    extra = [key for key in metadata if key not in allowed_keys]
+    if extra:
+        errors.append(
+            f"{path}: frontmatter has unsupported keys "
+            f"{sorted(str(key) for key in extra)}"
+        )
 
     frontmatter_name = metadata.get("name")
     if not isinstance(frontmatter_name, str) or not SKILL_NAME.fullmatch(frontmatter_name):
@@ -199,6 +212,39 @@ def check_skill_frontmatter(path: Path, name: str, errors: list[str]) -> None:
         errors.append(f"{path}: frontmatter description must be a non-empty string")
     elif len(description) > 1024:
         errors.append(f"{path}: frontmatter description must be at most 1024 characters")
+
+    license_value = metadata.get("license")
+    if "license" in metadata and (
+        not isinstance(license_value, str) or not license_value.strip()
+    ):
+        errors.append(f"{path}: frontmatter license must be a non-empty string")
+
+    compatibility = metadata.get("compatibility")
+    if "compatibility" in metadata:
+        if not isinstance(compatibility, str) or not compatibility.strip():
+            errors.append(f"{path}: frontmatter compatibility must be a non-empty string")
+        elif len(compatibility) > 500:
+            errors.append(
+                f"{path}: frontmatter compatibility must be at most 500 characters"
+            )
+
+    metadata_value = metadata.get("metadata")
+    if "metadata" in metadata and (
+        not isinstance(metadata_value, dict)
+        or any(
+            not isinstance(key, str) or not isinstance(value, str)
+            for key, value in metadata_value.items()
+        )
+    ):
+        errors.append(
+            f"{path}: frontmatter metadata must map strings to strings"
+        )
+
+    allowed_tools = metadata.get("allowed-tools")
+    if "allowed-tools" in metadata and (
+        not isinstance(allowed_tools, str) or not allowed_tools.strip()
+    ):
+        errors.append(f"{path}: frontmatter allowed-tools must be a non-empty string")
 
 
 def check_index(index: Any, errors: list[str]) -> list[dict[str, Any]]:

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -158,6 +158,18 @@ def check_sidecar(sidecar: Any, label: str, spec_date: Any, errors: list[str]) -
                 }:
                     errors.append(f"{harness_label}.status: invalid harness status")
                 non_empty_strings(declaration["differences"], f"{harness_label}.differences", errors)
+        if sidecar["status"] == "portable":
+            non_native = [
+                harness_name
+                for harness_name, declaration in harnesses.items()
+                if not isinstance(declaration, dict)
+                or declaration.get("status") != "native"
+            ]
+            if non_native:
+                errors.append(
+                    f"{label}.status: portable requires native harness declarations; "
+                    f"non-native={sorted(non_native)}"
+                )
 
     non_empty_strings(sidecar["limitations"], f"{label}.limitations", errors)
     non_empty_strings(sidecar["differences"], f"{label}.differences", errors)
@@ -649,14 +661,15 @@ def main(argv: list[str] | None = None) -> int:
             f"found={sorted(actual_sidecars)} expected={sorted(expected_sidecars)}"
         )
 
+    global_errors_before_skills = bool(errors)
     skill_results: dict[str, bool] = {}
     for name, skill_directory in sorted(skill_directories.items()):
-        skill_error_count = len(errors)
+        skill_errors: list[str] = []
         skill_markdown = skill_directory / "SKILL.md"
         if not skill_markdown.is_file():
-            errors.append(f"{skill_markdown}: required skill entrypoint does not exist")
+            skill_errors.append(f"{skill_markdown}: required skill entrypoint does not exist")
         else:
-            check_skill_frontmatter(skill_markdown, name, errors)
+            check_skill_frontmatter(skill_markdown, name, skill_errors)
 
         expected_index = {
             "name": name,
@@ -674,41 +687,49 @@ def main(argv: list[str] | None = None) -> int:
         if not isinstance(index_entry, dict) or any(
             index_entry.get(field) != value for field, value in expected_index.items()
         ):
-            errors.append(f"skills-index.json: entry for {name!r} has stale or mismatched paths")
+            skill_errors.append(f"skills-index.json: entry for {name!r} has stale or mismatched paths")
         if not isinstance(audit_entry, dict) or any(
             audit_entry.get(field) != value for field, value in expected_audit.items()
         ):
-            errors.append(f"audit.json: entry for {name!r} has stale or mismatched paths")
+            skill_errors.append(f"audit.json: entry for {name!r} has stale or mismatched paths")
 
         sidecar_path = skill_directory / "portability.json"
-        sidecar = load_json(sidecar_path, errors)
-        validate_schema(sidecar, schemas["portability"], str(sidecar_path), errors)
-        check_sidecar(sidecar, str(sidecar_path.relative_to(root)), spec_date, errors)
+        sidecar = load_json(sidecar_path, skill_errors)
+        validate_schema(sidecar, schemas["portability"], str(sidecar_path), skill_errors)
+        check_sidecar(sidecar, str(sidecar_path.relative_to(root)), spec_date, skill_errors)
         if isinstance(sidecar, dict):
-            expect(sidecar.get("skillDirectory"), f"skills/{name}", f"{sidecar_path}.skillDirectory", errors)
-            expect(sidecar.get("skillName"), name, f"{sidecar_path}.skillName", errors)
+            expect(
+                sidecar.get("skillDirectory"),
+                f"skills/{name}",
+                f"{sidecar_path}.skillDirectory",
+                skill_errors,
+            )
+            expect(sidecar.get("skillName"), name, f"{sidecar_path}.skillName", skill_errors)
             if isinstance(index_entry, dict):
                 expect(
                     index_entry.get("status"),
                     sidecar.get("status"),
                     f"{sidecar_path} and skills-index.json status",
-                    errors,
+                    skill_errors,
                 )
             if isinstance(audit_entry, dict):
                 expect(
                     audit_entry.get("status"),
                     sidecar.get("status"),
                     f"{sidecar_path} and audit.json status",
-                    errors,
+                    skill_errors,
                 )
         if isinstance(index_entry, dict) and isinstance(audit_entry, dict):
             expect(
                 audit_entry.get("status"),
                 index_entry.get("status"),
                 f"skills-index.json and audit.json status for {name!r}",
-                errors,
+                skill_errors,
             )
-        skill_results[name] = len(errors) == skill_error_count
+        errors.extend(skill_errors)
+        skill_results[name] = not skill_errors
+
+    errors_before_global_post_checks = len(errors)
 
     if isinstance(contract, dict):
         discovery = contract.get("discovery")
@@ -733,6 +754,12 @@ def main(argv: list[str] | None = None) -> int:
             errors.append(f"{adapter}: required executable does not exist")
         elif not adapter.stat().st_mode & 0o111:
             errors.append(f"{adapter}: required executable bit is not set")
+
+    global_checks_failed = global_errors_before_skills or (
+        len(errors) > errors_before_global_post_checks
+    )
+    if global_checks_failed:
+        skill_results = {name: False for name in skill_results}
 
     for name in sorted(skill_results):
         result = "passed" if skill_results[name] else "failed"

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -31,7 +31,7 @@ def load_json(path: Path, errors: list[str]) -> Any:
         return None
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
         errors.append(f"{path}: invalid JSON ({error})")
         return None
 

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -649,7 +649,9 @@ def main() -> int:
             f"found={sorted(actual_sidecars)} expected={sorted(expected_sidecars)}"
         )
 
+    skill_results: dict[str, bool] = {}
     for name, skill_directory in sorted(skill_directories.items()):
+        skill_error_count = len(errors)
         skill_markdown = skill_directory / "SKILL.md"
         if not skill_markdown.is_file():
             errors.append(f"{skill_markdown}: required skill entrypoint does not exist")
@@ -706,6 +708,7 @@ def main() -> int:
                 f"skills-index.json and audit.json status for {name!r}",
                 errors,
             )
+        skill_results[name] = len(errors) == skill_error_count
 
     if isinstance(contract, dict):
         discovery = contract.get("discovery")
@@ -730,6 +733,10 @@ def main() -> int:
             errors.append(f"{adapter}: required executable does not exist")
         elif not adapter.stat().st_mode & 0o111:
             errors.append(f"{adapter}: required executable bit is not set")
+
+    for name in sorted(skill_results):
+        result = "passed" if skill_results[name] else "failed"
+        print(f"Compatibility skill {name}: {result}")
 
     if errors:
         print("Compatibility conformance failed:", file=sys.stderr)

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -32,9 +32,13 @@ def load_json(path: Path, errors: list[str]) -> Any:
 
 
 def validate_schema(document: Any, schema: Any, label: str, errors: list[str]) -> None:
-    if document is None or schema is None:
+    if document is None:
+        return
+    if not isinstance(schema, dict):
+        errors.append(f"{label}: schema must be a JSON object")
         return
     try:
+        Draft202012Validator.check_schema(schema)
         validator = Draft202012Validator(schema, format_checker=FormatChecker())
         validation_errors = sorted(
             validator.iter_errors(document),
@@ -79,7 +83,11 @@ def non_empty_strings(value: Any, label: str, errors: list[str]) -> None:
 
 
 def status(value: Any, label: str, errors: list[str]) -> None:
-    if value not in {"portable", "portable-with-adapter", "harness-specific"}:
+    if not isinstance(value, str) or value not in {
+        "portable",
+        "portable-with-adapter",
+        "harness-specific",
+    }:
         errors.append(f"{label}: invalid repository status {value!r}")
 
 
@@ -137,7 +145,7 @@ def check_sidecar(sidecar: Any, label: str, spec_date: Any, errors: list[str]) -
         for harness_name, declaration in harnesses.items():
             harness_label = f"{label}.harnesses.{harness_name}"
             if has_keys(declaration, {"status", "differences"}, harness_label, errors):
-                if declaration["status"] not in {
+                if not isinstance(declaration["status"], str) or declaration["status"] not in {
                     "native",
                     "adapter-required",
                     "unsupported",

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -224,11 +224,13 @@ def check_index(index: Any, errors: list[str]) -> list[dict[str, Any]]:
         entry_label = f"{label}.skills[{number}]"
         if not has_keys(entry, entry_keys, entry_label, errors):
             continue
-        if not isinstance(entry["name"], str) or not SKILL_NAME.fullmatch(entry["name"]):
+        name = entry["name"]
+        if not isinstance(name, str) or not SKILL_NAME.fullmatch(name):
             errors.append(f"{entry_label}.name: invalid skill name")
-        if entry["name"] in names:
-            errors.append(f"{entry_label}.name: duplicate skill name {entry['name']!r}")
-        names.add(entry["name"])
+            continue
+        if name in names:
+            errors.append(f"{entry_label}.name: duplicate skill name {name!r}")
+        names.add(name)
         for field in ("skillDirectory", "skillMarkdown", "sidecar"):
             if not isinstance(entry[field], str):
                 errors.append(f"{entry_label}.{field}: expected a string")
@@ -271,11 +273,13 @@ def check_audit(audit: Any, errors: list[str]) -> list[dict[str, Any]]:
         entry_label = f"{label}.skills[{number}]"
         if not has_keys(entry, entry_keys, entry_label, errors):
             continue
-        if not isinstance(entry["name"], str) or not SKILL_NAME.fullmatch(entry["name"]):
+        name = entry["name"]
+        if not isinstance(name, str) or not SKILL_NAME.fullmatch(name):
             errors.append(f"{entry_label}.name: invalid skill name")
-        if entry["name"] in names:
-            errors.append(f"{entry_label}.name: duplicate skill name {entry['name']!r}")
-        names.add(entry["name"])
+            continue
+        if name in names:
+            errors.append(f"{entry_label}.name: duplicate skill name {name!r}")
+        names.add(name)
         for field in ("skillDirectory", "sidecar"):
             if not isinstance(entry[field], str):
                 errors.append(f"{entry_label}.{field}: expected a string")
@@ -562,7 +566,6 @@ def main() -> int:
         spec_date = None
     if isinstance(audit, dict):
         expect(audit.get("specRevisionOrAuditDate"), spec_date, "audit specification date", errors)
-        expect(audit.get("auditDate"), spec_date, "audit date", errors)
 
     skills_root = root / "skills"
     skill_directories = {
@@ -657,9 +660,11 @@ def main() -> int:
             )
 
     if isinstance(contract, dict):
-        required_entrypoint = contract.get("discovery", {}).get("requiredEntrypoint")
-        if isinstance(required_entrypoint, str) and not (root / required_entrypoint).is_file():
-            errors.append(f"{required_entrypoint}: required smoke entrypoint does not exist")
+        discovery = contract.get("discovery")
+        if isinstance(discovery, dict):
+            required_entrypoint = discovery.get("requiredEntrypoint")
+            if isinstance(required_entrypoint, str) and not (root / required_entrypoint).is_file():
+                errors.append(f"{required_entrypoint}: required smoke entrypoint does not exist")
     if isinstance(fixture, dict):
         expected = fixture.get("expected")
         if isinstance(expected, dict):

--- a/compatibility/check.py
+++ b/compatibility/check.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Check the repository-level skills portability contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+SPEC_URL = "https://agentskills.io/specification"
+SKILL_NAME = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def load_json(path: Path, errors: list[str]) -> Any:
+    if not path.is_file():
+        errors.append(f"{path}: file does not exist")
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        errors.append(f"{path}: invalid JSON ({error})")
+        return None
+
+
+def has_keys(value: Any, expected: set[str], label: str, errors: list[str]) -> bool:
+    if not isinstance(value, dict):
+        errors.append(f"{label}: expected an object")
+        return False
+    actual = set(value)
+    missing = expected - actual
+    extra = actual - expected
+    if missing:
+        errors.append(f"{label}: missing keys {sorted(missing)}")
+    if extra:
+        errors.append(f"{label}: unexpected keys {sorted(extra)}")
+    return not missing and not extra
+
+
+def expect(value: Any, expected: Any, label: str, errors: list[str]) -> None:
+    if value != expected:
+        errors.append(f"{label}: expected {expected!r}, got {value!r}")
+
+
+def non_empty_strings(value: Any, label: str, errors: list[str]) -> None:
+    if not isinstance(value, list) or not value or not all(
+        isinstance(item, str) and bool(item) for item in value
+    ):
+        errors.append(f"{label}: expected a non-empty list of strings")
+
+
+def status(value: Any, label: str, errors: list[str]) -> None:
+    if value not in {"portable", "portable-with-adapter", "harness-specific"}:
+        errors.append(f"{label}: invalid repository status {value!r}")
+
+
+def check_sidecar(sidecar: Any, label: str, spec_date: Any, errors: list[str]) -> None:
+    keys = {
+        "$schema",
+        "skillDirectory",
+        "skillName",
+        "status",
+        "agentSkillsSpec",
+        "harnesses",
+        "limitations",
+        "differences",
+    }
+    if not has_keys(sidecar, keys, label, errors):
+        return
+
+    expect(
+        sidecar["$schema"],
+        "../../compatibility/portability.schema.json",
+        f"{label}.$schema",
+        errors,
+    )
+    if not isinstance(sidecar["skillDirectory"], str):
+        errors.append(f"{label}.skillDirectory: expected a string")
+    if not isinstance(sidecar["skillName"], str) or not SKILL_NAME.fullmatch(
+        sidecar["skillName"]
+    ):
+        errors.append(f"{label}.skillName: invalid skill name")
+    status(sidecar["status"], f"{label}.status", errors)
+
+    specification = sidecar["agentSkillsSpec"]
+    if has_keys(
+        specification,
+        {"specUrl", "specRevisionOrAuditDate"},
+        f"{label}.agentSkillsSpec",
+        errors,
+    ):
+        expect(specification["specUrl"], SPEC_URL, f"{label}.agentSkillsSpec.specUrl", errors)
+        expect(
+            specification["specRevisionOrAuditDate"],
+            spec_date,
+            f"{label}.agentSkillsSpec.specRevisionOrAuditDate",
+            errors,
+        )
+
+    harnesses = sidecar["harnesses"]
+    if isinstance(harnesses, dict):
+        expect(
+            set(harnesses),
+            {"claude", "copilot", "generic"},
+            f"{label}.harnesses names",
+            errors,
+        )
+        for harness_name, declaration in harnesses.items():
+            harness_label = f"{label}.harnesses.{harness_name}"
+            if has_keys(declaration, {"status", "differences"}, harness_label, errors):
+                if declaration["status"] not in {
+                    "native",
+                    "adapter-required",
+                    "unsupported",
+                    "not-tested",
+                }:
+                    errors.append(f"{harness_label}.status: invalid harness status")
+                non_empty_strings(declaration["differences"], f"{harness_label}.differences", errors)
+
+    non_empty_strings(sidecar["limitations"], f"{label}.limitations", errors)
+    non_empty_strings(sidecar["differences"], f"{label}.differences", errors)
+
+
+def check_index(index: Any, errors: list[str]) -> list[dict[str, Any]]:
+    label = "compatibility/skills-index.json"
+    keys = {"$schema", "schemaVersion", "specUrl", "specRevisionOrAuditDate", "skills"}
+    if not has_keys(index, keys, label, errors):
+        return []
+    expect(index["$schema"], "./skills-index.schema.json", f"{label}.$schema", errors)
+    expect(index["schemaVersion"], 1, f"{label}.schemaVersion", errors)
+    expect(index["specUrl"], SPEC_URL, f"{label}.specUrl", errors)
+    if not isinstance(index["specRevisionOrAuditDate"], str) or not index[
+        "specRevisionOrAuditDate"
+    ]:
+        errors.append(f"{label}.specRevisionOrAuditDate: expected a non-empty string")
+
+    entries = index["skills"]
+    if not isinstance(entries, list) or not entries:
+        errors.append(f"{label}.skills: expected a non-empty list")
+        return []
+
+    result: list[dict[str, Any]] = []
+    names: set[str] = set()
+    entry_keys = {"name", "skillDirectory", "skillMarkdown", "sidecar", "status"}
+    for number, entry in enumerate(entries, start=1):
+        entry_label = f"{label}.skills[{number}]"
+        if not has_keys(entry, entry_keys, entry_label, errors):
+            continue
+        if not isinstance(entry["name"], str) or not SKILL_NAME.fullmatch(entry["name"]):
+            errors.append(f"{entry_label}.name: invalid skill name")
+        if entry["name"] in names:
+            errors.append(f"{entry_label}.name: duplicate skill name {entry['name']!r}")
+        names.add(entry["name"])
+        for field in ("skillDirectory", "skillMarkdown", "sidecar"):
+            if not isinstance(entry[field], str):
+                errors.append(f"{entry_label}.{field}: expected a string")
+        status(entry["status"], f"{entry_label}.status", errors)
+        result.append(entry)
+    return result
+
+
+def check_audit(audit: Any, errors: list[str]) -> list[dict[str, Any]]:
+    label = "compatibility/audit.json"
+    keys = {
+        "$schema",
+        "schemaVersion",
+        "specUrl",
+        "specRevisionOrAuditDate",
+        "auditDate",
+        "skills",
+    }
+    if not has_keys(audit, keys, label, errors):
+        return []
+    expect(audit["$schema"], "./audit.schema.json", f"{label}.$schema", errors)
+    expect(audit["schemaVersion"], 1, f"{label}.schemaVersion", errors)
+    expect(audit["specUrl"], SPEC_URL, f"{label}.specUrl", errors)
+    if not isinstance(audit["specRevisionOrAuditDate"], str) or not audit[
+        "specRevisionOrAuditDate"
+    ]:
+        errors.append(f"{label}.specRevisionOrAuditDate: expected a non-empty string")
+    if not isinstance(audit["auditDate"], str) or not DATE.fullmatch(audit["auditDate"]):
+        errors.append(f"{label}.auditDate: expected an ISO date")
+
+    entries = audit["skills"]
+    if not isinstance(entries, list) or not entries:
+        errors.append(f"{label}.skills: expected a non-empty list")
+        return []
+
+    result: list[dict[str, Any]] = []
+    names: set[str] = set()
+    entry_keys = {"name", "skillDirectory", "sidecar", "status"}
+    for number, entry in enumerate(entries, start=1):
+        entry_label = f"{label}.skills[{number}]"
+        if not has_keys(entry, entry_keys, entry_label, errors):
+            continue
+        if not isinstance(entry["name"], str) or not SKILL_NAME.fullmatch(entry["name"]):
+            errors.append(f"{entry_label}.name: invalid skill name")
+        if entry["name"] in names:
+            errors.append(f"{entry_label}.name: duplicate skill name {entry['name']!r}")
+        names.add(entry["name"])
+        for field in ("skillDirectory", "sidecar"):
+            if not isinstance(entry[field], str):
+                errors.append(f"{entry_label}.{field}: expected a string")
+        status(entry["status"], f"{entry_label}.status", errors)
+        result.append(entry)
+    return result
+
+
+def check_contract(contract: Any, errors: list[str]) -> None:
+    label = "compatibility/harness-smoke-contract.json"
+    keys = {
+        "$schema",
+        "schemaVersion",
+        "contractId",
+        "discovery",
+        "activation",
+        "resultAssertions",
+        "adapters",
+    }
+    if not has_keys(contract, keys, label, errors):
+        return
+    expect(contract["$schema"], "./harness-smoke-contract.schema.json", f"{label}.$schema", errors)
+    expect(contract["schemaVersion"], 1, f"{label}.schemaVersion", errors)
+    expect(
+        contract["contractId"],
+        "camunda-skills-harness-smoke-v1",
+        f"{label}.contractId",
+        errors,
+    )
+
+    discovery = contract["discovery"]
+    discovery_keys = {
+        "repositoryRoot",
+        "skillEntrypointPattern",
+        "requiredEntrypoint",
+        "sidecarPattern",
+        "discoveryResultField",
+    }
+    if has_keys(discovery, discovery_keys, f"{label}.discovery", errors):
+        expect(discovery["repositoryRoot"], ".", f"{label}.discovery.repositoryRoot", errors)
+        expect(
+            discovery["skillEntrypointPattern"],
+            "skills/<name>/SKILL.md",
+            f"{label}.discovery.skillEntrypointPattern",
+            errors,
+        )
+        expect(
+            discovery["requiredEntrypoint"],
+            "skills/camunda-bpmn/SKILL.md",
+            f"{label}.discovery.requiredEntrypoint",
+            errors,
+        )
+        expect(
+            discovery["sidecarPattern"],
+            "skills/<name>/portability.json",
+            f"{label}.discovery.sidecarPattern",
+            errors,
+        )
+        expect(
+            discovery["discoveryResultField"],
+            "discovered",
+            f"{label}.discovery.discoveryResultField",
+            errors,
+        )
+
+    activation = contract["activation"]
+    activation_keys = {"fixturePath", "skillNameField", "promptField", "activationResultField"}
+    if has_keys(activation, activation_keys, f"{label}.activation", errors):
+        expect(
+            activation["fixturePath"],
+            "compatibility/fixtures/camunda-bpmn-smoke.json",
+            f"{label}.activation.fixturePath",
+            errors,
+        )
+        expect(activation["skillNameField"], "skillName", f"{label}.activation.skillNameField", errors)
+        expect(activation["promptField"], "prompt", f"{label}.activation.promptField", errors)
+        expect(
+            activation["activationResultField"],
+            "activated",
+            f"{label}.activation.activationResultField",
+            errors,
+        )
+
+    assertions = contract["resultAssertions"]
+    if has_keys(
+        assertions,
+        {"required", "artifact", "toolCall"},
+        f"{label}.resultAssertions",
+        errors,
+    ):
+        required = assertions["required"]
+        if has_keys(
+            required,
+            {"discovered", "activated"},
+            f"{label}.resultAssertions.required",
+            errors,
+        ):
+            expect(required["discovered"], True, f"{label}.resultAssertions.required.discovered", errors)
+            expect(required["activated"], True, f"{label}.resultAssertions.required.activated", errors)
+
+        artifact = assertions["artifact"]
+        if has_keys(
+            artifact,
+            {"path", "required", "mustExist", "mustBeValid"},
+            f"{label}.resultAssertions.artifact",
+            errors,
+        ):
+            expect(artifact["path"], "process.bpmn", f"{label}.resultAssertions.artifact.path", errors)
+            for field in ("required", "mustExist", "mustBeValid"):
+                expect(
+                    artifact[field],
+                    True,
+                    f"{label}.resultAssertions.artifact.{field}",
+                    errors,
+                )
+
+        tool_call = assertions["toolCall"]
+        if has_keys(
+            tool_call,
+            {"command", "match", "required", "mustExecute", "mustSucceed"},
+            f"{label}.resultAssertions.toolCall",
+            errors,
+        ):
+            expect(
+                tool_call["command"],
+                "c8ctl bpmn lint process.bpmn",
+                f"{label}.resultAssertions.toolCall.command",
+                errors,
+            )
+            expect(tool_call["match"], "exact", f"{label}.resultAssertions.toolCall.match", errors)
+            for field in ("required", "mustExecute", "mustSucceed"):
+                expect(tool_call[field], True, f"{label}.resultAssertions.toolCall.{field}", errors)
+
+    adapters = contract["adapters"]
+    if not has_keys(adapters, {"deterministicMocks", "liveCopilot"}, f"{label}.adapters", errors):
+        return
+    mocks = adapters["deterministicMocks"]
+    mock_keys = {
+        "required",
+        "networkAccess",
+        "credentialsRequired",
+        "modelOutputRequired",
+        "entryPoints",
+        "passCondition",
+    }
+    if has_keys(mocks, mock_keys, f"{label}.adapters.deterministicMocks", errors):
+        for field in ("required",):
+            expect(mocks[field], True, f"{label}.adapters.deterministicMocks.{field}", errors)
+        for field in ("networkAccess", "credentialsRequired", "modelOutputRequired"):
+            expect(mocks[field], False, f"{label}.adapters.deterministicMocks.{field}", errors)
+        entry_points = mocks["entryPoints"]
+        if has_keys(
+            entry_points,
+            {"claude", "copilot"},
+            f"{label}.adapters.deterministicMocks.entryPoints",
+            errors,
+        ):
+            expect(
+                entry_points["claude"],
+                "compatibility/adapters/mock-claude",
+                f"{label}.adapters.deterministicMocks.entryPoints.claude",
+                errors,
+            )
+            expect(
+                entry_points["copilot"],
+                "compatibility/adapters/mock-copilot",
+                f"{label}.adapters.deterministicMocks.entryPoints.copilot",
+                errors,
+            )
+        if not isinstance(mocks["passCondition"], str) or not mocks["passCondition"]:
+            errors.append(f"{label}.adapters.deterministicMocks.passCondition: expected text")
+
+    live = adapters["liveCopilot"]
+    live_keys = {"optional", "optIn", "allowedResults", "unavailableBehavior"}
+    if has_keys(live, live_keys, f"{label}.adapters.liveCopilot", errors):
+        expect(live["optional"], True, f"{label}.adapters.liveCopilot.optional", errors)
+        if not isinstance(live["optIn"], str) or not live["optIn"]:
+            errors.append(f"{label}.adapters.liveCopilot.optIn: expected text")
+        expect(
+            live["allowedResults"],
+            ["passed", "failed", "skipped", "unavailable"],
+            f"{label}.adapters.liveCopilot.allowedResults",
+            errors,
+        )
+        if not isinstance(live["unavailableBehavior"], str) or not live["unavailableBehavior"]:
+            errors.append(f"{label}.adapters.liveCopilot.unavailableBehavior: expected text")
+
+
+def check_fixture(fixture: Any, errors: list[str]) -> None:
+    label = "compatibility/fixtures/camunda-bpmn-smoke.json"
+    keys = {"$schema", "fixtureId", "skillName", "prompt", "expected"}
+    if not has_keys(fixture, keys, label, errors):
+        return
+    expect(
+        fixture["$schema"],
+        "../harness-smoke-fixture.schema.json",
+        f"{label}.$schema",
+        errors,
+    )
+    expect(fixture["fixtureId"], "camunda-bpmn-basic", f"{label}.fixtureId", errors)
+    expect(fixture["skillName"], "camunda-bpmn", f"{label}.skillName", errors)
+    expect(
+        fixture["prompt"],
+        "Create a minimal Camunda 8 process in process.bpmn and validate it.",
+        f"{label}.prompt",
+        errors,
+    )
+    expected = fixture["expected"]
+    expected_keys = {
+        "discovered",
+        "activated",
+        "artifact",
+        "artifactSource",
+        "artifactExists",
+        "artifactValid",
+        "toolCommand",
+        "toolExecuted",
+        "toolSucceeded",
+    }
+    if not has_keys(expected, expected_keys, f"{label}.expected", errors):
+        return
+    for field in ("discovered", "activated", "artifactExists", "artifactValid", "toolExecuted", "toolSucceeded"):
+        expect(expected[field], True, f"{label}.expected.{field}", errors)
+    expect(expected["artifact"], "process.bpmn", f"{label}.expected.artifact", errors)
+    expect(
+        expected["artifactSource"],
+        "compatibility/fixtures/process.bpmn",
+        f"{label}.expected.artifactSource",
+        errors,
+    )
+    expect(
+        expected["toolCommand"],
+        "c8ctl bpmn lint process.bpmn",
+        f"{label}.expected.toolCommand",
+        errors,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parent.parent)
+    args = parser.parse_args()
+    root = args.root.resolve()
+    errors: list[str] = []
+
+    compatibility = root / "compatibility"
+    index = load_json(compatibility / "skills-index.json", errors)
+    audit = load_json(compatibility / "audit.json", errors)
+    contract = load_json(compatibility / "harness-smoke-contract.json", errors)
+    fixture = load_json(compatibility / "fixtures" / "camunda-bpmn-smoke.json", errors)
+    index_entries = check_index(index, errors)
+    audit_entries = check_audit(audit, errors)
+    check_contract(contract, errors)
+    check_fixture(fixture, errors)
+
+    schema_files = [
+        "audit.schema.json",
+        "harness-smoke-contract.schema.json",
+        "harness-smoke-fixture.schema.json",
+        "portability.schema.json",
+        "skills-index.schema.json",
+    ]
+    for schema_file in schema_files:
+        load_json(compatibility / schema_file, errors)
+
+    spec_date = index.get("specRevisionOrAuditDate") if isinstance(index, dict) else None
+    if not isinstance(spec_date, str) or not spec_date:
+        spec_date = None
+    if isinstance(audit, dict):
+        expect(audit.get("specRevisionOrAuditDate"), spec_date, "audit specification date", errors)
+        expect(audit.get("auditDate"), spec_date, "audit date", errors)
+
+    skills_root = root / "skills"
+    skill_directories = {
+        path.name: path
+        for path in skills_root.iterdir()
+        if path.is_dir() and (path / "SKILL.md").is_file()
+    } if skills_root.is_dir() else {}
+    if not skill_directories:
+        errors.append("skills: no skill directories with SKILL.md were found")
+
+    index_by_name = {entry.get("name"): entry for entry in index_entries}
+    audit_by_name = {entry.get("name"): entry for entry in audit_entries}
+    names = set(skill_directories)
+    if set(index_by_name) != names:
+        errors.append(
+            f"skills-index.json skill set does not match checkout: "
+            f"index={sorted(index_by_name)} checkout={sorted(names)}"
+        )
+    if set(audit_by_name) != names:
+        errors.append(
+            f"audit.json skill set does not match checkout: "
+            f"audit={sorted(audit_by_name)} checkout={sorted(names)}"
+        )
+
+    actual_sidecars = {
+        path.relative_to(root).as_posix()
+        for path in skills_root.glob("*/portability.json")
+    } if skills_root.is_dir() else set()
+    expected_sidecars = {f"skills/{name}/portability.json" for name in names}
+    if actual_sidecars != expected_sidecars:
+        errors.append(
+            f"sidecar set does not match checkout: "
+            f"found={sorted(actual_sidecars)} expected={sorted(expected_sidecars)}"
+        )
+
+    for name, skill_directory in sorted(skill_directories.items()):
+        skill_markdown = skill_directory / "SKILL.md"
+        try:
+            frontmatter = re.match(
+                r"^---\s*\n(.*?)\n---(?:\s|$)",
+                skill_markdown.read_text(encoding="utf-8"),
+                re.DOTALL,
+            )
+        except OSError as error:
+            errors.append(f"{skill_markdown}: cannot read ({error})")
+            frontmatter = None
+        match = re.search(r"^name:\s*([^\s#]+)\s*$", frontmatter.group(1), re.MULTILINE) if frontmatter else None
+        if not match or match.group(1) != name:
+            errors.append(f"{skill_markdown}: frontmatter name must be {name!r}")
+
+        expected_index = {
+            "name": name,
+            "skillDirectory": f"skills/{name}",
+            "skillMarkdown": f"skills/{name}/SKILL.md",
+            "sidecar": f"skills/{name}/portability.json",
+            "status": "portable-with-adapter",
+        }
+        expected_audit = {
+            "name": name,
+            "skillDirectory": f"skills/{name}",
+            "sidecar": f"skills/{name}/portability.json",
+            "status": "portable-with-adapter",
+        }
+        if index_by_name.get(name) != expected_index:
+            errors.append(f"skills-index.json: entry for {name!r} has stale or mismatched paths")
+        if audit_by_name.get(name) != expected_audit:
+            errors.append(f"audit.json: entry for {name!r} has stale or mismatched paths")
+
+        sidecar_path = skill_directory / "portability.json"
+        sidecar = load_json(sidecar_path, errors)
+        check_sidecar(sidecar, str(sidecar_path.relative_to(root)), spec_date, errors)
+        if isinstance(sidecar, dict):
+            expect(sidecar.get("skillDirectory"), f"skills/{name}", f"{sidecar_path}.skillDirectory", errors)
+            expect(sidecar.get("skillName"), name, f"{sidecar_path}.skillName", errors)
+            expect(sidecar.get("status"), "portable-with-adapter", f"{sidecar_path}.status", errors)
+
+    if isinstance(contract, dict):
+        required_entrypoint = contract.get("discovery", {}).get("requiredEntrypoint")
+        if isinstance(required_entrypoint, str) and not (root / required_entrypoint).is_file():
+            errors.append(f"{required_entrypoint}: required smoke entrypoint does not exist")
+    if isinstance(fixture, dict):
+        expected = fixture.get("expected")
+        if isinstance(expected, dict):
+            for field in ("artifactSource",):
+                value = expected.get(field)
+                if isinstance(value, str) and not (root / value).is_file():
+                    errors.append(f"{value}: smoke fixture path does not exist")
+
+    for adapter in (
+        root / "compatibility" / "adapters" / "mock-claude",
+        root / "compatibility" / "adapters" / "mock-copilot",
+        root / "compatibility" / "adapters" / "c8ctl",
+    ):
+        if not adapter.is_file():
+            errors.append(f"{adapter}: required executable does not exist")
+        elif not adapter.stat().st_mode & 0o111:
+            errors.append(f"{adapter}: required executable bit is not set")
+
+    if errors:
+        print("Compatibility conformance failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"Compatibility conformance passed for {len(names)} skills.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/compatibility/fixtures/camunda-bpmn-smoke.json
+++ b/compatibility/fixtures/camunda-bpmn-smoke.json
@@ -7,6 +7,11 @@
     "discovered": true,
     "activated": true,
     "artifact": "process.bpmn",
-    "toolCommand": "c8ctl bpmn lint process.bpmn"
+    "artifactSource": "compatibility/fixtures/process.bpmn",
+    "artifactExists": true,
+    "artifactValid": true,
+    "toolCommand": "c8ctl bpmn lint process.bpmn",
+    "toolExecuted": true,
+    "toolSucceeded": true
   }
 }

--- a/compatibility/fixtures/camunda-bpmn-smoke.json
+++ b/compatibility/fixtures/camunda-bpmn-smoke.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../harness-smoke-fixture.schema.json",
+  "fixtureId": "camunda-bpmn-basic",
+  "skillName": "camunda-bpmn",
+  "prompt": "Create a minimal Camunda 8 process in process.bpmn and validate it.",
+  "expected": {
+    "discovered": true,
+    "activated": true,
+    "artifact": "process.bpmn",
+    "toolCommand": "c8ctl bpmn lint process.bpmn"
+  }
+}

--- a/compatibility/fixtures/process.bpmn
+++ b/compatibility/fixtures/process.bpmn
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             targetNamespace="https://github.com/camunda/skills">
+  <process id="Process_1" isExecutable="true">
+    <startEvent id="StartEvent_1" />
+    <endEvent id="EndEvent_1" />
+    <sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+  </process>
+</definitions>

--- a/compatibility/fixtures/process.bpmn
+++ b/compatibility/fixtures/process.bpmn
@@ -1,10 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             targetNamespace="https://github.com/camunda/skills">
-  <process id="Process_1" isExecutable="true">
-    <startEvent id="StartEvent_1" />
-    <endEvent id="EndEvent_1" />
-    <sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
-  </process>
-</definitions>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start process">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1" name="End process">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="490" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="490" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/compatibility/harness-smoke-contract.json
+++ b/compatibility/harness-smoke-contract.json
@@ -22,12 +22,16 @@
     },
     "artifact": {
       "path": "process.bpmn",
-      "required": true
+      "required": true,
+      "mustExist": true,
+      "mustBeValid": true
     },
     "toolCall": {
       "command": "c8ctl bpmn lint process.bpmn",
       "match": "exact",
-      "required": true
+      "required": true,
+      "mustExecute": true,
+      "mustSucceed": true
     }
   },
   "adapters": {
@@ -37,10 +41,10 @@
       "credentialsRequired": false,
       "modelOutputRequired": false,
       "entryPoints": {
-        "claude": "mock-claude",
-        "copilot": "mock-copilot"
+        "claude": "compatibility/adapters/mock-claude",
+        "copilot": "compatibility/adapters/mock-copilot"
       },
-      "passCondition": "Both entry points satisfy every resultAssertions field."
+      "passCondition": "Both entry points emit process.bpmn, validate it as BPMN, execute c8ctl bpmn lint process.bpmn, and report exit code 0."
     },
     "liveCopilot": {
       "optional": true,

--- a/compatibility/harness-smoke-contract.json
+++ b/compatibility/harness-smoke-contract.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "./harness-smoke-contract.schema.json",
+  "schemaVersion": 1,
+  "contractId": "camunda-skills-harness-smoke-v1",
+  "discovery": {
+    "repositoryRoot": ".",
+    "skillEntrypointPattern": "skills/<name>/SKILL.md",
+    "requiredEntrypoint": "skills/camunda-bpmn/SKILL.md",
+    "sidecarPattern": "skills/<name>/portability.json",
+    "discoveryResultField": "discovered"
+  },
+  "activation": {
+    "fixturePath": "compatibility/fixtures/camunda-bpmn-smoke.json",
+    "skillNameField": "skillName",
+    "promptField": "prompt",
+    "activationResultField": "activated"
+  },
+  "resultAssertions": {
+    "required": {
+      "discovered": true,
+      "activated": true
+    },
+    "artifact": {
+      "path": "process.bpmn",
+      "required": true
+    },
+    "toolCall": {
+      "command": "c8ctl bpmn lint process.bpmn",
+      "match": "exact",
+      "required": true
+    }
+  },
+  "adapters": {
+    "deterministicMocks": {
+      "required": true,
+      "networkAccess": false,
+      "credentialsRequired": false,
+      "modelOutputRequired": false,
+      "entryPoints": {
+        "claude": "mock-claude",
+        "copilot": "mock-copilot"
+      },
+      "passCondition": "Both entry points satisfy every resultAssertions field."
+    },
+    "liveCopilot": {
+      "optional": true,
+      "optIn": "Explicit workflow dispatch or documented live-integration opt-in.",
+      "allowedResults": ["passed", "failed", "skipped", "unavailable"],
+      "unavailableBehavior": "Report skipped or unavailable explicitly; never count it as a deterministic mock pass."
+    }
+  }
+}

--- a/compatibility/harness-smoke-contract.json
+++ b/compatibility/harness-smoke-contract.json
@@ -44,7 +44,7 @@
         "claude": "compatibility/adapters/mock-claude",
         "copilot": "compatibility/adapters/mock-copilot"
       },
-      "passCondition": "Both entry points emit process.bpmn, validate it as BPMN, execute c8ctl bpmn lint process.bpmn, and report exit code 0."
+      "passCondition": "Both entry points run the shared contract fixture: each emits process.bpmn, validates it as BPMN, executes c8ctl bpmn lint process.bpmn, and reports exit code 0. This is shared contract-fixture coverage, not independent per-harness implementation coverage."
     },
     "liveCopilot": {
       "optional": true,

--- a/compatibility/harness-smoke-contract.schema.json
+++ b/compatibility/harness-smoke-contract.schema.json
@@ -117,7 +117,7 @@
         "artifact": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["path", "required"],
+          "required": ["path", "required", "mustExist", "mustBeValid"],
           "properties": {
             "path": {
               "type": "string",
@@ -125,13 +125,19 @@
             },
             "required": {
               "const": true
+            },
+            "mustExist": {
+              "const": true
+            },
+            "mustBeValid": {
+              "const": true
             }
           }
         },
         "toolCall": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["command", "match", "required"],
+          "required": ["command", "match", "required", "mustExecute", "mustSucceed"],
           "properties": {
             "command": {
               "type": "string",
@@ -142,6 +148,12 @@
               "const": "exact"
             },
             "required": {
+              "const": true
+            },
+            "mustExecute": {
+              "const": true
+            },
+            "mustSucceed": {
               "const": true
             }
           }
@@ -184,11 +196,11 @@
               "properties": {
                 "claude": {
                   "type": "string",
-                  "const": "mock-claude"
+                  "const": "compatibility/adapters/mock-claude"
                 },
                 "copilot": {
                   "type": "string",
-                  "const": "mock-copilot"
+                  "const": "compatibility/adapters/mock-copilot"
                 }
               }
             },

--- a/compatibility/harness-smoke-contract.schema.json
+++ b/compatibility/harness-smoke-contract.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/camunda/skills/compatibility/harness-smoke-contract.schema.json",
+  "title": "Camunda harness smoke contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "contractId",
+    "discovery",
+    "activation",
+    "resultAssertions",
+    "adapters"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "./harness-smoke-contract.schema.json"
+    },
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "contractId": {
+      "type": "string",
+      "const": "camunda-skills-harness-smoke-v1"
+    },
+    "discovery": {
+      "$ref": "#/$defs/discovery"
+    },
+    "activation": {
+      "$ref": "#/$defs/activation"
+    },
+    "resultAssertions": {
+      "$ref": "#/$defs/resultAssertions"
+    },
+    "adapters": {
+      "$ref": "#/$defs/adapters"
+    }
+  },
+  "$defs": {
+    "discovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repositoryRoot",
+        "skillEntrypointPattern",
+        "requiredEntrypoint",
+        "sidecarPattern",
+        "discoveryResultField"
+      ],
+      "properties": {
+        "repositoryRoot": {
+          "type": "string",
+          "const": "."
+        },
+        "skillEntrypointPattern": {
+          "type": "string",
+          "const": "skills/<name>/SKILL.md"
+        },
+        "requiredEntrypoint": {
+          "type": "string",
+          "const": "skills/camunda-bpmn/SKILL.md"
+        },
+        "sidecarPattern": {
+          "type": "string",
+          "const": "skills/<name>/portability.json"
+        },
+        "discoveryResultField": {
+          "type": "string",
+          "const": "discovered"
+        }
+      }
+    },
+    "activation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fixturePath", "skillNameField", "promptField", "activationResultField"],
+      "properties": {
+        "fixturePath": {
+          "type": "string",
+          "const": "compatibility/fixtures/camunda-bpmn-smoke.json"
+        },
+        "skillNameField": {
+          "type": "string",
+          "const": "skillName"
+        },
+        "promptField": {
+          "type": "string",
+          "const": "prompt"
+        },
+        "activationResultField": {
+          "type": "string",
+          "const": "activated"
+        }
+      }
+    },
+    "resultAssertions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "artifact", "toolCall"],
+      "properties": {
+        "required": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["discovered", "activated"],
+          "properties": {
+            "discovered": {
+              "const": true
+            },
+            "activated": {
+              "const": true
+            }
+          }
+        },
+        "artifact": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path", "required"],
+          "properties": {
+            "path": {
+              "type": "string",
+              "const": "process.bpmn"
+            },
+            "required": {
+              "const": true
+            }
+          }
+        },
+        "toolCall": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["command", "match", "required"],
+          "properties": {
+            "command": {
+              "type": "string",
+              "const": "c8ctl bpmn lint process.bpmn"
+            },
+            "match": {
+              "type": "string",
+              "const": "exact"
+            },
+            "required": {
+              "const": true
+            }
+          }
+        }
+      }
+    },
+    "adapters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["deterministicMocks", "liveCopilot"],
+      "properties": {
+        "deterministicMocks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "required",
+            "networkAccess",
+            "credentialsRequired",
+            "modelOutputRequired",
+            "entryPoints",
+            "passCondition"
+          ],
+          "properties": {
+            "required": {
+              "const": true
+            },
+            "networkAccess": {
+              "const": false
+            },
+            "credentialsRequired": {
+              "const": false
+            },
+            "modelOutputRequired": {
+              "const": false
+            },
+            "entryPoints": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["claude", "copilot"],
+              "properties": {
+                "claude": {
+                  "type": "string",
+                  "const": "mock-claude"
+                },
+                "copilot": {
+                  "type": "string",
+                  "const": "mock-copilot"
+                }
+              }
+            },
+            "passCondition": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "liveCopilot": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["optional", "optIn", "allowedResults", "unavailableBehavior"],
+          "properties": {
+            "optional": {
+              "const": true
+            },
+            "optIn": {
+              "type": "string",
+              "minLength": 1
+            },
+            "allowedResults": {
+              "type": "array",
+              "uniqueItems": true,
+              "const": ["passed", "failed", "skipped", "unavailable"]
+            },
+            "unavailableBehavior": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/compatibility/harness-smoke-fixture.schema.json
+++ b/compatibility/harness-smoke-fixture.schema.json
@@ -25,7 +25,17 @@
     "expected": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["discovered", "activated", "artifact", "toolCommand"],
+      "required": [
+        "discovered",
+        "activated",
+        "artifact",
+        "artifactSource",
+        "artifactExists",
+        "artifactValid",
+        "toolCommand",
+        "toolExecuted",
+        "toolSucceeded"
+      ],
       "properties": {
         "discovered": {
           "const": true
@@ -37,9 +47,25 @@
           "type": "string",
           "const": "process.bpmn"
         },
+        "artifactSource": {
+          "type": "string",
+          "const": "compatibility/fixtures/process.bpmn"
+        },
+        "artifactExists": {
+          "const": true
+        },
+        "artifactValid": {
+          "const": true
+        },
         "toolCommand": {
           "type": "string",
           "const": "c8ctl bpmn lint process.bpmn"
+        },
+        "toolExecuted": {
+          "const": true
+        },
+        "toolSucceeded": {
+          "const": true
         }
       }
     }

--- a/compatibility/harness-smoke-fixture.schema.json
+++ b/compatibility/harness-smoke-fixture.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/camunda/skills/compatibility/harness-smoke-fixture.schema.json",
+  "title": "Camunda harness smoke fixture",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "fixtureId", "skillName", "prompt", "expected"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "../harness-smoke-fixture.schema.json"
+    },
+    "fixtureId": {
+      "type": "string",
+      "const": "camunda-bpmn-basic"
+    },
+    "skillName": {
+      "type": "string",
+      "const": "camunda-bpmn"
+    },
+    "prompt": {
+      "type": "string",
+      "const": "Create a minimal Camunda 8 process in process.bpmn and validate it."
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["discovered", "activated", "artifact", "toolCommand"],
+      "properties": {
+        "discovered": {
+          "const": true
+        },
+        "activated": {
+          "const": true
+        },
+        "artifact": {
+          "type": "string",
+          "const": "process.bpmn"
+        },
+        "toolCommand": {
+          "type": "string",
+          "const": "c8ctl bpmn lint process.bpmn"
+        }
+      }
+    }
+  }
+}

--- a/compatibility/portability-contract.md
+++ b/compatibility/portability-contract.md
@@ -10,7 +10,7 @@ parallel compatibility metadata.
 ## Contract authority and scope
 
 The external format authority is the [Agent Skills specification](https://agentskills.io/specification).
-The canonical URL is repeated in every machine-readable artifact as
+The canonical URL is repeated in the inventory, audit, and portability declarations as
 `https://agentskills.io/specification`. The current audit baseline is
 `2026-09-11`; it is represented by `specRevisionOrAuditDate` until a named
 specification revision is available.
@@ -170,6 +170,10 @@ separate, opt-in integration. Its result must be explicitly `passed`, `failed`,
 `skipped`, or `unavailable`; `skipped` and `unavailable` are reported outcomes
 and never count as a mock pass. An unavailable live integration must not be
 converted into success by a catch-all fallback.
+Before activation, each adapter reads the required `SKILL.md`, validates its
+frontmatter name and description, and confirms that it declares the required
+BPMN lint command. This prevents path-only discovery from being reported as
+activation.
 
 ## Conformance and smoke commands
 
@@ -201,6 +205,7 @@ deterministic generic equivalent:
 
 ```json
 {
+  "$schema": "../../compatibility/portability.schema.json",
   "skillDirectory": "skills/example",
   "skillName": "example",
   "status": "harness-specific",

--- a/compatibility/portability-contract.md
+++ b/compatibility/portability-contract.md
@@ -184,8 +184,11 @@ make compatibility-check
 ```
 
 The conformance checker validates the inventory, audit, sidecar, schema-shape,
-and filesystem relationships. The two deterministic adapters then validate
-the artifact and execute the required command independently.
+and filesystem relationships. It emits one `Compatibility skill <name>:
+passed` or `failed` record for every discovered skill before the aggregate
+result. The two deterministic adapters then validate the artifact and execute
+the required command independently; each smoke result retains its `adapter`
+harness name.
 
 ## Examples
 

--- a/compatibility/portability-contract.md
+++ b/compatibility/portability-contract.md
@@ -165,14 +165,18 @@ interaction boundary:
 5. Execute the exact tool command `c8ctl bpmn lint process.bpmn` and require a
    successful result.
 
-The Claude and GitHub Copilot deterministic mock adapters are separate entry
+The Claude and GitHub Copilot deterministic mock commands are separate entry
 points at `compatibility/adapters/mock-claude` and
-`compatibility/adapters/mock-copilot`. Both produce the same assertion shape
+`compatibility/adapters/mock-copilot` into one shared contract fixture. They
+intentionally do not emulate independent harness implementations or
+per-harness discovery and tool mappings. Both produce the same assertion shape
 without credentials, network calls, or model output. They materialize the
 checked-in `compatibility/fixtures/process.bpmn`, validate the emitted copy,
 and execute the contract command through the local deterministic
-`compatibility/adapters/c8ctl` shim. A deterministic mock pass is required PR
-evidence and is enforced by `make compatibility-check` and
+`compatibility/adapters/c8ctl` shim. These are shared contract-fixture smoke
+checks, not independent per-harness implementation coverage; harness-specific
+behavior requires dedicated integration tests. A deterministic mock pass is
+required PR evidence and is enforced by `make compatibility-check` and
 `.github/workflows/compatibility.yml`. Live GitHub Copilot execution is a
 separate, opt-in integration. Its result must be explicitly `passed`, `failed`,
 `skipped`, or `unavailable`; `skipped` and `unavailable` are reported outcomes

--- a/compatibility/portability-contract.md
+++ b/compatibility/portability-contract.md
@@ -139,6 +139,9 @@ each current skill exactly once and records:
 - `sidecar`: the repository-relative portability declaration;
 - `status`: the same repository status as the sidecar.
 
+The reserved skill names `claude` and `anthropic` cannot be used for an
+inventory entry, sidecar, or skill directory.
+
 `compatibility/audit.json` is the dated audit record. It repeats the canonical
 specification URL, `specRevisionOrAuditDate`, `auditDate`, and the complete
 skill list with the same name, paths, and status values. The index and audit

--- a/compatibility/portability-contract.md
+++ b/compatibility/portability-contract.md
@@ -1,0 +1,207 @@
+# Skills portability contract
+
+This directory is the contract surface for running the skills in this repository
+with Claude Code, GitHub Copilot, and other Agent Skills-compatible runtimes.
+The contract is intentionally separate from the user documentation, skill
+instructions, behavioural evaluations, and CI implementation. Those consumers
+must use the names, paths, and semantics defined here instead of defining
+parallel compatibility metadata.
+
+## Contract authority and scope
+
+The external format authority is the [Agent Skills specification](https://agentskills.io/specification).
+The canonical URL is repeated in every machine-readable artifact as
+`https://agentskills.io/specification`. The current audit baseline is
+`2026-09-11`; it is represented by `specRevisionOrAuditDate` until a named
+specification revision is available.
+
+The specification defines the portable skill package and its `SKILL.md`
+metadata. This repository policy defines the following additional compatibility
+surface:
+
+| Field or behavior | Authority |
+| --- | --- |
+| `skills/<name>/SKILL.md` package layout, `name`, `description`, and supported frontmatter | Agent Skills specification |
+| `skillDirectory`, `skillName`, `status`, `agentSkillsSpec`, `harnesses`, `limitations`, and `differences` in `portability.json` | Repository policy |
+| `skills-index.json`, `audit.json`, and their cross-file consistency rules | Repository policy |
+| Discovery, activation fixture, result assertions, adapter modes, and live-integration reporting | Repository policy |
+
+Do not add portability fields to `SKILL.md` frontmatter. Portability belongs in
+the sidecar described below.
+
+## Ownership boundaries
+
+This wave defines the contract and seed inventories. Later changes must keep
+these ownership boundaries:
+
+- `compatibility/portability-contract.md` is the normative human-readable
+  contract.
+- `compatibility/portability.schema.json` validates each
+  `skills/<skill>/portability.json` sidecar.
+- `compatibility/skills-index.json` is the complete inventory of skills,
+  entrypoints, sidecars, and repository-level statuses.
+- `compatibility/audit.json` records the dated audit and the same complete skill
+  set.
+- `compatibility/harness-smoke-contract.json` defines the adapter boundary and
+  assertions.
+- `compatibility/fixtures/camunda-bpmn-smoke.json` is the fixed checked-in
+  smoke fixture consumed by both deterministic adapters.
+- The conformance checker is responsible for filesystem and cross-file checks:
+  missing skills, duplicate names, stale paths, and mismatched sidecar,
+  inventory, and audit values are failures.
+
+The contract does not prescribe where a harness installs a skill or how its
+adapter is implemented. It does prescribe the repository-relative discovery
+path and the observable smoke result.
+
+## Per-skill portability declaration
+
+Every skill directory must contain `portability.json` at
+`skills/<skillName>/portability.json`. It must validate against
+`compatibility/portability.schema.json` and contain exactly these top-level
+fields:
+
+```json
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-bpmn",
+  "skillName": "camunda-bpmn",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps the c8ctl command to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies discovery and tool invocation adapters."]
+    }
+  },
+  "limitations": ["A Camunda 8 cluster is required for live c8ctl operations."],
+  "differences": ["Tool names and credential setup can vary by harness."]
+}
+```
+### Repository status enum
+
+`status` describes the skill as a repository artifact, not the result of one
+smoke run:
+
+- `portable`: the package and behavior use the common Agent Skills contract
+  without a harness-specific adapter.
+- `portable-with-adapter`: the skill package is portable, but a documented
+  adapter is required for one or more harness tool, credential, or invocation
+  differences.
+- `harness-specific`: a documented behavior cannot currently be represented by
+  the common contract. The sidecar must identify the exception and the usable
+  portable path, if one exists.
+
+### Harness status enum
+
+Each of `harnesses.claude`, `harnesses.copilot`, and
+`harnesses.generic` is required and has a `status` plus at least one concrete
+`differences` entry. The allowed statuses are:
+
+- `native`: the harness can discover and invoke the skill without a
+  compatibility adapter.
+- `adapter-required`: the skill is usable after the repository or host maps a
+  documented harness difference.
+- `unsupported`: the skill is not usable in that harness under the current
+  contract; `differences` must explain the blocking behavior.
+- `not-tested`: no compatibility claim is made yet; `differences` must state
+  what remains unverified. This status is not a successful smoke result.
+
+`limitations` and the top-level `differences` list are mandatory, even when a
+skill is `portable`. They must contain concrete behavior, setup, or support
+constraints rather than generic text.
+
+## Repository inventory and audit
+
+`compatibility/skills-index.json` is the machine-readable inventory. It lists
+each current skill exactly once and records:
+
+- `name`: the skill name and `SKILL.md` frontmatter name;
+- `skillDirectory`: the repository-relative skill directory;
+- `skillMarkdown`: the repository-relative entrypoint;
+- `sidecar`: the repository-relative portability declaration;
+- `status`: the same repository status as the sidecar.
+
+`compatibility/audit.json` is the dated audit record. It repeats the canonical
+specification URL, `specRevisionOrAuditDate`, `auditDate`, and the complete
+skill list with the same name, paths, and status values. The index and audit
+must agree with every sidecar. A checker must reject omitted skills, duplicate
+names, paths that do not resolve to the expected files, and status or
+specification-date mismatches. The seed files in this wave enumerate all
+current skills; the content-audit wave supplies and verifies each sidecar.
+
+## Harness smoke boundary
+
+The contract in `harness-smoke-contract.json` and the checked-in fixture at
+`compatibility/fixtures/camunda-bpmn-smoke.json` define one deterministic
+interaction boundary:
+
+1. Discover `skills/camunda-bpmn/SKILL.md` from the repository root.
+2. Activate `camunda-bpmn` with the fixture's fixed prompt.
+3. Report `discovered: true` and `activated: true`.
+4. Emit an artifact named exactly `process.bpmn`.
+5. Record the exact tool command `c8ctl bpmn lint process.bpmn`.
+
+The Claude and GitHub Copilot deterministic mock adapters are separate entry
+points, but both must produce the same assertion shape without credentials,
+network calls, or model output. A deterministic mock pass is required PR
+evidence. Live GitHub Copilot execution is a separate, opt-in integration. Its
+result must be explicitly `passed`, `failed`, `skipped`, or `unavailable`;
+`skipped` and `unavailable` are reported outcomes and never count as a mock
+pass. An unavailable live integration must not be converted into success by a
+catch-all fallback.
+
+## Examples
+
+### Portable skill with an adapter
+
+`camunda-bpmn` can be `portable-with-adapter` when all three harness entries
+can load the same package, but Copilot and generic hosts need a mapping from
+the skill's c8ctl command to their tool surface. The sidecar keeps that
+difference in `harnesses.copilot.differences` and
+`harnesses.generic.differences`; it does not change `SKILL.md` frontmatter.
+
+### Harness-specific exception
+
+A skill with `"status": "harness-specific"` must identify the unsupported
+operation, for example a Claude-only interactive feature that has no
+deterministic generic equivalent:
+
+```json
+{
+  "skillDirectory": "skills/example",
+  "skillName": "example",
+  "status": "harness-specific",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Supports the interactive operation."]
+    },
+    "copilot": {
+      "status": "unsupported",
+      "differences": ["The operation has no Copilot adapter."]
+    },
+    "generic": {
+      "status": "unsupported",
+      "differences": ["The operation requires a host capability not in this contract."]
+    }
+  },
+  "limitations": ["Use the documented non-interactive path when available."],
+  "differences": ["Interactive operation support differs by harness."]
+}
+```

--- a/compatibility/portability-contract.md
+++ b/compatibility/portability-contract.md
@@ -64,7 +64,7 @@ fields:
 
 ```json
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-bpmn",
   "skillName": "camunda-bpmn",
   "status": "portable-with-adapter",
@@ -205,7 +205,7 @@ deterministic generic equivalent:
 
 ```json
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/example",
   "skillName": "example",
   "status": "harness-specific",

--- a/compatibility/portability-contract.md
+++ b/compatibility/portability-contract.md
@@ -104,6 +104,11 @@ smoke run:
   the common contract. The sidecar must identify the exception and the usable
   portable path, if one exists.
 
+The checker requires every `portable` sidecar to declare only `native`
+harnesses, every `portable-with-adapter` sidecar to declare at least one
+`adapter-required` harness, and every `harness-specific` sidecar to declare at
+least one `unsupported` harness.
+
 ### Harness status enum
 
 Each of `harnesses.claude`, `harnesses.copilot`, and

--- a/compatibility/portability-contract.md
+++ b/compatibility/portability-contract.md
@@ -46,7 +46,8 @@ these ownership boundaries:
   assertions.
 - `compatibility/fixtures/camunda-bpmn-smoke.json` is the fixed checked-in
   smoke fixture consumed by both deterministic adapters.
-- The conformance checker is responsible for filesystem and cross-file checks:
+- `compatibility/check.py` is the conformance checker and is responsible for
+  filesystem and cross-file checks:
   missing skills, duplicate names, stale paths, and mismatched sidecar,
   inventory, and audit values are failures.
 
@@ -138,8 +139,9 @@ specification URL, `specRevisionOrAuditDate`, `auditDate`, and the complete
 skill list with the same name, paths, and status values. The index and audit
 must agree with every sidecar. A checker must reject omitted skills, duplicate
 names, paths that do not resolve to the expected files, and status or
-specification-date mismatches. The seed files in this wave enumerate all
-current skills; the content-audit wave supplies and verifies each sidecar.
+specification-date mismatches. The checked-in sidecars are part of this
+contract, so the checker also rejects a skill directory without a sidecar or a
+sidecar that is not represented in both inventories.
 
 ## Harness smoke boundary
 
@@ -150,17 +152,36 @@ interaction boundary:
 1. Discover `skills/camunda-bpmn/SKILL.md` from the repository root.
 2. Activate `camunda-bpmn` with the fixture's fixed prompt.
 3. Report `discovered: true` and `activated: true`.
-4. Emit an artifact named exactly `process.bpmn`.
-5. Record the exact tool command `c8ctl bpmn lint process.bpmn`.
+4. Emit an artifact named exactly `process.bpmn`, and require that it exists
+   and is valid BPMN.
+5. Execute the exact tool command `c8ctl bpmn lint process.bpmn` and require a
+   successful result.
 
 The Claude and GitHub Copilot deterministic mock adapters are separate entry
-points, but both must produce the same assertion shape without credentials,
-network calls, or model output. A deterministic mock pass is required PR
-evidence. Live GitHub Copilot execution is a separate, opt-in integration. Its
-result must be explicitly `passed`, `failed`, `skipped`, or `unavailable`;
-`skipped` and `unavailable` are reported outcomes and never count as a mock
-pass. An unavailable live integration must not be converted into success by a
-catch-all fallback.
+points at `compatibility/adapters/mock-claude` and
+`compatibility/adapters/mock-copilot`. Both produce the same assertion shape
+without credentials, network calls, or model output. They materialize the
+checked-in `compatibility/fixtures/process.bpmn`, validate the emitted copy,
+and execute the contract command through the local deterministic
+`compatibility/adapters/c8ctl` shim. A deterministic mock pass is required PR
+evidence and is enforced by `make compatibility-check` and
+`.github/workflows/compatibility.yml`. Live GitHub Copilot execution is a
+separate, opt-in integration. Its result must be explicitly `passed`, `failed`,
+`skipped`, or `unavailable`; `skipped` and `unavailable` are reported outcomes
+and never count as a mock pass. An unavailable live integration must not be
+converted into success by a catch-all fallback.
+
+## Conformance and smoke commands
+
+Run the complete local gate from the repository root:
+
+```bash
+make compatibility-check
+```
+
+The conformance checker validates the inventory, audit, sidecar, schema-shape,
+and filesystem relationships. The two deterministic adapters then validate
+the artifact and execute the required command independently.
 
 ## Examples
 

--- a/compatibility/portability.schema.json
+++ b/compatibility/portability.schema.json
@@ -21,11 +21,17 @@
     },
     "skillDirectory": {
       "type": "string",
+      "not": {
+        "enum": ["skills/anthropic", "skills/claude"]
+      },
       "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*$"
     },
     "skillName": {
       "type": "string",
       "maxLength": 64,
+      "not": {
+        "enum": ["anthropic", "claude"]
+      },
       "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
     },
     "status": {

--- a/compatibility/portability.schema.json
+++ b/compatibility/portability.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/camunda/skills/compatibility/portability.schema.json",
+  "title": "Camunda skill portability declaration",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "skillDirectory",
+    "skillName",
+    "status",
+    "agentSkillsSpec",
+    "harnesses",
+    "limitations",
+    "differences"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "../../compatibility/portability.schema.json"
+    },
+    "skillDirectory": {
+      "type": "string",
+      "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "skillName": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["portable", "portable-with-adapter", "harness-specific"]
+    },
+    "agentSkillsSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["specUrl", "specRevisionOrAuditDate"],
+      "properties": {
+        "specUrl": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://agentskills.io/specification"
+        },
+        "specRevisionOrAuditDate": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "harnesses": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["claude", "copilot", "generic"],
+      "properties": {
+        "claude": {
+          "$ref": "#/$defs/harnessDeclaration"
+        },
+        "copilot": {
+          "$ref": "#/$defs/harnessDeclaration"
+        },
+        "generic": {
+          "$ref": "#/$defs/harnessDeclaration"
+        }
+      }
+    },
+    "limitations": {
+      "$ref": "#/$defs/nonEmptyStringList"
+    },
+    "differences": {
+      "$ref": "#/$defs/nonEmptyStringList"
+    }
+  },
+  "$defs": {
+    "harnessDeclaration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "differences"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["native", "adapter-required", "unsupported", "not-tested"]
+        },
+        "differences": {
+          "$ref": "#/$defs/nonEmptyStringList"
+        }
+      }
+    },
+    "nonEmptyStringList": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/compatibility/portability.schema.json
+++ b/compatibility/portability.schema.json
@@ -25,6 +25,7 @@
     },
     "skillName": {
       "type": "string",
+      "maxLength": 64,
       "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
     },
     "status": {

--- a/compatibility/portability.schema.json
+++ b/compatibility/portability.schema.json
@@ -17,7 +17,7 @@
   "properties": {
     "$schema": {
       "type": "string",
-      "const": "../../compatibility/portability.schema.json"
+      "const": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json"
     },
     "skillDirectory": {
       "type": "string",

--- a/compatibility/skills-index.json
+++ b/compatibility/skills-index.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "./skills-index.schema.json",
+  "schemaVersion": 1,
+  "specUrl": "https://agentskills.io/specification",
+  "specRevisionOrAuditDate": "2026-09-11",
+  "skills": [
+    {
+      "name": "camunda-ai-agents",
+      "skillDirectory": "skills/camunda-ai-agents",
+      "skillMarkdown": "skills/camunda-ai-agents/SKILL.md",
+      "sidecar": "skills/camunda-ai-agents/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-bpmn",
+      "skillDirectory": "skills/camunda-bpmn",
+      "skillMarkdown": "skills/camunda-bpmn/SKILL.md",
+      "sidecar": "skills/camunda-bpmn/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-c8ctl",
+      "skillDirectory": "skills/camunda-c8ctl",
+      "skillMarkdown": "skills/camunda-c8ctl/SKILL.md",
+      "sidecar": "skills/camunda-c8ctl/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-connectors",
+      "skillDirectory": "skills/camunda-connectors",
+      "skillMarkdown": "skills/camunda-connectors/SKILL.md",
+      "sidecar": "skills/camunda-connectors/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-connectors-development",
+      "skillDirectory": "skills/camunda-connectors-development",
+      "skillMarkdown": "skills/camunda-connectors-development/SKILL.md",
+      "sidecar": "skills/camunda-connectors-development/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-development",
+      "skillDirectory": "skills/camunda-development",
+      "skillMarkdown": "skills/camunda-development/SKILL.md",
+      "sidecar": "skills/camunda-development/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-dmn",
+      "skillDirectory": "skills/camunda-dmn",
+      "skillMarkdown": "skills/camunda-dmn/SKILL.md",
+      "sidecar": "skills/camunda-dmn/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-docs",
+      "skillDirectory": "skills/camunda-docs",
+      "skillMarkdown": "skills/camunda-docs/SKILL.md",
+      "sidecar": "skills/camunda-docs/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-feel",
+      "skillDirectory": "skills/camunda-feel",
+      "skillMarkdown": "skills/camunda-feel/SKILL.md",
+      "sidecar": "skills/camunda-feel/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-forms",
+      "skillDirectory": "skills/camunda-forms",
+      "skillMarkdown": "skills/camunda-forms/SKILL.md",
+      "sidecar": "skills/camunda-forms/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-job-workers",
+      "skillDirectory": "skills/camunda-job-workers",
+      "skillMarkdown": "skills/camunda-job-workers/SKILL.md",
+      "sidecar": "skills/camunda-job-workers/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-process-mgmt",
+      "skillDirectory": "skills/camunda-process-mgmt",
+      "skillMarkdown": "skills/camunda-process-mgmt/SKILL.md",
+      "sidecar": "skills/camunda-process-mgmt/portability.json",
+      "status": "portable-with-adapter"
+    },
+    {
+      "name": "camunda-process-test",
+      "skillDirectory": "skills/camunda-process-test",
+      "skillMarkdown": "skills/camunda-process-test/SKILL.md",
+      "sidecar": "skills/camunda-process-test/portability.json",
+      "status": "portable-with-adapter"
+    }
+  ]
+}

--- a/compatibility/skills-index.schema.json
+++ b/compatibility/skills-index.schema.json
@@ -40,6 +40,7 @@
       "properties": {
         "name": {
           "type": "string",
+          "maxLength": 64,
           "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
         },
         "skillDirectory": {

--- a/compatibility/skills-index.schema.json
+++ b/compatibility/skills-index.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/camunda/skills/compatibility/skills-index.schema.json",
+  "title": "Camunda skills portability inventory",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schemaVersion", "specUrl", "specRevisionOrAuditDate", "skills"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "./skills-index.schema.json"
+    },
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "specUrl": {
+      "type": "string",
+      "format": "uri",
+      "const": "https://agentskills.io/specification"
+    },
+    "specRevisionOrAuditDate": {
+      "type": "string",
+      "minLength": 1
+    },
+    "skills": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/skillInventoryEntry"
+      }
+    }
+  },
+  "$defs": {
+    "skillInventoryEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "skillDirectory", "skillMarkdown", "sidecar", "status"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "skillDirectory": {
+          "type": "string",
+          "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "skillMarkdown": {
+          "type": "string",
+          "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*/SKILL\\.md$"
+        },
+        "sidecar": {
+          "type": "string",
+          "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*/portability\\.json$"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["portable", "portable-with-adapter", "harness-specific"]
+        }
+      }
+    }
+  }
+}

--- a/compatibility/skills-index.schema.json
+++ b/compatibility/skills-index.schema.json
@@ -41,18 +41,36 @@
         "name": {
           "type": "string",
           "maxLength": 64,
+          "not": {
+            "enum": ["anthropic", "claude"]
+          },
           "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
         },
         "skillDirectory": {
           "type": "string",
+          "not": {
+            "enum": ["skills/anthropic", "skills/claude"]
+          },
           "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*$"
         },
         "skillMarkdown": {
           "type": "string",
+          "not": {
+            "enum": [
+              "skills/anthropic/SKILL.md",
+              "skills/claude/SKILL.md"
+            ]
+          },
           "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*/SKILL\\.md$"
         },
         "sidecar": {
           "type": "string",
+          "not": {
+            "enum": [
+              "skills/anthropic/portability.json",
+              "skills/claude/portability.json"
+            ]
+          },
           "pattern": "^skills/[a-z0-9]+(?:-[a-z0-9]+)*/portability\\.json$"
         },
         "status": {

--- a/compatibility/test_bpmn_lint.py
+++ b/compatibility/test_bpmn_lint.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pytest
+
+from adapters.bpmn_lint import validate_bpmn
+
+
+FIXTURE = Path(__file__).with_name("fixtures") / "process.bpmn"
+
+
+def copy_fixture(tmp_path: Path) -> Path:
+    artifact = tmp_path / "process.bpmn"
+    artifact.write_text(FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    return artifact
+
+
+def test_rejects_flow_nodes_with_dangling_references(tmp_path: Path) -> None:
+    artifact = copy_fixture(tmp_path)
+    content = artifact.read_text(encoding="utf-8").replace(
+        "<bpmn:incoming>Flow_1</bpmn:incoming>",
+        "<bpmn:incoming>Missing</bpmn:incoming>",
+        1,
+    )
+    artifact.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="incoming references"):
+        validate_bpmn(artifact)
+
+
+def test_rejects_unsupported_process_elements(tmp_path: Path) -> None:
+    artifact = copy_fixture(tmp_path)
+    content = artifact.read_text(encoding="utf-8").replace(
+        '    <bpmn:sequenceFlow id="Flow_1"',
+        '    <bpmn:bogus id="Bogus" name="Bogus" />\n'
+        '    <bpmn:sequenceFlow id="Flow_1"',
+        1,
+    )
+    artifact.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unsupported process element"):
+        validate_bpmn(artifact)

--- a/compatibility/test_bpmn_lint.py
+++ b/compatibility/test_bpmn_lint.py
@@ -27,6 +27,52 @@ def test_rejects_flow_nodes_with_dangling_references(tmp_path: Path) -> None:
         validate_bpmn(artifact)
 
 
+def test_rejects_start_events_with_incoming_flows(tmp_path: Path) -> None:
+    artifact = copy_fixture(tmp_path)
+    content = artifact.read_text(encoding="utf-8").replace(
+        '    <bpmn:startEvent id="StartEvent_1" name="Start process">\n',
+        '    <bpmn:startEvent id="StartEvent_1" name="Start process">\n'
+        "      <bpmn:incoming>Flow_2</bpmn:incoming>\n",
+        1,
+    ).replace(
+        "      <bpmn:incoming>Flow_1</bpmn:incoming>\n"
+        "    </bpmn:endEvent>",
+        "      <bpmn:incoming>Flow_1</bpmn:incoming>\n"
+        "      <bpmn:outgoing>Flow_2</bpmn:outgoing>\n"
+        "    </bpmn:endEvent>",
+        1,
+    ).replace(
+        '    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />\n',
+        '    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />\n'
+        '    <bpmn:sequenceFlow id="Flow_2" sourceRef="EndEvent_1" targetRef="StartEvent_1" />\n',
+        1,
+    )
+    artifact.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="start event .*incoming"):
+        validate_bpmn(artifact)
+
+
+def test_rejects_end_events_with_outgoing_flows(tmp_path: Path) -> None:
+    artifact = copy_fixture(tmp_path)
+    content = artifact.read_text(encoding="utf-8").replace(
+        '      <bpmn:incoming>Flow_1</bpmn:incoming>\n',
+        '      <bpmn:incoming>Flow_1</bpmn:incoming>\n'
+        "      <bpmn:incoming>Flow_2</bpmn:incoming>\n"
+        "      <bpmn:outgoing>Flow_2</bpmn:outgoing>\n",
+        1,
+    ).replace(
+        '    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />\n',
+        '    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />\n'
+        '    <bpmn:sequenceFlow id="Flow_2" sourceRef="EndEvent_1" targetRef="EndEvent_1" />\n',
+        1,
+    )
+    artifact.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="end event .*outgoing"):
+        validate_bpmn(artifact)
+
+
 def test_rejects_unsupported_process_elements(tmp_path: Path) -> None:
     artifact = copy_fixture(tmp_path)
     content = artifact.read_text(encoding="utf-8").replace(

--- a/compatibility/test_bpmn_lint.py
+++ b/compatibility/test_bpmn_lint.py
@@ -41,6 +41,36 @@ def test_rejects_unsupported_process_elements(tmp_path: Path) -> None:
         validate_bpmn(artifact)
 
 
+def test_rejects_nested_flow_containers_until_they_are_supported(tmp_path: Path) -> None:
+    artifact = copy_fixture(tmp_path)
+    content = artifact.read_text(encoding="utf-8").replace(
+        '    <bpmn:startEvent id="StartEvent_1"',
+        '    <bpmn:subProcess id="Nested_1" />\n'
+        '    <bpmn:startEvent id="StartEvent_1"',
+        1,
+    )
+    artifact.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unsupported process element"):
+        validate_bpmn(artifact)
+
+
+def test_allows_flow_nodes_without_names(tmp_path: Path) -> None:
+    artifact = copy_fixture(tmp_path)
+    content = artifact.read_text(encoding="utf-8").replace(
+        ' name="Start process"',
+        "",
+        1,
+    ).replace(
+        ' name="End process"',
+        "",
+        1,
+    )
+    artifact.write_text(content, encoding="utf-8")
+
+    validate_bpmn(artifact)
+
+
 def test_rejects_elements_reusing_definitions_id(tmp_path: Path) -> None:
     artifact = copy_fixture(tmp_path)
     content = artifact.read_text(encoding="utf-8").replace(

--- a/compatibility/test_bpmn_lint.py
+++ b/compatibility/test_bpmn_lint.py
@@ -39,3 +39,16 @@ def test_rejects_unsupported_process_elements(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="unsupported process element"):
         validate_bpmn(artifact)
+
+
+def test_rejects_elements_reusing_definitions_id(tmp_path: Path) -> None:
+    artifact = copy_fixture(tmp_path)
+    content = artifact.read_text(encoding="utf-8").replace(
+        'id="StartEvent_1"',
+        'id="Definitions_1"',
+        1,
+    )
+    artifact.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate BPMN id"):
+        validate_bpmn(artifact)

--- a/compatibility/test_check.py
+++ b/compatibility/test_check.py
@@ -83,3 +83,11 @@ def test_rejects_sidecar_skill_name_mismatch(tmp_path: Path) -> None:
     write_json(path, sidecar)
 
     assert check.main(["--root", str(root)]) == 1
+
+
+def test_rejects_invalid_utf8_json(tmp_path: Path) -> None:
+    root = copy_contract_root(tmp_path)
+    path = root / "compatibility" / "skills-index.json"
+    path.write_bytes(b"\xff")
+
+    assert check.main(["--root", str(root)]) == 1

--- a/compatibility/test_check.py
+++ b/compatibility/test_check.py
@@ -73,6 +73,20 @@ def test_rejects_schema_invalid_sidecar(tmp_path: Path) -> None:
     assert check.main(["--root", str(root)]) == 1
 
 
+def test_rejects_reserved_skill_names(tmp_path: Path, capsys: object) -> None:
+    for reserved_name in ("claude", "anthropic"):
+        root = copy_contract_root(tmp_path / reserved_name)
+        name = first_skill_name(root)
+        sidecar_path = root / "skills" / name / "portability.json"
+        sidecar = read_json(sidecar_path)
+        assert isinstance(sidecar, dict)
+        sidecar["skillName"] = reserved_name
+        write_json(sidecar_path, sidecar)
+
+        assert check.main(["--root", str(root)]) == 1
+        assert "invalid or reserved skill name" in capsys.readouterr().err
+
+
 def test_rejects_sidecar_skill_name_mismatch(tmp_path: Path) -> None:
     root = copy_contract_root(tmp_path)
     name = first_skill_name(root)
@@ -116,6 +130,54 @@ def test_rejects_portable_status_with_adapter_required_harness(
 
     assert check.main(["--root", str(root)]) == 1
     assert "portable requires native harness declarations" in capsys.readouterr().err
+
+
+def test_rejects_portable_with_adapter_without_adapter(
+    tmp_path: Path, capsys: object
+) -> None:
+    root = copy_contract_root(tmp_path)
+    name = first_skill_name(root)
+    sidecar_path = root / "skills" / name / "portability.json"
+    sidecar = read_json(sidecar_path)
+    assert isinstance(sidecar, dict)
+    for declaration in sidecar["harnesses"].values():
+        declaration["status"] = "native"
+    write_json(sidecar_path, sidecar)
+
+    assert check.main(["--root", str(root)]) == 1
+    assert (
+        "portable-with-adapter requires an adapter-required harness declaration"
+        in capsys.readouterr().err
+    )
+
+
+def test_rejects_harness_specific_without_unsupported(
+    tmp_path: Path, capsys: object
+) -> None:
+    root = copy_contract_root(tmp_path)
+    name = first_skill_name(root)
+    sidecar_path = root / "skills" / name / "portability.json"
+    sidecar = read_json(sidecar_path)
+    assert isinstance(sidecar, dict)
+    sidecar["status"] = "harness-specific"
+    for declaration in sidecar["harnesses"].values():
+        declaration["status"] = "native"
+    write_json(sidecar_path, sidecar)
+
+    for inventory_name in ("skills-index.json", "audit.json"):
+        inventory_path = root / "compatibility" / inventory_name
+        inventory = read_json(inventory_path)
+        assert isinstance(inventory, dict)
+        for entry in inventory["skills"]:
+            if entry["name"] == name:
+                entry["status"] = "harness-specific"
+        write_json(inventory_path, inventory)
+
+    assert check.main(["--root", str(root)]) == 1
+    assert (
+        "harness-specific requires an unsupported harness declaration"
+        in capsys.readouterr().err
+    )
 
 
 def test_marks_skills_failed_for_global_pre_skill_errors(

--- a/compatibility/test_check.py
+++ b/compatibility/test_check.py
@@ -1,0 +1,85 @@
+import json
+import shutil
+from pathlib import Path
+
+import check
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def copy_contract_root(tmp_path: Path) -> Path:
+    root = tmp_path / "repository"
+    shutil.copytree(REPOSITORY_ROOT / "compatibility", root / "compatibility")
+    shutil.copytree(REPOSITORY_ROOT / "skills", root / "skills")
+    return root
+
+
+def read_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def first_skill_name(root: Path) -> str:
+    index = read_json(root / "compatibility" / "skills-index.json")
+    assert isinstance(index, dict)
+    skills = index["skills"]
+    assert isinstance(skills, list) and skills
+    first = skills[0]
+    assert isinstance(first, dict)
+    name = first["name"]
+    assert isinstance(name, str)
+    return name
+
+
+def test_rejects_duplicate_inventory_entries(tmp_path: Path) -> None:
+    root = copy_contract_root(tmp_path)
+    path = root / "compatibility" / "skills-index.json"
+    index = read_json(path)
+    assert isinstance(index, dict)
+    skills = index["skills"]
+    assert isinstance(skills, list) and skills
+    skills.append(skills[0].copy())
+    write_json(path, index)
+
+    assert check.main(["--root", str(root)]) == 1
+
+
+def test_rejects_stale_inventory_paths(tmp_path: Path) -> None:
+    root = copy_contract_root(tmp_path)
+    path = root / "compatibility" / "skills-index.json"
+    index = read_json(path)
+    assert isinstance(index, dict)
+    skills = index["skills"]
+    assert isinstance(skills, list) and skills
+    skills[0]["skillDirectory"] = "skills/stale"
+    write_json(path, index)
+
+    assert check.main(["--root", str(root)]) == 1
+
+
+def test_rejects_schema_invalid_sidecar(tmp_path: Path) -> None:
+    root = copy_contract_root(tmp_path)
+    name = first_skill_name(root)
+    path = root / "skills" / name / "portability.json"
+    sidecar = read_json(path)
+    assert isinstance(sidecar, dict)
+    sidecar["status"] = "invalid"
+    write_json(path, sidecar)
+
+    assert check.main(["--root", str(root)]) == 1
+
+
+def test_rejects_sidecar_skill_name_mismatch(tmp_path: Path) -> None:
+    root = copy_contract_root(tmp_path)
+    name = first_skill_name(root)
+    path = root / "skills" / name / "portability.json"
+    sidecar = read_json(path)
+    assert isinstance(sidecar, dict)
+    sidecar["skillName"] = "different-skill"
+    write_json(path, sidecar)
+
+    assert check.main(["--root", str(root)]) == 1

--- a/compatibility/test_check.py
+++ b/compatibility/test_check.py
@@ -91,3 +91,62 @@ def test_rejects_invalid_utf8_json(tmp_path: Path) -> None:
     path.write_bytes(b"\xff")
 
     assert check.main(["--root", str(root)]) == 1
+
+
+def test_rejects_portable_status_with_adapter_required_harness(
+    tmp_path: Path, capsys: object
+) -> None:
+    root = copy_contract_root(tmp_path)
+    name = first_skill_name(root)
+    sidecar_path = root / "skills" / name / "portability.json"
+    sidecar = read_json(sidecar_path)
+    assert isinstance(sidecar, dict)
+    sidecar["status"] = "portable"
+    sidecar["harnesses"]["copilot"]["status"] = "adapter-required"
+    write_json(sidecar_path, sidecar)
+
+    for inventory_name in ("skills-index.json", "audit.json"):
+        inventory_path = root / "compatibility" / inventory_name
+        inventory = read_json(inventory_path)
+        assert isinstance(inventory, dict)
+        for entry in inventory["skills"]:
+            if entry["name"] == name:
+                entry["status"] = "portable"
+        write_json(inventory_path, inventory)
+
+    assert check.main(["--root", str(root)]) == 1
+    assert "portable requires native harness declarations" in capsys.readouterr().err
+
+
+def test_marks_skills_failed_for_global_pre_skill_errors(
+    tmp_path: Path, capsys: object
+) -> None:
+    root = copy_contract_root(tmp_path)
+    index_path = root / "compatibility" / "skills-index.json"
+    index = read_json(index_path)
+    assert isinstance(index, dict)
+    index["skills"].append(index["skills"][0].copy())
+    write_json(index_path, index)
+
+    assert check.main(["--root", str(root)]) == 1
+    output = capsys.readouterr().out
+    skill_lines = [
+        line for line in output.splitlines() if line.startswith("Compatibility skill ")
+    ]
+    assert skill_lines
+    assert all(line.endswith(": failed") for line in skill_lines)
+
+
+def test_marks_skills_failed_for_global_post_skill_errors(
+    tmp_path: Path, capsys: object
+) -> None:
+    root = copy_contract_root(tmp_path)
+    (root / "compatibility" / "adapters" / "mock-claude").unlink()
+
+    assert check.main(["--root", str(root)]) == 1
+    output = capsys.readouterr().out
+    skill_lines = [
+        line for line in output.splitlines() if line.startswith("Compatibility skill ")
+    ]
+    assert skill_lines
+    assert all(line.endswith(": failed") for line in skill_lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "anthropic==0.107.1",
     "jsonschema>=4.20",
     "pydantic>=2.10",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/skills/camunda-ai-agents/portability.json
+++ b/skills/camunda-ai-agents/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-ai-agents",
+  "skillName": "camunda-ai-agents",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies discovery and tool invocation adapters."]
+    }
+  },
+  "limitations": [
+    "Live agent operations require an installed and configured Camunda toolchain."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-ai-agents/portability.json
+++ b/skills/camunda-ai-agents/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-ai-agents",
   "skillName": "camunda-ai-agents",
   "status": "portable-with-adapter",

--- a/skills/camunda-ai-agents/portability.json
+++ b/skills/camunda-ai-agents/portability.json
@@ -25,6 +25,6 @@
     "Live agent operations require an installed and configured Camunda toolchain."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "AI Agent Sub-process configuration is mapped to each harness's available model and tool-call surface."
   ]
 }

--- a/skills/camunda-bpmn/SKILL.md
+++ b/skills/camunda-bpmn/SKILL.md
@@ -119,7 +119,7 @@ A BPMN edit is **not structurally done** until `c8ctl bpmn lint` reports zero er
 1. Run the linter against the file you touched:
 
    ```bash
-   c8ctl bpmn lint path/to/process.bpmn
+   c8ctl bpmn lint process.bpmn
    ```
 
    `c8ctl bpmn lint` auto-detects the Camunda execution platform version from the BPMN file and applies sensible Camunda defaults. If a `.bpmnlintrc` is present in the project, it is used instead. Stdin also works: `cat process.bpmn | c8ctl bpmn lint`.

--- a/skills/camunda-bpmn/SKILL.md
+++ b/skills/camunda-bpmn/SKILL.md
@@ -119,7 +119,7 @@ A BPMN edit is **not structurally done** until `c8ctl bpmn lint` reports zero er
 1. Run the linter against the file you touched:
 
    ```bash
-   c8ctl bpmn lint process.bpmn
+   c8ctl bpmn lint <path-to-touched-file.bpmn>
    ```
 
    `c8ctl bpmn lint` auto-detects the Camunda execution platform version from the BPMN file and applies sensible Camunda defaults. If a `.bpmnlintrc` is present in the project, it is used instead. Stdin also works: `cat process.bpmn | c8ctl bpmn lint`.
@@ -136,6 +136,12 @@ A BPMN edit is **not structurally done** until `c8ctl bpmn lint` reports zero er
 3. Loop until the linter is clean. Do not declare the task structurally done while warnings remain — silently-failing BPMN deploys to the cluster and surfaces as runtime incidents.
 
 If a warning is genuinely a false positive, suppress it explicitly in a project-level `.bpmnlintrc` and flag the suppression in your final message — never silently ignore.
+
+For the repository's deterministic smoke contract, the fixed fixture command is:
+
+```bash
+c8ctl bpmn lint process.bpmn
+```
 
 ### Batch linting and fix guidance
 

--- a/skills/camunda-bpmn/portability.json
+++ b/skills/camunda-bpmn/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-bpmn",
   "skillName": "camunda-bpmn",
   "status": "portable-with-adapter",

--- a/skills/camunda-bpmn/portability.json
+++ b/skills/camunda-bpmn/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-bpmn",
+  "skillName": "camunda-bpmn",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies discovery and tool invocation adapters."]
+    }
+  },
+  "limitations": [
+    "Live process modeling requires an installed and configured c8ctl CLI."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-bpmn/portability.json
+++ b/skills/camunda-bpmn/portability.json
@@ -25,6 +25,6 @@
     "Live process modeling requires an installed and configured c8ctl CLI."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "BPMN lint and formatting commands are exposed through c8ctl, with adapters mapping equivalent tool calls."
   ]
 }

--- a/skills/camunda-c8ctl/portability.json
+++ b/skills/camunda-c8ctl/portability.json
@@ -25,6 +25,6 @@
     "Cluster and profile operations require an installed c8ctl CLI."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "Profile and cluster lifecycle commands depend on each harness's credential and process environment."
   ]
 }

--- a/skills/camunda-c8ctl/portability.json
+++ b/skills/camunda-c8ctl/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-c8ctl",
+  "skillName": "camunda-c8ctl",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies discovery and tool invocation adapters."]
+    }
+  },
+  "limitations": [
+    "Cluster and profile operations require an installed c8ctl CLI."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-c8ctl/portability.json
+++ b/skills/camunda-c8ctl/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-c8ctl",
   "skillName": "camunda-c8ctl",
   "status": "portable-with-adapter",

--- a/skills/camunda-connectors-development/portability.json
+++ b/skills/camunda-connectors-development/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-connectors-development",
+  "skillName": "camunda-connectors-development",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies discovery and tool invocation adapters."]
+    }
+  },
+  "limitations": [
+    "Connector builds require the host's supported Java and Maven toolchain."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-connectors-development/portability.json
+++ b/skills/camunda-connectors-development/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-connectors-development",
   "skillName": "camunda-connectors-development",
   "status": "portable-with-adapter",

--- a/skills/camunda-connectors-development/portability.json
+++ b/skills/camunda-connectors-development/portability.json
@@ -25,6 +25,6 @@
     "Connector builds require the host's supported Java and Maven toolchain."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "Java connector builds require the harness to provide a compatible Java/Maven process and dependency cache."
   ]
 }

--- a/skills/camunda-connectors/portability.json
+++ b/skills/camunda-connectors/portability.json
@@ -25,6 +25,6 @@
     "Connector configuration may require access to the OOTB template catalog."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "Element-template discovery and application depend on the harness exposing c8ctl's connector catalog commands."
   ]
 }

--- a/skills/camunda-connectors/portability.json
+++ b/skills/camunda-connectors/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-connectors",
+  "skillName": "camunda-connectors",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies discovery and tool invocation adapters."]
+    }
+  },
+  "limitations": [
+    "Connector configuration may require access to the OOTB template catalog."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-connectors/portability.json
+++ b/skills/camunda-connectors/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-connectors",
   "skillName": "camunda-connectors",
   "status": "portable-with-adapter",

--- a/skills/camunda-development/portability.json
+++ b/skills/camunda-development/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-development",
   "skillName": "camunda-development",
   "status": "portable-with-adapter",

--- a/skills/camunda-development/portability.json
+++ b/skills/camunda-development/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-development",
+  "skillName": "camunda-development",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies discovery and tool invocation adapters."]
+    }
+  },
+  "limitations": [
+    "Integration design depends on the host's available Camunda and system tools."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-development/portability.json
+++ b/skills/camunda-development/portability.json
@@ -25,6 +25,6 @@
     "Integration design depends on the host's available Camunda and system tools."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "Integration decisions route to different adapter surfaces when a host lacks the selected connector, worker, or cluster tool."
   ]
 }

--- a/skills/camunda-dmn/portability.json
+++ b/skills/camunda-dmn/portability.json
@@ -25,6 +25,6 @@
     "Decision validation requires the host's DMN linting and evaluation tools."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "DMN lint and evaluation commands must be mapped to the harness's available c8ctl or local validation tools."
   ]
 }

--- a/skills/camunda-dmn/portability.json
+++ b/skills/camunda-dmn/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-dmn",
   "skillName": "camunda-dmn",
   "status": "portable-with-adapter",

--- a/skills/camunda-dmn/portability.json
+++ b/skills/camunda-dmn/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-dmn",
+  "skillName": "camunda-dmn",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies discovery and tool invocation adapters."]
+    }
+  },
+  "limitations": [
+    "Decision validation requires the host's DMN linting and evaluation tools."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-docs/portability.json
+++ b/skills/camunda-docs/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-docs",
   "skillName": "camunda-docs",
   "status": "portable-with-adapter",

--- a/skills/camunda-docs/portability.json
+++ b/skills/camunda-docs/portability.json
@@ -25,6 +25,6 @@
     "Current Camunda behavior depends on access to the official documentation source."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "Documentation lookups use the harness's network, browser, or cached documentation retrieval capability."
   ]
 }

--- a/skills/camunda-docs/portability.json
+++ b/skills/camunda-docs/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-docs",
+  "skillName": "camunda-docs",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps documentation lookup to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies documentation discovery and retrieval adapters."]
+    }
+  },
+  "limitations": [
+    "Current Camunda behavior depends on access to the official documentation source."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-feel/portability.json
+++ b/skills/camunda-feel/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-feel",
   "skillName": "camunda-feel",
   "status": "portable-with-adapter",

--- a/skills/camunda-feel/portability.json
+++ b/skills/camunda-feel/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-feel",
+  "skillName": "camunda-feel",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps FEEL evaluation to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies discovery and FEEL evaluation adapters."]
+    }
+  },
+  "limitations": [
+    "Expression evaluation requires a compatible Camunda FEEL engine."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-feel/portability.json
+++ b/skills/camunda-feel/portability.json
@@ -25,6 +25,6 @@
     "Expression evaluation requires a compatible Camunda FEEL engine."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "FEEL expressions are evaluated through a harness-provided c8ctl or local FEEL engine with potentially different runtime capabilities."
   ]
 }

--- a/skills/camunda-forms/portability.json
+++ b/skills/camunda-forms/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-forms",
   "skillName": "camunda-forms",
   "status": "portable-with-adapter",

--- a/skills/camunda-forms/portability.json
+++ b/skills/camunda-forms/portability.json
@@ -25,6 +25,6 @@
     "Form validation depends on the host's supported Camunda form tooling."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "Form JSON authoring and FEEL validation depend on the harness exposing Camunda form tooling."
   ]
 }

--- a/skills/camunda-forms/portability.json
+++ b/skills/camunda-forms/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-forms",
+  "skillName": "camunda-forms",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps form modeling operations to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies form discovery and validation adapters."]
+    }
+  },
+  "limitations": [
+    "Form validation depends on the host's supported Camunda form tooling."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-job-workers/portability.json
+++ b/skills/camunda-job-workers/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-job-workers",
+  "skillName": "camunda-job-workers",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps worker implementation operations to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies code generation and build adapters."]
+    }
+  },
+  "limitations": [
+    "Worker implementation requires the selected SDK and its supported runtime."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-job-workers/portability.json
+++ b/skills/camunda-job-workers/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-job-workers",
   "skillName": "camunda-job-workers",
   "status": "portable-with-adapter",

--- a/skills/camunda-job-workers/portability.json
+++ b/skills/camunda-job-workers/portability.json
@@ -25,6 +25,6 @@
     "Worker implementation requires the selected SDK and its supported runtime."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "Worker implementation commands depend on the harness's language SDK, build runner, and runtime process controls."
   ]
 }

--- a/skills/camunda-process-mgmt/portability.json
+++ b/skills/camunda-process-mgmt/portability.json
@@ -25,6 +25,6 @@
     "Live process operations require a reachable and authorized Camunda cluster."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "Deployment and process-operation commands require the harness to map credentials and cluster endpoints into c8ctl."
   ]
 }

--- a/skills/camunda-process-mgmt/portability.json
+++ b/skills/camunda-process-mgmt/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-process-mgmt",
   "skillName": "camunda-process-mgmt",
   "status": "portable-with-adapter",

--- a/skills/camunda-process-mgmt/portability.json
+++ b/skills/camunda-process-mgmt/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-process-mgmt",
+  "skillName": "camunda-process-mgmt",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps cluster operations to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies cluster discovery and operation adapters."]
+    }
+  },
+  "limitations": [
+    "Live process operations require a reachable and authorized Camunda cluster."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/skills/camunda-process-test/portability.json
+++ b/skills/camunda-process-test/portability.json
@@ -25,6 +25,6 @@
     "Process tests require the supported Camunda Process Test runtime and build tools."
   ],
   "differences": [
-    "Tool names, model configuration, and credential setup can vary by harness."
+    "Process-test execution depends on the harness's Java/Maven runner and embedded engine support."
   ]
 }

--- a/skills/camunda-process-test/portability.json
+++ b/skills/camunda-process-test/portability.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../compatibility/portability.schema.json",
+  "$schema": "https://raw.githubusercontent.com/camunda/skills/main/compatibility/portability.schema.json",
   "skillDirectory": "skills/camunda-process-test",
   "skillName": "camunda-process-test",
   "status": "portable-with-adapter",

--- a/skills/camunda-process-test/portability.json
+++ b/skills/camunda-process-test/portability.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../compatibility/portability.schema.json",
+  "skillDirectory": "skills/camunda-process-test",
+  "skillName": "camunda-process-test",
+  "status": "portable-with-adapter",
+  "agentSkillsSpec": {
+    "specUrl": "https://agentskills.io/specification",
+    "specRevisionOrAuditDate": "2026-09-11"
+  },
+  "harnesses": {
+    "claude": {
+      "status": "native",
+      "differences": ["Uses the repository's Claude Code skill discovery path."]
+    },
+    "copilot": {
+      "status": "adapter-required",
+      "differences": ["Maps process test operations to the Copilot tool surface."]
+    },
+    "generic": {
+      "status": "adapter-required",
+      "differences": ["The host supplies test execution and reporting adapters."]
+    }
+  },
+  "limitations": [
+    "Process tests require the supported Camunda Process Test runtime and build tools."
+  ],
+  "differences": [
+    "Tool names, model configuration, and credential setup can vary by harness."
+  ]
+}

--- a/uv.lock
+++ b/uv.lock
@@ -285,6 +285,7 @@ dependencies = [
     { name = "inspect-swe" },
     { name = "jsonschema" },
     { name = "pydantic" },
+    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -300,6 +301,7 @@ requires-dist = [
     { name = "inspect-swe", specifier = "==0.2.62" },
     { name = "jsonschema", specifier = ">=4.20" },
     { name = "pydantic", specifier = ">=2.10" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Description

Establishes the wave-0 compatibility contract for Agent Skills portability and harness smoke testing. It defines the per-skill sidecar schema, complete inventory and dated audit artifacts, deterministic Claude/Copilot mock boundary, optional live Copilot result semantics, and the checked-in camunda-bpmn smoke fixture.

Refs #95

## Checklist

- [x] JSON contract artifacts and schemas validate
- [ ] `make lint` passes
