### PR TITLE
fix(skills): audit harness portability declarations

### DIFF
--- a/evals/skills/camunda-docs/triggers.py
+++ b/evals/skills/camunda-docs/triggers.py
@@ -27,5 +27,25 @@ def trigger_eval() -> Task:
                 "Build a user task form with a name field, an email field, and an approval checkbox.",
                 should_load=["camunda-forms"],
             ),
+            Negative(
+                "author-bpmn",
+                "Create a BPMN process for invoice approval with a review task and an approval gateway.",
+                should_load=["camunda-bpmn"],
+            ),
+            Negative(
+                "author-dmn",
+                "Create a DMN decision table that selects a shipping method from package weight and destination.",
+                should_load=["camunda-dmn"],
+            ),
+            Negative(
+                "configure-connector",
+                "Apply a REST connector template to a BPMN service task and configure its request URL.",
+                should_load=["camunda-connectors"],
+            ),
+            Negative(
+                "operate-process",
+                "Deploy my BPMN process to the cluster and start an instance with these variables.",
+                should_load=["camunda-process-mgmt"],
+            ),
         ],
     )

--- a/evals/skills/camunda-process-test/triggers.py
+++ b/evals/skills/camunda-process-test/triggers.py
@@ -27,5 +27,29 @@ def trigger_eval() -> Task:
                 "Just deploy my process to the cluster and run it once so I can watch it execute.",
                 should_load=["camunda-process-mgmt"],
             ),
+            Negative(
+                "author-bpmn",
+                "Design a new BPMN process for invoice approval with a review task and an approval gateway.",
+                should_load=["camunda-bpmn"],
+            ),
+            Negative(
+                "author-dmn",
+                "Create a DMN decision table that routes orders by amount and customer tier.",
+                should_load=["camunda-dmn"],
+            ),
+            Negative(
+                "write-feel",
+                "Write the FEEL condition for an approval gateway when `amount` is greater than 1000.",
+                should_load=["camunda-feel"],
+            ),
+            Negative(
+                "build-form",
+                "Create a Camunda form for the approval user task with a required comment field.",
+                should_load=["camunda-forms"],
+            ),
+            Negative(
+                "test-ui",
+                "Write an end-to-end test that clicks through the approval process in the Tasklist UI.",
+            ),
         ],
     )

--- a/skills/camunda-ai-agents/portability.json
+++ b/skills/camunda-ai-agents/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and applies the documented BPMN and c8ctl workflow."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+      "differences": [
+        "Maps connector-template application, file editing, and model/tool configuration to Copilot terminal capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies discovery and tool invocation adapters."]
+      "differences": [
+        "The host supplies LLM-provider credential and tool-call execution adapters for live processes."
+      ]
     }
   },
   "limitations": [
-    "Live agent operations require an installed and configured Camunda toolchain."
+    "Live agent operations require c8ctl, a Camunda 8.8+ cluster, and a model-provider secret."
   ],
   "differences": [
-    "AI Agent Sub-process configuration is mapped to each harness's available model and tool-call surface."
+    "BPMN and connector configuration are harness-neutral; model-provider credentials and tool execution are host-managed."
   ]
 }

--- a/skills/camunda-bpmn/portability.json
+++ b/skills/camunda-bpmn/portability.json
@@ -28,7 +28,7 @@
     }
   },
   "limitations": [
-    "Process modeling requires c8ctl 3.0.0 or newer and a BPMN-aware project workspace."
+    "Basic BPMN linting requires c8ctl 3.0.0 or newer; the documented bpmn format workflow requires c8ctl 3.2.0 or newer, plus a BPMN-aware project workspace."
   ],
   "differences": [
     "BPMN XML and c8ctl command syntax are harness-neutral; file editing and command execution depend on host capabilities."

--- a/skills/camunda-bpmn/portability.json
+++ b/skills/camunda-bpmn/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and runs the documented c8ctl BPMN workflow."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+      "differences": [
+        "Maps BPMN file editing plus c8ctl bpmn lint and format commands to Copilot terminal capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies discovery and tool invocation adapters."]
+      "differences": [
+        "The host supplies filesystem and c8ctl process adapters for authoring and validation."
+      ]
     }
   },
   "limitations": [
-    "Live process modeling requires an installed and configured c8ctl CLI."
+    "Process modeling requires c8ctl 3.0.0 or newer and a BPMN-aware project workspace."
   ],
   "differences": [
-    "BPMN lint and formatting commands are exposed through c8ctl, with adapters mapping equivalent tool calls."
+    "BPMN XML and c8ctl command syntax are harness-neutral; file editing and command execution depend on host capabilities."
   ]
 }

--- a/skills/camunda-c8ctl/portability.json
+++ b/skills/camunda-c8ctl/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and invokes c8ctl through the host terminal."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+      "differences": [
+        "Maps c8ctl process execution, profile selection, and secret setup to Copilot terminal capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies discovery and tool invocation adapters."]
+      "differences": [
+        "The host supplies terminal, environment-variable, and credential adapters for c8ctl."
+      ]
     }
   },
   "limitations": [
-    "Cluster and profile operations require an installed c8ctl CLI."
+    "Cluster and profile operations require c8ctl 3.0.0 or newer, Node.js 22.18.0 or newer, and credentials for remote clusters."
   ],
   "differences": [
-    "Profile and cluster lifecycle commands depend on each harness's credential and process environment."
+    "The c8ctl command surface is stable across harnesses; profile storage, environment variables, and process lifecycle are host-managed."
   ]
 }

--- a/skills/camunda-connectors-development/portability.json
+++ b/skills/camunda-connectors-development/portability.json
@@ -28,7 +28,7 @@
     }
   },
   "limitations": [
-    "Java connector builds require Java 17 or newer, Maven, and a connector runtime or hosting target."
+    "Java connector builds require Java 17 or newer, Maven 3.8+ or an equivalent Gradle toolchain, and a connector runtime or hosting target."
   ],
   "differences": [
     "Template and SDK semantics are harness-neutral; build, dependency-cache, and hosting commands depend on host capabilities."

--- a/skills/camunda-connectors-development/portability.json
+++ b/skills/camunda-connectors-development/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and follows the JSON-template or Java SDK path."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+      "differences": [
+        "Maps c8ctl template retrieval, Java/Maven commands, and project file edits to Copilot terminal capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies discovery and tool invocation adapters."]
+      "differences": [
+        "The host supplies Java, Maven, filesystem, and connector-runtime adapters for Path B."
+      ]
     }
   },
   "limitations": [
-    "Connector builds require the host's supported Java and Maven toolchain."
+    "Java connector builds require Java 17 or newer, Maven, and a connector runtime or hosting target."
   ],
   "differences": [
-    "Java connector builds require the harness to provide a compatible Java/Maven process and dependency cache."
+    "Template and SDK semantics are harness-neutral; build, dependency-cache, and hosting commands depend on host capabilities."
   ]
 }

--- a/skills/camunda-connectors/portability.json
+++ b/skills/camunda-connectors/portability.json
@@ -28,7 +28,7 @@
     }
   },
   "limitations": [
-    "Connector configuration requires c8ctl 3.0.0 or newer and access to the selected template catalog."
+    "Basic connector template operations require c8ctl 3.0.0 or newer; use c8ctl 3.2.0 or newer for --engine-version discovery and --set FEEL auto-prefixing, plus access to the selected template catalog."
   ],
   "differences": [
     "Element-template IDs and property mappings are harness-neutral; catalog access and BPMN file editing are host-managed."

--- a/skills/camunda-connectors/portability.json
+++ b/skills/camunda-connectors/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and invokes the documented c8ctl element-template workflow."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+      "differences": [
+        "Maps c8ctl element-template search, inspection, and apply commands to Copilot terminal capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies discovery and tool invocation adapters."]
+      "differences": [
+        "The host supplies c8ctl catalog access and BPMN file-editing adapters."
+      ]
     }
   },
   "limitations": [
-    "Connector configuration may require access to the OOTB template catalog."
+    "Connector configuration requires c8ctl 3.0.0 or newer and access to the selected template catalog."
   ],
   "differences": [
-    "Element-template discovery and application depend on the harness exposing c8ctl's connector catalog commands."
+    "Element-template IDs and property mappings are harness-neutral; catalog access and BPMN file editing are host-managed."
   ]
 }

--- a/skills/camunda-development/portability.json
+++ b/skills/camunda-development/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and routes the decision to the named Camunda skill."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+      "differences": [
+        "Maps repository inspection and the selected c8ctl or SDK workflow to Copilot terminal capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies discovery and tool invocation adapters."]
+      "differences": [
+        "The host supplies discovery of the focused skill and the tools required by the selected integration path."
+      ]
     }
   },
   "limitations": [
-    "Integration design depends on the host's available Camunda and system tools."
+    "The decision matrix requires access to the Camunda tools and the language or runtime named by the selected path."
   ],
   "differences": [
-    "Integration decisions route to different adapter surfaces when a host lacks the selected connector, worker, or cluster tool."
+    "The routing rules are harness-neutral; the selected connector, worker, or cluster workflow still depends on host tool availability."
   ]
 }

--- a/skills/camunda-dmn/portability.json
+++ b/skills/camunda-dmn/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and runs the documented DMN lint and evaluation workflow."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps Camunda tool operations to the Copilot tool surface."]
+      "differences": [
+        "Maps dmnlint, c8ctl, and DMN file-editing commands to Copilot terminal capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies discovery and tool invocation adapters."]
+      "differences": [
+        "The host supplies DMN lint, FEEL evaluation, and optional cluster execution adapters."
+      ]
     }
   },
   "limitations": [
-    "Decision validation requires the host's DMN linting and evaluation tools."
+    "Decision validation requires dmnlint plus a compatible FEEL or Camunda evaluation path."
   ],
   "differences": [
-    "DMN lint and evaluation commands must be mapped to the harness's available c8ctl or local validation tools."
+    "DMN XML and hit-policy guidance are harness-neutral; linting, evaluation, and deployment commands depend on host tools."
   ]
 }

--- a/skills/camunda-docs/SKILL.md
+++ b/skills/camunda-docs/SKILL.md
@@ -1,10 +1,16 @@
 ---
 name: camunda-docs
 description: |
-  Use this skill to look up Camunda 8 documentation. The official docs at docs.camunda.io are the source of truth for current behavior — FEEL function signatures, BPMN extension attribute shapes, REST API endpoints, version requirements, feature availability. Trigger any time you need to verify a Camunda specific against the current docs, including when you think you already know the answer — Camunda 8 evolves fast and training data drifts. If you start with a conceptual explanation and find yourself about to state specifics (defaults, names, syntax, version requirements), stop and invoke before writing those specifics.
+  Use this skill to retrieve current Camunda 8 documentation from docs.camunda.io. Use it for version-specific FEEL functions, BPMN extension attributes, REST endpoints, release requirements, and feature availability. It chooses MCP, Algolia, or llms.txt retrieval and cites source URLs. Do not use it to author BPMN, DMN, forms, connectors, or process operations.
 ---
 
 # Camunda Docs Lookup
+
+**UTILITY SKILL**: retrieve source-backed Camunda documentation, then route implementation work to the focused skill.
+
+## DO NOT USE FOR:
+
+Do not use this skill to author BPMN, DMN, forms, or connectors, or to deploy and operate process instances. Route those tasks to the corresponding Camunda skill after verifying any version-sensitive fact here.
 
 Two retrieval paths into `docs.camunda.io`, each with a different strength. Pick by question shape; fall back to `llms.txt` only if both are unavailable.
 
@@ -20,13 +26,7 @@ Use both primary paths in parallel when in doubt — they're cheap and frequentl
 
 If the `camunda-docs` MCP server (`https://camunda-docs.mcp.kapa.ai`, HTTP transport) is connected, call its knowledge search tool with a single, well-formed natural-language sentence (the tool requires a complete sentence, not keywords).
 
-If it isn't connected, suggest installing it once so the user has it set up for future questions. Skip the suggestion if you've already made it earlier in this conversation. For Claude Code:
-
-```bash
-claude mcp add --transport http camunda-docs https://camunda-docs.mcp.kapa.ai
-```
-
-For VS Code Copilot, Cursor, or generic MCP clients, see [the reference](https://docs.camunda.io/docs/reference/mcp-docs/). Google sign-in on first use; 40 requests/hour and 200/day per user; not for CI.
+If it isn't connected, suggest configuring the server once so the user has it set up for future questions. Skip the suggestion if you've already made it earlier in this conversation. Add the HTTP server at `https://camunda-docs.mcp.kapa.ai` using the harness's documented MCP configuration flow. For VS Code Copilot, Cursor, or other generic MCP clients, see [the reference](https://docs.camunda.io/docs/reference/mcp-docs/). Google sign-in on first use; 40 requests/hour and 200/day per user; not for CI.
 
 ## Algolia DocSearch
 
@@ -135,3 +135,9 @@ If neither MCP nor Algolia is usable, fetch [`https://docs.camunda.io/llms.txt`]
 ## Last resort: llms-full.txt (full docs corpus)
 
 Only if `llms.txt` doesn't surface what you need, fall back to [`https://docs.camunda.io/llms-full.txt`](https://docs.camunda.io/llms-full.txt) (~11 MB) — every docs page concatenated. **Even larger; never read whole into context.** Cache locally, search with surrounding context for the term. Use when the right page name isn't obvious from the index.
+
+## Troubleshooting
+
+- If MCP is unavailable, use `scripts/docs-search.sh` when `curl` and `jq` are installed.
+- If Algolia search fails, use the `llms.txt` index to locate a page, then fetch that page directly.
+- If no source is reachable, state that the lookup is unverified instead of presenting remembered behavior as current.

--- a/skills/camunda-docs/SKILL.md
+++ b/skills/camunda-docs/SKILL.md
@@ -30,10 +30,12 @@ If it isn't connected, suggest configuring the server once so the user has it se
 
 ## Algolia DocSearch
 
-A bash wrapper around the public Algolia DocSearch endpoint lives at `scripts/docs-search.sh`. Run it as:
+A bash wrapper around the public Algolia DocSearch endpoint lives at
+`$CAMUNDA_DOCS_SKILL_DIR/scripts/docs-search.sh`. Set `CAMUNDA_DOCS_SKILL_DIR` to the
+installed `camunda-docs` directory before running it:
 
 ```bash
-scripts/docs-search.sh "<query>" [--version stable|next|<major>.<minor>|all] [--limit N]
+"$CAMUNDA_DOCS_SKILL_DIR/scripts/docs-search.sh" "<query>" [--version stable|next|<major>.<minor>|all] [--limit N]
 ```
 
 Default `--version stable` resolves to the highest numeric version in the index (so it keeps working when 9.0 ships). Default `--limit 10`. Returns JSON:
@@ -84,18 +86,22 @@ In `--version all` mode the script over-fetches (4× `--limit`, capped at 100) s
 
 ### Examples
 
+The shell starts in the user's project directory, not the installed skill directory. Set
+`CAMUNDA_DOCS_SKILL_DIR` to the installed `camunda-docs` directory (the directory containing
+this `SKILL.md`) before running the wrapper, or have the host adapter provide it.
+
 ```bash
 # Default — latest stable
-scripts/docs-search.sh "zeebe gateway long polling timeout"
+"$CAMUNDA_DOCS_SKILL_DIR/scripts/docs-search.sh" "zeebe gateway long polling timeout"
 
 # Specific version (customer on 8.7)
-scripts/docs-search.sh "task assignment" --version 8.7
+"$CAMUNDA_DOCS_SKILL_DIR/scripts/docs-search.sh" "task assignment" --version 8.7
 
 # Upcoming behavior
-scripts/docs-search.sh "agentic connectors" --version next
+"$CAMUNDA_DOCS_SKILL_DIR/scripts/docs-search.sh" "agentic connectors" --version next
 
 # Compare across versions (deduped by URL stem)
-scripts/docs-search.sh "decision evaluation API" --version all --limit 15
+"$CAMUNDA_DOCS_SKILL_DIR/scripts/docs-search.sh" "decision evaluation API" --version all --limit 15
 ```
 
 ### Refinement strategy
@@ -111,11 +117,11 @@ Don't loop more than 2-3 refinements. If still nothing, switch to the MCP path (
 
 ### No credentials needed
 
-The Algolia search-only API key is public — Algolia ships it in the browser JS bundle of docs.camunda.io, so every visitor already has it. It's hardcoded at the top of `scripts/docs-search.sh` with a comment explaining why it's safe to commit. No env vars, no auth, safe in CI.
+The Algolia search-only API key is public — Algolia ships it in the browser JS bundle of docs.camunda.io, so every visitor already has it. It's hardcoded at the top of `"$CAMUNDA_DOCS_SKILL_DIR/scripts/docs-search.sh"` with a comment explaining why it's safe to commit. No credentials or API environment variables are required, and the wrapper is safe in CI.
 
 ### Without the wrapper script
 
-If you can't or don't want to run `scripts/docs-search.sh` (e.g. `jq` missing, restricted sandbox, or you just need the raw API), call the Algolia endpoint directly:
+If you can't or don't want to run `"$CAMUNDA_DOCS_SKILL_DIR/scripts/docs-search.sh"` (e.g. `jq` missing, restricted sandbox, or you just need the raw API), call the Algolia endpoint directly:
 
 ```bash
 curl -sS -f -X POST \
@@ -138,6 +144,6 @@ Only if `llms.txt` doesn't surface what you need, fall back to [`https://docs.ca
 
 ## Troubleshooting
 
-- If MCP is unavailable, use `scripts/docs-search.sh` when `curl` and `jq` are installed.
+- If MCP is unavailable, use `"$CAMUNDA_DOCS_SKILL_DIR/scripts/docs-search.sh"` when `curl` and `jq` are installed.
 - If Algolia search fails, use the `llms.txt` index to locate a page, then fetch that page directly.
 - If no source is reachable, state that the lookup is unverified instead of presenting remembered behavior as current.

--- a/skills/camunda-docs/portability.json
+++ b/skills/camunda-docs/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and can use the MCP path or the bundled Algolia script."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps documentation lookup to the Copilot tool surface."]
+      "differences": [
+        "MCP server registration is harness-specific; the bundled curl and jq search script is the portable fallback."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies documentation discovery and retrieval adapters."]
+      "differences": [
+        "The host must provide HTTP retrieval and optionally an MCP client; script-based search remains available."
+      ]
     }
   },
   "limitations": [
-    "Current Camunda behavior depends on access to the official documentation source."
+    "Current Camunda behavior depends on network access to the official documentation source or a current local cache."
   ],
   "differences": [
-    "Documentation lookups use the harness's network, browser, or cached documentation retrieval capability."
+    "The MCP and Algolia paths return different result shapes, so the skill normalizes both to source-backed documentation lookup."
   ]
 }

--- a/skills/camunda-feel/portability.json
+++ b/skills/camunda-feel/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and uses the documented cluster-first FEEL evaluation path."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps FEEL evaluation to the Copilot tool surface."]
+      "differences": [
+        "Maps c8ctl feel evaluate, variable input, and expression-file editing to Copilot terminal capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies discovery and FEEL evaluation adapters."]
+      "differences": [
+        "The host supplies a Camunda FEEL engine and adapters for variables, files, and result reporting."
+      ]
     }
   },
   "limitations": [
-    "Expression evaluation requires a compatible Camunda FEEL engine."
+    "Expression evaluation requires a Camunda 8.9 or newer cluster for the default c8ctl path, or an explicitly selected compatible local engine."
   ],
   "differences": [
-    "FEEL expressions are evaluated through a harness-provided c8ctl or local FEEL engine with potentially different runtime capabilities."
+    "Expression syntax is harness-neutral; cluster and local engines can differ in available functions and coercion behavior."
   ]
 }

--- a/skills/camunda-forms/portability.json
+++ b/skills/camunda-forms/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and edits the portable .form JSON artifact."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps form modeling operations to the Copilot tool surface."]
+      "differences": [
+        "Maps JSON editing, schema validation, and optional c8ctl checks to Copilot terminal capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies form discovery and validation adapters."]
+      "differences": [
+        "The host supplies JSON editing and validation tools; BPMN linking remains an explicit cross-skill step."
+      ]
     }
   },
   "limitations": [
-    "Form validation depends on the host's supported Camunda form tooling."
+    "Form validation requires a JSON-aware editor or validator and a Camunda 8.8+ BPMN project for live linking."
   ],
   "differences": [
-    "Form JSON authoring and FEEL validation depend on the harness exposing Camunda form tooling."
+    "Form JSON is portable; editor previews, schema checks, and FEEL evaluation depend on host-provided tooling."
   ]
 }

--- a/skills/camunda-job-workers/portability.json
+++ b/skills/camunda-job-workers/portability.json
@@ -28,7 +28,7 @@
     }
   },
   "limitations": [
-    "Worker implementation requires the selected SDK, its supported runtime, and a reachable Camunda 8.8+ cluster."
+    "Worker implementation requires the selected SDK, its supported runtime, and a reachable Camunda 8.8+ cluster; the @camunda8/orchestration-cluster-api TypeScript path requires Camunda 8.9+, while @camunda8/sdk covers older targets."
   ],
   "differences": [
     "Worker handler semantics are harness-neutral; SDK installation, build, process control, and cluster credentials are host-managed."

--- a/skills/camunda-job-workers/portability.json
+++ b/skills/camunda-job-workers/portability.json
@@ -28,7 +28,7 @@
     }
   },
   "limitations": [
-    "Standard worker implementations target a reachable Camunda 8.8+ cluster; the @camunda8/orchestration-cluster-api TypeScript path requires Camunda 8.9+, while @camunda8/sdk is the fallback within supported 8.8+ projects for needs such as gRPC streaming or migration. Sub-8.8 targets are outside this skill's supported scope."
+    "Java and Spring worker implementations target a reachable Camunda 8.8+ cluster. The @camunda8/orchestration-cluster-api TypeScript path requires Camunda 8.9+, while the Node-only @camunda8/sdk remains the documented fallback for gRPC streaming, Camunda 8.7-or-earlier targets, Operate v1 queries, or migration friction; browser-hosted workers cannot use that fallback."
   ],
   "differences": [
     "Worker handler semantics are harness-neutral; SDK installation, build, process control, and cluster credentials are host-managed."

--- a/skills/camunda-job-workers/portability.json
+++ b/skills/camunda-job-workers/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and selects the documented Java, Spring, or TypeScript worker path."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps worker implementation operations to the Copilot tool surface."]
+      "differences": [
+        "Maps source editing, SDK dependency commands, and worker process execution to Copilot terminal capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies code generation and build adapters."]
+      "differences": [
+        "The host supplies the selected language runtime, build tool, and Camunda cluster credential adapters."
+      ]
     }
   },
   "limitations": [
-    "Worker implementation requires the selected SDK and its supported runtime."
+    "Worker implementation requires the selected SDK, its supported runtime, and a reachable Camunda 8.8+ cluster."
   ],
   "differences": [
-    "Worker implementation commands depend on the harness's language SDK, build runner, and runtime process controls."
+    "Worker handler semantics are harness-neutral; SDK installation, build, process control, and cluster credentials are host-managed."
   ]
 }

--- a/skills/camunda-job-workers/portability.json
+++ b/skills/camunda-job-workers/portability.json
@@ -28,7 +28,7 @@
     }
   },
   "limitations": [
-    "Standard worker implementations target a reachable Camunda 8.8+ cluster; the @camunda8/orchestration-cluster-api TypeScript path requires Camunda 8.9+, while @camunda8/sdk is the fallback for sub-8.8 targets."
+    "Standard worker implementations target a reachable Camunda 8.8+ cluster; the @camunda8/orchestration-cluster-api TypeScript path requires Camunda 8.9+, while @camunda8/sdk is the fallback within supported 8.8+ projects for needs such as gRPC streaming or migration. Sub-8.8 targets are outside this skill's supported scope."
   ],
   "differences": [
     "Worker handler semantics are harness-neutral; SDK installation, build, process control, and cluster credentials are host-managed."

--- a/skills/camunda-job-workers/portability.json
+++ b/skills/camunda-job-workers/portability.json
@@ -28,7 +28,7 @@
     }
   },
   "limitations": [
-    "Worker implementation requires the selected SDK, its supported runtime, and a reachable Camunda 8.8+ cluster; the @camunda8/orchestration-cluster-api TypeScript path requires Camunda 8.9+, while @camunda8/sdk covers older targets."
+    "Standard worker implementations target a reachable Camunda 8.8+ cluster; the @camunda8/orchestration-cluster-api TypeScript path requires Camunda 8.9+, while @camunda8/sdk is the fallback for sub-8.8 targets."
   ],
   "differences": [
     "Worker handler semantics are harness-neutral; SDK installation, build, process control, and cluster credentials are host-managed."

--- a/skills/camunda-process-mgmt/portability.json
+++ b/skills/camunda-process-mgmt/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and invokes c8ctl with an explicit profile for mutations."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps cluster operations to the Copilot tool surface."]
+      "differences": [
+        "Maps c8ctl deployment, inspection, and mutation commands to Copilot terminal and credential capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies cluster discovery and operation adapters."]
+      "differences": [
+        "The host supplies profile selection, authentication, and result adapters for live cluster operations."
+      ]
     }
   },
   "limitations": [
-    "Live process operations require a reachable and authorized Camunda cluster."
+    "Live process operations require a reachable and authorized Camunda 8.8+ cluster plus an installed c8ctl CLI."
   ],
   "differences": [
-    "Deployment and process-operation commands require the harness to map credentials and cluster endpoints into c8ctl."
+    "Deployment and process-operation semantics are stable; profile credentials, endpoints, and confirmation prompts are host-managed."
   ]
 }

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: camunda-process-test
 description: |
-  Use this skill to author and run Camunda Process Test suites for 100% BPMN coverage. Use it for segment planning, `.test.json` scenarios, Java fallback tests, `mvn test`, coverage reports, and suite maintenance. Do not use it to author BPMN, DMN, FEEL, or forms, deploy live processes, or build UI/E2E tests.
+  Use this skill to author and run Camunda Process Test suites for 100% BPMN coverage. Use it for segment planning, `.test.json` scenarios, Java fallback tests, Maven test commands, coverage reports, and suite maintenance. Do not use it to author BPMN, DMN, FEEL, or forms, deploy live processes, or build UI/E2E tests.
 ---
 
 # Camunda Process Test
 
-**WORKFLOW SKILL**: plan segments, author scenarios, run `mvn test`, and close coverage gaps.
+**WORKFLOW SKILL**: plan segments, author scenarios, run the Maven test command, and close coverage gaps.
 
 ## DO NOT USE FOR:
 
@@ -17,8 +17,12 @@ Author and run Camunda Process Test suites for Camunda 8.8+ that reach **100% BP
 ## Prerequisites
 
 - Java 21+, Maven (or `./mvnw`), Docker runtime (OrbStack, Docker Desktop, or Rancher Desktop) — see [references/setup.md](references/setup.md)
-- `camunda-process-test-spring` 8.9+ on the test classpath (instruction-based JSON format requires 8.9)
+- `camunda-process-test-spring` 8.8+ on the test classpath; the instruction-based JSON format and 8.9-only APIs require 8.9+
 - A working BPMN file (lint clean — see camunda-bpmn). DMN and form files referenced by the BPMN must also be present.
+
+For a Node.js layout, set `NODE_RESOURCE_DIR` as described in [references/setup.md](references/setup.md). Use
+`-Dnode.resource.dir="${NODE_RESOURCE_DIR:-}"` on every Maven command below; the empty property is harmless
+for standard Java layouts.
 
 ## Cross-References
 
@@ -64,11 +68,12 @@ Then classify current suite gaps:
 - **Stale**: IDs still exist, but branch-driving variables or assumptions no longer match gateway/DMN behavior.
 - **Missing**: new branches, boundary events, or end events have no segment coverage.
 
-Fix in this order: broken → stale → missing, then run `mvn test` and continue with coverage verification.
+Fix in this order: broken → stale → missing, then run `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test`
+and continue with coverage verification.
 
 ### 2. Setup (only if missing)
 
-Follow [references/setup.md](references/setup.md): run the readiness preflight (Java, Maven/wrapper, Docker), add the CPT dependency, scaffold `src/test/java/io/camunda/tests/ProcessTest.java` and `src/test/resources/scenarios/`. Confirm with `mvn test-compile`.
+Follow [references/setup.md](references/setup.md): run the readiness preflight (Java, Maven/wrapper, Docker), add the CPT dependency, scaffold `src/test/java/io/camunda/tests/ProcessTest.java` and `src/test/resources/scenarios/`. Confirm with `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test-compile`.
 
 ### 3. Plan segments (set-cover, not per-element)
 
@@ -91,7 +96,7 @@ Use the Java fallback only when the segment needs Spring bean mocking, parameter
 ### 5. Run
 
 ```bash
-mvn test
+mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test
 ```
 
 On failure, diagnose with [references/troubleshooting.md](references/troubleshooting.md). Distinguish **test problems** (variable typo, wrong element id, missing instruction) from **process problems** (wrong FEEL condition, wrong DMN rule, wrong error code). Fix the right side. Re-run. Stop after 3 repair cycles with no progress.
@@ -142,7 +147,7 @@ PY
 
 Diff against the BPMN element + sequenceFlow id list (`grep -oE 'id="[A-Za-z0-9_]+"' <bpmn>`, exclude `_di`, `BPMNDiagram`, `BPMNPlane`, `Definitions_`, `ErrorDef_`, `TimerDef_`, `Signal_`, `Message_`).
 
-**Surface the HTML report path to the user as soon as `mvn test` exits — pass or fail.** The agent already verifies coverage from the JSON data above; the HTML report is for the user to inspect. Print the absolute path (`target/coverage-report/report.html`) in the final reply so they can open it themselves. In an interactive local session you may additionally offer to open it on their behalf (`open` on macOS, `xdg-open` on Linux, `start` on Windows) — do not run that unprompted in a sandboxed / remote environment where it has no effect.
+**Surface the HTML report path to the user as soon as `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test` exits — pass or fail.** The agent already verifies coverage from the JSON data above; the HTML report is for the user to inspect. Print the absolute path (`target/coverage-report/report.html`) in the final reply so they can open it themselves. In an interactive local session you may additionally offer to open it on their behalf (`open` on macOS, `xdg-open` on Linux, `start` on Windows) — do not run that unprompted in a sandboxed / remote environment where it has no effect.
 
 **Patch-loop on prediction misses — default behavior.** Set-cover planning in step 3 should reach 100% on the first authoring pass. When it does not, the gap is a *prediction miss*: the static walk for some candidate did not match runtime behavior. For each uncovered id:
 
@@ -150,7 +155,7 @@ Diff against the BPMN element + sequenceFlow id list (`grep -oE 'id="[A-Za-z0-9_
 2. Re-run greedy set-cover restricted to the remaining uncovered ids. Add the chosen candidates (often one) to the scenario file.
 3. For timer boundary events: use `INCREASE_TIME` with an ISO 8601 `duration` greater than the timer cycle (e.g. `"PT25H"` for `R/PT24H`). The boundary fires; the outgoing path's job is created; complete it with `COMPLETE_JOB`.
 4. For message boundary events: `PUBLISH_MESSAGE` instruction with matching name + correlationKey.
-5. Re-run step 5 (`mvn test`) → step 6. Each iteration should strictly reduce the uncovered set; if it does not, the planner's path prediction is wrong — fix the prediction logic in [references/coverage-strategy.md](references/coverage-strategy.md), do not paper over with more scenarios.
+5. Re-run step 5 (`mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test`) → step 6. Each iteration should strictly reduce the uncovered set; if it does not, the planner's path prediction is wrong — fix the prediction logic in [references/coverage-strategy.md](references/coverage-strategy.md), do not paper over with more scenarios.
 
 Hard blockers that terminate the loop:
 
@@ -187,7 +192,7 @@ Duplicates flagged: 0
 
 When tests already exist and the user asks to run, diagnose, or improve them (without generating a brand-new suite), use these focused workflows:
 
-1. **Run and diagnose failures** — execute `mvn test`, classify each failure as infrastructure/test/process, then fix in batches. Use [references/troubleshooting.md](references/troubleshooting.md) plus [references/run-and-diagnose.md](references/run-and-diagnose.md).
+1. **Run and diagnose failures** — execute `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test`, classify each failure as infrastructure/test/process, then fix in batches. Use [references/troubleshooting.md](references/troubleshooting.md) plus [references/run-and-diagnose.md](references/run-and-diagnose.md).
 2. **Evaluate coverage gaps before writing new tests** — explain current suite coverage in business terms, list uncovered branches/boundaries/rules, and recommend the smallest next set of scenarios. See [references/evaluation.md](references/evaluation.md).
 3. **Wire tests into CI** — configure CI to run CPT reliably and publish JUnit artifacts, with optional integration profile runs gated to trusted branches. See [references/ci.md](references/ci.md).
 

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -94,6 +94,10 @@ For CPT 8.9+, use the Java fallback only when the segment needs Spring bean mock
 
 ### 5. Run
 
+Run Maven from the directory containing the relevant `pom.xml`. For a Node.js layout, use the
+generated `test/` directory and keep `NODE_RESOURCE_DIR` set to the resolved resource directory
+for this command and every retry, as described in [references/setup.md](references/setup.md).
+
 ```bash
 mvn test
 ```
@@ -191,7 +195,7 @@ Duplicates flagged: 0
 
 When tests already exist and the user asks to run, diagnose, or improve them (without generating a brand-new suite), use these focused workflows:
 
-1. **Run and diagnose failures** — execute `mvn test`, classify each failure as infrastructure/test/process, then fix in batches. Use [references/troubleshooting.md](references/troubleshooting.md) plus [references/run-and-diagnose.md](references/run-and-diagnose.md).
+1. **Run and diagnose failures** — execute `mvn test` from the directory containing the relevant `pom.xml`; for a Node.js layout, run it from `test/` with `NODE_RESOURCE_DIR` set to the resolved resource directory for the initial run and every retry. Classify each failure as infrastructure/test/process, then fix in batches. Use [references/troubleshooting.md](references/troubleshooting.md) plus [references/run-and-diagnose.md](references/run-and-diagnose.md).
 2. **Evaluate coverage gaps before writing new tests** — explain current suite coverage in business terms, list uncovered branches/boundaries/rules, and recommend the smallest next set of scenarios. See [references/evaluation.md](references/evaluation.md).
 3. **Wire tests into CI** — configure CI to run CPT reliably and publish JUnit artifacts, with optional integration profile runs gated to trusted branches. See [references/ci.md](references/ci.md).
 

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: camunda-process-test
 description: |
-  Use this skill to author and run Camunda Process Test (CPT) suites that cover every BPMN gateway branch, DMN rule, and error boundary to 100%.
-
-  Use for: scaffolding the `camunda-process-test-spring` harness, planning the minimum set of test segments for full element coverage, authoring `.test.json` instruction-based scenarios, running `mvn test`, parsing the CPT coverage report, deduplicating redundant segments.
-
-  Do not use for: authoring the BPMN (use camunda-bpmn), writing FEEL or DMN expressions (use camunda-feel), deploying to a live cluster (use camunda-process-mgmt), UI or E2E tests against Operate or Tasklist.
-
-  **Workflow skill** — segment-based authoring loop covering `mvn test`, coverage report parsing, and scenario deduplication.
+  Use this skill to author and run Camunda Process Test suites for 100% BPMN coverage. Use it for segment planning, `.test.json` scenarios, Java fallback tests, `mvn test`, coverage reports, and suite maintenance. Do not use it to author BPMN, DMN, FEEL, or forms, deploy live processes, or build UI/E2E tests.
 ---
 
 # Camunda Process Test
+
+**WORKFLOW SKILL**: plan segments, author scenarios, run `mvn test`, and close coverage gaps.
+
+## DO NOT USE FOR:
+
+Do not use this skill to author BPMN, DMN, FEEL, or forms, deploy to a live cluster, or test UI behavior. Route those tasks to **camunda-bpmn**, **camunda-dmn**, **camunda-feel**, **camunda-forms**, **camunda-process-mgmt**, or the relevant UI test framework.
 
 Author and run Camunda Process Test suites for Camunda 8.8+ that reach **100% BPMN element coverage** with the minimum number of test segments. Test assertions are limited to reachability and routing — CPT exercises that the engine traverses the right elements, not the data values produced by service tasks or external systems.
 
@@ -43,7 +43,8 @@ Find the BPMN under test in priority order:
 
 1. `src/main/resources/processes/`
 2. `src/main/resources/bpmn/`
-3. `../resources/` (Node.js layouts where the test harness lives in `test/`)
+3. The resource directory declared by the project build (for example, a Node.js
+   project may keep it at `resources/` while the test harness lives in `test/`).
 
 Skip `target/`, `node_modules/`, `.git/`, `build/`. If multiple files match, list them and ask which to target.
 
@@ -78,6 +79,8 @@ Plan the minimum number of segments **before** authoring anything. Apply [refere
 3. **Greedy set-cover.** Repeatedly pick the candidate whose predicted set covers the largest number of still-uncovered ids. Tie-break by shortest path (cheapest to author). Stop when the union covers every id.
 4. **Diagnostic-isolation override (optional).** If two chosen segments share a root but exercise different failure modes (e.g. one fires a boundary event, the other completes the user task normally), keep both so a failure points at one cause cleanly. Apply only when the user is debugging a specific area; default is pure set-cover.
 5. Print the segment plan as a table: `segment name | root | predicted ids covered | end condition`. Authoring then implements exactly this list — no speculative scenarios that may be deduped later.
+
+**Example:** for a gateway with `approved` and `rejected` flows, plan one segment per flow, predict the visited IDs through the next join, and keep the smallest set of segments that covers both branches and the shared end path.
 
 ### 4. Author
 

--- a/skills/camunda-process-test/SKILL.md
+++ b/skills/camunda-process-test/SKILL.md
@@ -17,12 +17,12 @@ Author and run Camunda Process Test suites for Camunda 8.8+ that reach **100% BP
 ## Prerequisites
 
 - Java 21+, Maven (or `./mvnw`), Docker runtime (OrbStack, Docker Desktop, or Rancher Desktop) — see [references/setup.md](references/setup.md)
-- `camunda-process-test-spring` 8.8+ on the test classpath; the instruction-based JSON format and 8.9-only APIs require 8.9+
+- `camunda-process-test-spring` 8.8+ on the test classpath for Java fallback suites; the instruction-based `.test.json` format and 8.9-only APIs require 8.9+
 - A working BPMN file (lint clean — see camunda-bpmn). DMN and form files referenced by the BPMN must also be present.
 
-For a Node.js layout, set `NODE_RESOURCE_DIR` as described in [references/setup.md](references/setup.md). Use
-`-Dnode.resource.dir="${NODE_RESOURCE_DIR:-}"` on every Maven command below; the empty property is harmless
-for standard Java layouts.
+For a Node.js layout, set `NODE_RESOURCE_DIR` and run Maven from the generated `test/` directory as
+described in [references/setup.md](references/setup.md). The Maven commands below are shell-neutral; the
+Node.js POM reads the environment variable and standard Java layouts do not need it.
 
 ## Cross-References
 
@@ -68,12 +68,11 @@ Then classify current suite gaps:
 - **Stale**: IDs still exist, but branch-driving variables or assumptions no longer match gateway/DMN behavior.
 - **Missing**: new branches, boundary events, or end events have no segment coverage.
 
-Fix in this order: broken → stale → missing, then run `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test`
-and continue with coverage verification.
+Fix in this order: broken → stale → missing, then run `mvn test` and continue with coverage verification.
 
 ### 2. Setup (only if missing)
 
-Follow [references/setup.md](references/setup.md): run the readiness preflight (Java, Maven/wrapper, Docker), add the CPT dependency, scaffold `src/test/java/io/camunda/tests/ProcessTest.java` and `src/test/resources/scenarios/`. Confirm with `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test-compile`.
+Follow [references/setup.md](references/setup.md): run the readiness preflight (Java, Maven/wrapper, Docker), add the CPT dependency, scaffold `src/test/java/io/camunda/tests/ProcessTest.java` and `src/test/resources/scenarios/` for CPT 8.9+, or use the Java fallback for CPT 8.8. Confirm with `mvn test-compile`.
 
 ### 3. Plan segments (set-cover, not per-element)
 
@@ -89,14 +88,14 @@ Plan the minimum number of segments **before** authoring anything. Apply [refere
 
 ### 4. Author
 
-For each segment, write one entry inside `src/test/resources/scenarios/<processId>.test.json` using [references/authoring.md](references/authoring.md). Naming: `"<who/what> — <outcome>"`. Assertions: `ASSERT_ELEMENT_INSTANCES` on the elements the segment must visit, `ASSERT_PROCESS_INSTANCE` only when the segment runs to an end event.
+For CPT 8.9+, write one entry inside `src/test/resources/scenarios/<processId>.test.json` using [references/authoring.md](references/authoring.md). For CPT 8.8, use the Java fallback described in that reference instead of `.test.json`. Naming: `"<who/what> — <outcome>"`. Assertions: `ASSERT_ELEMENT_INSTANCES` on the elements the segment must visit, `ASSERT_PROCESS_INSTANCE` only when the segment runs to an end event.
 
-Use the Java fallback only when the segment needs Spring bean mocking, parameterized data tables, non-deterministic runtime races (`context.when().then()` *(8.9+)*), or assertions richer than the JSON instruction set offers — see [references/test-context.md](references/test-context.md). Accept that Java tests are invisible to Web Modeler.
+For CPT 8.9+, use the Java fallback only when the segment needs Spring bean mocking, parameterized data tables, non-deterministic runtime races (`context.when().then()` *(8.9+)*), or assertions richer than the JSON instruction set offers. For CPT 8.8, Java tests are required because the instruction-based format is not available. See [references/test-context.md](references/test-context.md); Java tests are invisible to Web Modeler.
 
 ### 5. Run
 
 ```bash
-mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test
+mvn test
 ```
 
 On failure, diagnose with [references/troubleshooting.md](references/troubleshooting.md). Distinguish **test problems** (variable typo, wrong element id, missing instruction) from **process problems** (wrong FEEL condition, wrong DMN rule, wrong error code). Fix the right side. Re-run. Stop after 3 repair cycles with no progress.
@@ -147,7 +146,7 @@ PY
 
 Diff against the BPMN element + sequenceFlow id list (`grep -oE 'id="[A-Za-z0-9_]+"' <bpmn>`, exclude `_di`, `BPMNDiagram`, `BPMNPlane`, `Definitions_`, `ErrorDef_`, `TimerDef_`, `Signal_`, `Message_`).
 
-**Surface the HTML report path to the user as soon as `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test` exits — pass or fail.** The agent already verifies coverage from the JSON data above; the HTML report is for the user to inspect. Print the absolute path (`target/coverage-report/report.html`) in the final reply so they can open it themselves. In an interactive local session you may additionally offer to open it on their behalf (`open` on macOS, `xdg-open` on Linux, `start` on Windows) — do not run that unprompted in a sandboxed / remote environment where it has no effect.
+**Surface the HTML report path to the user as soon as `mvn test` exits — pass or fail.** The agent already verifies coverage from the JSON data above; the HTML report is for the user to inspect. Print the absolute path (`target/coverage-report/report.html`) in the final reply so they can open it themselves. In an interactive local session you may additionally offer to open it on their behalf (`open` on macOS, `xdg-open` on Linux, `start` on Windows) — do not run that unprompted in a sandboxed / remote environment where it has no effect.
 
 **Patch-loop on prediction misses — default behavior.** Set-cover planning in step 3 should reach 100% on the first authoring pass. When it does not, the gap is a *prediction miss*: the static walk for some candidate did not match runtime behavior. For each uncovered id:
 
@@ -155,7 +154,7 @@ Diff against the BPMN element + sequenceFlow id list (`grep -oE 'id="[A-Za-z0-9_
 2. Re-run greedy set-cover restricted to the remaining uncovered ids. Add the chosen candidates (often one) to the scenario file.
 3. For timer boundary events: use `INCREASE_TIME` with an ISO 8601 `duration` greater than the timer cycle (e.g. `"PT25H"` for `R/PT24H`). The boundary fires; the outgoing path's job is created; complete it with `COMPLETE_JOB`.
 4. For message boundary events: `PUBLISH_MESSAGE` instruction with matching name + correlationKey.
-5. Re-run step 5 (`mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test`) → step 6. Each iteration should strictly reduce the uncovered set; if it does not, the planner's path prediction is wrong — fix the prediction logic in [references/coverage-strategy.md](references/coverage-strategy.md), do not paper over with more scenarios.
+5. Re-run step 5 (`mvn test`) → step 6. Each iteration should strictly reduce the uncovered set; if it does not, the planner's path prediction is wrong — fix the prediction logic in [references/coverage-strategy.md](references/coverage-strategy.md), do not paper over with more scenarios.
 
 Hard blockers that terminate the loop:
 
@@ -192,7 +191,7 @@ Duplicates flagged: 0
 
 When tests already exist and the user asks to run, diagnose, or improve them (without generating a brand-new suite), use these focused workflows:
 
-1. **Run and diagnose failures** — execute `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test`, classify each failure as infrastructure/test/process, then fix in batches. Use [references/troubleshooting.md](references/troubleshooting.md) plus [references/run-and-diagnose.md](references/run-and-diagnose.md).
+1. **Run and diagnose failures** — execute `mvn test`, classify each failure as infrastructure/test/process, then fix in batches. Use [references/troubleshooting.md](references/troubleshooting.md) plus [references/run-and-diagnose.md](references/run-and-diagnose.md).
 2. **Evaluate coverage gaps before writing new tests** — explain current suite coverage in business terms, list uncovered branches/boundaries/rules, and recommend the smallest next set of scenarios. See [references/evaluation.md](references/evaluation.md).
 3. **Wire tests into CI** — configure CI to run CPT reliably and publish JUnit artifacts, with optional integration profile runs gated to trusted branches. See [references/ci.md](references/ci.md).
 

--- a/skills/camunda-process-test/portability.json
+++ b/skills/camunda-process-test/portability.json
@@ -10,21 +10,27 @@
   "harnesses": {
     "claude": {
       "status": "native",
-      "differences": ["Uses the repository's Claude Code skill discovery path."]
+      "differences": [
+        "Loads the standard SKILL.md package and follows the segment-planning and coverage-report workflow."
+      ]
     },
     "copilot": {
       "status": "adapter-required",
-      "differences": ["Maps process test operations to the Copilot tool surface."]
+      "differences": [
+        "Maps Maven, Docker, source editing, and coverage-report commands to Copilot terminal capabilities."
+      ]
     },
     "generic": {
       "status": "adapter-required",
-      "differences": ["The host supplies test execution and reporting adapters."]
+      "differences": [
+        "The host supplies Java, Maven, Docker, and test-report adapters for the embedded engine."
+      ]
     }
   },
   "limitations": [
-    "Process tests require the supported Camunda Process Test runtime and build tools."
+    "Process tests require Camunda Process Test 8.9+, Java 21+, Maven, Docker, and a test project with the referenced resources."
   ],
   "differences": [
-    "Process-test execution depends on the harness's Java/Maven runner and embedded engine support."
+    "Scenario and coverage semantics are harness-neutral; Java/Maven execution, Docker lifecycle, and report collection are host-managed."
   ]
 }

--- a/skills/camunda-process-test/portability.json
+++ b/skills/camunda-process-test/portability.json
@@ -28,7 +28,7 @@
     }
   },
   "limitations": [
-    "Process tests require Camunda Process Test 8.9+, Java 21+, Maven, Docker, and a test project with the referenced resources."
+    "Process tests require Camunda Process Test 8.8+, Java 21+, Maven, Docker, and a test project with the referenced resources; the instruction-based .test.json workflow requires 8.9+."
   ],
   "differences": [
     "Scenario and coverage semantics are harness-neutral; Java/Maven execution, Docker lifecycle, and report collection are host-managed."

--- a/skills/camunda-process-test/references/authoring.md
+++ b/skills/camunda-process-test/references/authoring.md
@@ -1,6 +1,6 @@
 # Authoring CPT scenarios
 
-> Default to `.test.json` (instruction-based). Use Java `@Test` only when JSON cannot express the test — see [§ Java fallback](#java-fallback) at the bottom.
+> For CPT 8.9+, default to `.test.json` (instruction-based). CPT 8.8 suites must use Java `@Test`; for 8.9+, use Java only when JSON cannot express the test — see [§ Java fallback](#java-fallback) at the bottom.
 
 ## `.test.json` format
 

--- a/skills/camunda-process-test/references/ci.md
+++ b/skills/camunda-process-test/references/ci.md
@@ -29,8 +29,8 @@ jobs:
           distribution: temurin
           java-version: '21'
           cache: maven
-      - name: Run CPT tests
-        run: mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test
+      - name: Run CPT tests (standard Java layout)
+        run: mvn test
       - name: Upload Surefire reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -39,10 +39,23 @@ jobs:
           path: "**/target/surefire-reports/*.xml"
 ```
 
+For a Node.js layout, replace the test step with a step that runs from the generated `test/` directory
+and sets `NODE_RESOURCE_DIR` to the resource directory declared by the project build:
+
+```yaml
+      - name: Run CPT tests (Node.js harness)
+        working-directory: test
+        env:
+          NODE_RESOURCE_DIR: ${{ github.workspace }}/<resource-path-declared-by-project-build>
+        run: mvn test
+```
+
 ## Optional split: process vs integration profile
 
-- Keep the Maven test command on pull requests for fast feedback.
-- Run integration profile jobs (`mvn verify -P integration-test`) on protected branches or scheduled runs.
+- Keep the Maven test command on pull requests for fast feedback. For Node.js layouts, run it from
+  `test/` with the same `NODE_RESOURCE_DIR` environment setting.
+- Run the integration profile (`mvn verify -P integration-test`) on protected branches or scheduled runs,
+  using the same working directory and environment setting for Node.js layouts.
 - Store required cluster credentials in CI secrets, never in repo files.
 
 ## Common CI failure causes

--- a/skills/camunda-process-test/references/ci.md
+++ b/skills/camunda-process-test/references/ci.md
@@ -30,7 +30,7 @@ jobs:
           java-version: '21'
           cache: maven
       - name: Run CPT tests
-        run: mvn test
+        run: mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test
       - name: Upload Surefire reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -41,7 +41,7 @@ jobs:
 
 ## Optional split: process vs integration profile
 
-- Keep `mvn test` on pull requests for fast feedback.
+- Keep the Maven test command on pull requests for fast feedback.
 - Run integration profile jobs (`mvn verify -P integration-test`) on protected branches or scheduled runs.
 - Store required cluster credentials in CI secrets, never in repo files.
 

--- a/skills/camunda-process-test/references/coverage-strategy.md
+++ b/skills/camunda-process-test/references/coverage-strategy.md
@@ -95,7 +95,7 @@ Author exactly this list.
 
 ## Step 5 — verify against the CPT report
 
-Run `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test`. Parse `target/coverage-report/report.html` (the page embeds the full dataset as a `window.COVERAGE_DATA` JSON literal — see SKILL.md for the extractor).
+Run `mvn test`. For a Node.js layout, run it from `test/` with `NODE_RESOURCE_DIR` set as described in [setup.md](setup.md). Parse `target/coverage-report/report.html` (the page embeds the full dataset as a `window.COVERAGE_DATA` JSON literal — see SKILL.md for the extractor).
 
 If aggregate runtime coverage equals predicted coverage, done. If it does not, the gap is a **prediction miss** — the static walk for one of the chosen candidates did not match the engine's actual path. Common causes: gateway condition the parser couldn't evaluate, FEEL expression depending on a variable the planner did not set, non-interrupting boundary that creates a parallel branch the walker missed.
 

--- a/skills/camunda-process-test/references/coverage-strategy.md
+++ b/skills/camunda-process-test/references/coverage-strategy.md
@@ -95,7 +95,7 @@ Author exactly this list.
 
 ## Step 5 — verify against the CPT report
 
-Run `mvn test`. Parse `target/coverage-report/report.html` (the page embeds the full dataset as a `window.COVERAGE_DATA` JSON literal — see SKILL.md for the extractor).
+Run `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test`. Parse `target/coverage-report/report.html` (the page embeds the full dataset as a `window.COVERAGE_DATA` JSON literal — see SKILL.md for the extractor).
 
 If aggregate runtime coverage equals predicted coverage, done. If it does not, the gap is a **prediction miss** — the static walk for one of the chosen candidates did not match the engine's actual path. Common causes: gateway condition the parser couldn't evaluate, FEEL expression depending on a variable the planner did not set, non-interrupting boundary that creates a parallel branch the walker missed.
 

--- a/skills/camunda-process-test/references/run-and-diagnose.md
+++ b/skills/camunda-process-test/references/run-and-diagnose.md
@@ -8,14 +8,14 @@ Use this when tests already exist and the user asks to run/fix them.
 2. Run:
 
 ```bash
-mvn test
+mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test
 ```
 
 3. If tests fail, classify each failure:
    - **Infrastructure** (Docker down, deployment parse failure, missing resources)
    - **Test defect** (wrong IDs, missing instruction, stale variable names)
    - **Process defect** (gateway logic, DMN rule behavior, BPMN error code mismatch)
-4. Apply fixes in batches by class (not one-by-one churn), then re-run `mvn test`.
+4. Apply fixes in batches by class (not one-by-one churn), then re-run `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test`.
 5. Stop after 3 no-progress cycles — defined as a re-run producing no reduction in failing tests and no new diagnostic signal — and surface blockers explicitly.
 
 ## Failure-class defaults

--- a/skills/camunda-process-test/references/run-and-diagnose.md
+++ b/skills/camunda-process-test/references/run-and-diagnose.md
@@ -5,7 +5,9 @@ Use this when tests already exist and the user asks to run/fix them.
 ## Execution loop
 
 1. Ensure Docker runtime is available (see [setup.md](setup.md)).
-2. Run:
+2. Run Maven from the directory containing the relevant `pom.xml`. For a Node.js layout, run it
+   from the generated `test/` directory with `NODE_RESOURCE_DIR` set to the resource directory
+   declared by the project build (see [setup.md](setup.md)):
 
 ```bash
 mvn test
@@ -15,7 +17,8 @@ mvn test
    - **Infrastructure** (Docker down, deployment parse failure, missing resources)
    - **Test defect** (wrong IDs, missing instruction, stale variable names)
    - **Process defect** (gateway logic, DMN rule behavior, BPMN error code mismatch)
-4. Apply fixes in batches by class (not one-by-one churn), then re-run `mvn test`.
+4. Apply fixes in batches by class (not one-by-one churn), then re-run `mvn test` from the same
+   Maven directory with the same `NODE_RESOURCE_DIR` setting.
 5. Stop after 3 no-progress cycles — defined as a re-run producing no reduction in failing tests and no new diagnostic signal — and surface blockers explicitly.
 
 ## Failure-class defaults

--- a/skills/camunda-process-test/references/run-and-diagnose.md
+++ b/skills/camunda-process-test/references/run-and-diagnose.md
@@ -8,14 +8,14 @@ Use this when tests already exist and the user asks to run/fix them.
 2. Run:
 
 ```bash
-mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test
+mvn test
 ```
 
 3. If tests fail, classify each failure:
    - **Infrastructure** (Docker down, deployment parse failure, missing resources)
    - **Test defect** (wrong IDs, missing instruction, stale variable names)
    - **Process defect** (gateway logic, DMN rule behavior, BPMN error code mismatch)
-4. Apply fixes in batches by class (not one-by-one churn), then re-run `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test`.
+4. Apply fixes in batches by class (not one-by-one churn), then re-run `mvn test`.
 5. Stop after 3 no-progress cycles — defined as a re-run producing no reduction in failing tests and no new diagnostic signal — and surface blockers explicitly.
 
 ## Failure-class defaults

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -56,6 +56,10 @@ Required entry in the project (or test harness) `pom.xml`:
 </dependencies>
 ```
 
+The dependency and `@TestCaseSource` scaffold above are for the 8.9+ instruction-based workflow. For
+an 8.8 project, pin a compatible 8.8.x release and use the Java fallback tests described in
+[authoring.md](authoring.md#java-fallback).
+
 Use 8.9+ for the instruction-based `.test.json` format (`CREATE_PROCESS_INSTANCE`, `COMPLETE_JOB`, …).
 Java fallback-only suites can use a compatible 8.8.x release.
 
@@ -155,7 +159,7 @@ If the project root has `package.json` but no `pom.xml`, scaffold a sibling `tes
     <excludes><exclude>scenarios/**</exclude></excludes>
   </testResource>
   <testResource>
-    <directory>${node.resource.dir}</directory>
+    <directory>${env.NODE_RESOURCE_DIR}</directory>
     <targetPath>processes</targetPath>
     <includes>
       <include>**/*.bpmn</include>
@@ -166,15 +170,26 @@ If the project root has `package.json` but no `pom.xml`, scaffold a sibling `tes
 </testResources>
 ```
 
-Pass the resolved directory to every Maven invocation, including `test` and any retry. The workflow commands
-in `SKILL.md` use the same property:
+Run the commands below from the generated `test/` directory, which contains the `pom.xml`. Set
+`NODE_RESOURCE_DIR` to the resolved directory before running Maven. Maven reads the environment
+property independently of the shell:
 
-```bash
-mvn -Dnode.resource.dir="$NODE_RESOURCE_DIR" test-compile
-mvn -Dnode.resource.dir="$NODE_RESOURCE_DIR" test
+```sh
+export NODE_RESOURCE_DIR=/absolute/path/from-the-project-build
 ```
 
-Do not replace `node.resource.dir` with `../resources` unless that is the directory the project build declares.
+```powershell
+$env:NODE_RESOURCE_DIR = "C:\path\from-the-project-build"
+```
+
+Then run every Maven invocation, including `test` and any retry, from `test/`:
+
+```text
+mvn test-compile
+mvn test
+```
+
+Do not replace `NODE_RESOURCE_DIR` with `../resources` unless that is the directory the project build declares.
 
 ## Filename hygiene
 

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -156,7 +156,6 @@ If the project root has `package.json` but no `pom.xml`, scaffold a sibling `tes
 <testResources>
   <testResource>
     <directory>src/test/resources</directory>
-    <excludes><exclude>scenarios/**</exclude></excludes>
   </testResource>
   <testResource>
     <directory>${env.NODE_RESOURCE_DIR}</directory>

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -145,7 +145,7 @@ Required so `@SpringBootTest` has an application context to load.
 
 ## Node.js project layout
 
-If the project root has `package.json` but no `pom.xml`, scaffold a sibling `test/` directory holding its own `pom.xml`. The test harness reads BPMN / DMN / form files from the parent project via a `<testResource>` mapping:
+If the project root has `package.json` but no `pom.xml`, scaffold a sibling `test/` directory holding its own `pom.xml`. First resolve the BPMN / DMN / form resource directory declared by the Node.js project's build configuration. Set that resolved absolute path, or a path relative to `test/`, as `NODE_RESOURCE_DIR`; do not assume a `resources/` directory:
 
 ```xml
 <testResources>
@@ -154,7 +154,7 @@ If the project root has `package.json` but no `pom.xml`, scaffold a sibling `tes
     <excludes><exclude>scenarios/**</exclude></excludes>
   </testResource>
   <testResource>
-    <directory>../resources</directory>
+    <directory>${node.resource.dir}</directory>
     <targetPath>processes</targetPath>
     <includes>
       <include>**/*.bpmn</include>
@@ -165,7 +165,13 @@ If the project root has `package.json` but no `pom.xml`, scaffold a sibling `tes
 </testResources>
 ```
 
-Confirm the scaffold by running `mvn test-compile` from `test/`.
+Pass the resolved directory to every Maven invocation, for example:
+
+```bash
+mvn -Dnode.resource.dir="$NODE_RESOURCE_DIR" test-compile
+```
+
+Do not replace `node.resource.dir` with `../resources` unless that is the directory the project build declares.
 
 ## Filename hygiene
 

--- a/skills/camunda-process-test/references/setup.md
+++ b/skills/camunda-process-test/references/setup.md
@@ -56,7 +56,8 @@ Required entry in the project (or test harness) `pom.xml`:
 </dependencies>
 ```
 
-Use 8.9+ — the instruction-based `.test.json` format (`CREATE_PROCESS_INSTANCE`, `COMPLETE_JOB`, …) requires it.
+Use 8.9+ for the instruction-based `.test.json` format (`CREATE_PROCESS_INSTANCE`, `COMPLETE_JOB`, …).
+Java fallback-only suites can use a compatible 8.8.x release.
 
 ### Spring Boot 4.x pin (CPT 8.9.x only)
 
@@ -165,10 +166,12 @@ If the project root has `package.json` but no `pom.xml`, scaffold a sibling `tes
 </testResources>
 ```
 
-Pass the resolved directory to every Maven invocation, for example:
+Pass the resolved directory to every Maven invocation, including `test` and any retry. The workflow commands
+in `SKILL.md` use the same property:
 
 ```bash
 mvn -Dnode.resource.dir="$NODE_RESOURCE_DIR" test-compile
+mvn -Dnode.resource.dir="$NODE_RESOURCE_DIR" test
 ```
 
 Do not replace `node.resource.dir` with `../resources` unless that is the directory the project build declares.

--- a/skills/camunda-process-test/references/troubleshooting.md
+++ b/skills/camunda-process-test/references/troubleshooting.md
@@ -1,6 +1,6 @@
 # CPT troubleshooting
 
-Diagnose `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test` failures. Each row classifies the failure as a **test problem** (fix the scenario) or a **process problem** (fix the BPMN, DMN, form, or worker). Confusing the two costs hours.
+Diagnose `mvn test` failures. For a Node.js layout, run it from `test/` with `NODE_RESOURCE_DIR` set as described in [setup.md](setup.md). Each row classifies the failure as a **test problem** (fix the scenario) or a **process problem** (fix the BPMN, DMN, form, or worker). Confusing the two costs hours.
 
 ## Quick triage
 
@@ -34,13 +34,13 @@ When BPMN changed since the last passing suite, sync tests before deep debugging
 1. Diff BPMN changes: `git diff <base-branch>...HEAD -- <bpmn-path>` (often `main`).
 2. Re-read BPMN IDs and compare with scenario `elementId`/`processDefinitionId` references.
 3. Update broken IDs first, then variable-driven branch expectations, then add missing branch segments.
-4. Re-run `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test` and return to the quick-triage table for remaining failures.
+4. Re-run `mvn test` and return to the quick-triage table for remaining failures.
 
 ## Repair discipline
 
 1. Diagnose **every** failure first. Do not start fixing until the full list is classified.
 2. Group fixes by class. Test problems batch into one commit; process problems batch into another. Mixed commits make later reviews hard.
-3. Re-run `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test` once per batch. Three repair cycles without progress means the diagnosis is wrong — stop and re-read.
+3. Re-run `mvn test` once per batch. Three repair cycles without progress means the diagnosis is wrong — stop and re-read.
 4. Never silence a failure by deleting the scenario. If a scenario is genuinely redundant, the deduplication pass in the main workflow handles it — not the repair loop.
 
 ## When in doubt

--- a/skills/camunda-process-test/references/troubleshooting.md
+++ b/skills/camunda-process-test/references/troubleshooting.md
@@ -1,6 +1,6 @@
 # CPT troubleshooting
 
-Diagnose `mvn test` failures. Each row classifies the failure as a **test problem** (fix the scenario) or a **process problem** (fix the BPMN, DMN, form, or worker). Confusing the two costs hours.
+Diagnose `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test` failures. Each row classifies the failure as a **test problem** (fix the scenario) or a **process problem** (fix the BPMN, DMN, form, or worker). Confusing the two costs hours.
 
 ## Quick triage
 
@@ -34,13 +34,13 @@ When BPMN changed since the last passing suite, sync tests before deep debugging
 1. Diff BPMN changes: `git diff <base-branch>...HEAD -- <bpmn-path>` (often `main`).
 2. Re-read BPMN IDs and compare with scenario `elementId`/`processDefinitionId` references.
 3. Update broken IDs first, then variable-driven branch expectations, then add missing branch segments.
-4. Re-run `mvn test` and return to the quick-triage table for remaining failures.
+4. Re-run `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test` and return to the quick-triage table for remaining failures.
 
 ## Repair discipline
 
 1. Diagnose **every** failure first. Do not start fixing until the full list is classified.
 2. Group fixes by class. Test problems batch into one commit; process problems batch into another. Mixed commits make later reviews hard.
-3. Re-run `mvn test` once per batch. Three repair cycles without progress means the diagnosis is wrong — stop and re-read.
+3. Re-run `mvn -Dnode.resource.dir="${NODE_RESOURCE_DIR:-}" test` once per batch. Three repair cycles without progress means the diagnosis is wrong — stop and re-read.
 4. Never silence a failure by deleting the scenario. If a scenario is genuinely redundant, the deduplication pass in the main workflow handles it — not the repair loop.
 
 ## When in doubt


### PR DESCRIPTION
## Description

Audits all 13 Camunda skills against the Agent Skills specification baseline recorded in `compatibility/audit.json`.

- Removes the avoidable Claude-only MCP registration command from `camunda-docs`.
- Replaces the process-test skill's external `../resources` assumption with a project-build resource lookup.
- Improves metadata, routing, anti-trigger, troubleshooting, and example guidance where the audit identified gaps.
- Replaces scaffold sidecar wording with concrete per-skill Claude, Copilot, and generic harness differences and limitations.
- Confirms the complete index and dated audit remain aligned with every sidecar.

## Validation

- `make compatibility-check`
- `azd waza check skills/camunda-docs`
- `azd waza check skills/camunda-process-test`

Refs #95
